### PR TITLE
Add chat command attribute and dynamic loading

### DIFF
--- a/src/Rhisis.Core/Network/PacketHandlers.cs
+++ b/src/Rhisis.Core/Network/PacketHandlers.cs
@@ -10,12 +10,12 @@ namespace Rhisis.Core.Network
 {
     public static class PacketHandler<T>
     {
-        private static readonly Dictionary<object, Action<T, NetPacketBase>> _handlers = new Dictionary<object, Action<T, NetPacketBase>>();
+        private static readonly Dictionary<object, Action<T, NetPacketBase>> Handlers = new Dictionary<object, Action<T, NetPacketBase>>();
 
         private struct PacketMethodHandler : IEquatable<PacketMethodHandler>
         {
-            public PacketHandlerAttribute Attribute;
-            public MethodInfo Method;
+            public readonly PacketHandlerAttribute Attribute;
+            public readonly MethodInfo Method;
 
             public PacketMethodHandler(MethodInfo method, PacketHandlerAttribute attribute)
             {
@@ -33,18 +33,18 @@ namespace Rhisis.Core.Network
 
         public static void Initialize()
         {
-            var handlers = from type in typeof(T).Assembly.GetTypes()
-                           let typeInfo = type.GetTypeInfo()
-                           let methodsInfo = typeInfo.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                           let handler = (from x in methodsInfo
-                                          let attribute = x.GetCustomAttribute<PacketHandlerAttribute>()
-                                          where attribute != null
-                                          select new PacketMethodHandler(x, attribute)).ToArray()
-                           select handler;
+            IEnumerable<PacketMethodHandler[]> handlers = from type in typeof(T).Assembly.GetTypes()
+                                                          let typeInfo = type.GetTypeInfo()
+                                                          let methodsInfo = typeInfo.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                                                          let handler = (from x in methodsInfo
+                                                                         let attribute = x.GetCustomAttribute<PacketHandlerAttribute>()
+                                                                         where attribute != null
+                                                                         select new PacketMethodHandler(x, attribute)).ToArray()
+                                                          select handler;
 
-            foreach (var handler in handlers)
+            foreach (PacketMethodHandler[] handler in handlers)
             {
-                foreach (var methodHandler in handler)
+                foreach (PacketMethodHandler methodHandler in handler)
                 {
                     ParameterInfo[] parameters = methodHandler.Method.GetParameters();
 
@@ -53,20 +53,20 @@ namespace Rhisis.Core.Network
 
                     var action = methodHandler.Method.CreateDelegate(typeof(Action<T, NetPacketBase>)) as Action<T, NetPacketBase>;
 
-                    _handlers.Add(methodHandler.Attribute.Header, action);
+                    Handlers.Add(methodHandler.Attribute.Header, action);
                 }
             }
         }
 
         public static void Invoke(T invoker, NetPacketBase packet, object packetHeader)
         {
-            if (!_handlers.ContainsKey(packetHeader))
+            if (!Handlers.ContainsKey(packetHeader))
                 throw new KeyNotFoundException();
 
             try
             {
                 Logger.Debug("Received packet: {0}", packetHeader);
-                _handlers[packetHeader].Invoke(invoker, packet);
+                Handlers[packetHeader].Invoke(invoker, packet);
             }
             catch (Exception e)
             {

--- a/src/Rhisis.Core/Reflection/ReflectionHelper.cs
+++ b/src/Rhisis.Core/Reflection/ReflectionHelper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Rhisis.Core.Reflection
+{
+    public static class ReflectionHelper
+    {
+        /// <summary>
+        /// Get classes with a custom attribute.
+        /// </summary>
+        /// <param name="type">Attribute type</param>
+        /// <returns></returns>
+        public static IEnumerable<Type> GetClassesWithCustomAttribute(Type type)
+        {
+            return Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(x => x.GetTypeInfo().GetCustomAttribute(type) != null);
+        }
+
+        /// <summary>
+        /// Get classes with a custom attribute.
+        /// </summary>
+        /// <typeparam name="T">Attribute type</typeparam>
+        /// <returns></returns>
+        public static IEnumerable<Type> GetClassesWithCustomAttribute<T>() => GetClassesWithCustomAttribute(typeof(T));
+
+        /// <summary>
+        /// Get methods with custom attributes.
+        /// </summary>
+        /// <param name="type">Attribute type</param>
+        /// <returns></returns>
+        public static IEnumerable<MethodInfo> GetMethodsWithAttributes(Type type)
+        {
+            return Assembly.GetEntryAssembly()
+                .GetTypes()
+                .SelectMany(x => x.GetMethods())
+                .Where(x => x.GetCustomAttributes(type)?.Count() > 0);
+        }
+
+        /// <summary>
+        /// Get methods with custom attributes.
+        /// </summary>
+        /// <typeparam name="T">Attribute type</typeparam>
+        /// <returns></returns>
+        public static IEnumerable<MethodInfo> GetMethodsWithAttributes<T>() => GetMethodsWithAttributes(typeof(T));
+    }
+}

--- a/src/Rhisis.World/Game/Chat/ChatCommandAttribute.cs
+++ b/src/Rhisis.World/Game/Chat/ChatCommandAttribute.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Rhisis.World.Game.Chat
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    internal class ChatCommandAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the chat command.
+        /// </summary>
+        public string Command { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="ChatCommandAttribute"/> instance.
+        /// </summary>
+        /// <param name="command">Chat command</param>
+        public ChatCommandAttribute(string command)
+        {
+            this.Command = command;
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
+++ b/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Rhisis.Core.IO;
+using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World.Game.Chat
+{
+    public static class CreateItemChatCommand
+    {
+        [ChatCommand("/createitem")]
+        [ChatCommand("/ci")]
+        [ChatCommand("/item")]
+        public static void CreateItem(IPlayerEntity player, string[] parameters)
+        {
+            Logger.Debug("{0} want to create an item", player.ObjectComponent.Name);
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/ChatSystem.cs
+++ b/src/Rhisis.World/Systems/ChatSystem.cs
@@ -73,9 +73,9 @@ namespace Rhisis.World.Systems
         /// <returns></returns>
         private string[] GetCommandParameters(string command, string commandName)
         {
-            command = command.Remove(0, commandName.Length);
+            string commandParameters = command.Remove(0, commandName.Length);
 
-            return Regex.Matches(command, @"[\""].+?[\""]|[^ ]+").Select(m => m.Value.Trim('"')).ToArray();
+            return Regex.Matches(commandParameters, @"[\""].+?[\""]|[^ ]+").Select(m => m.Value.Trim('"')).ToArray();
         }
 
         /// <summary>

--- a/src/Rhisis.World/Systems/ChatSystem.cs
+++ b/src/Rhisis.World/Systems/ChatSystem.cs
@@ -1,17 +1,26 @@
-﻿using Rhisis.World.Core.Systems;
+﻿using Rhisis.Core.IO;
+using Rhisis.Core.Reflection;
+using Rhisis.World.Core.Systems;
+using Rhisis.World.Game.Chat;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Interfaces;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Events;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Rhisis.World.Systems
 {
     [System]
     public class ChatSystem : NotifiableSystemBase
     {
+        private static readonly IDictionary<string, Action<IPlayerEntity, string[]>> ChatCommands = new Dictionary<string, Action<IPlayerEntity, string[]>>();
+
         /// <summary>
         /// Gets the <see cref="ChatSystem"/> match filte.
         /// </summary>
@@ -35,18 +44,59 @@ namespace Rhisis.World.Systems
         {
             var chatEvent = e as ChatEventArgs;
 
-            if (string.IsNullOrEmpty(chatEvent.Message))
+            if (string.IsNullOrEmpty(chatEvent?.Message))
                 return;
             
             var player = entity as IPlayerEntity;
 
             if (chatEvent.Message.StartsWith("/"))
             {
-                // command
+                string commandName = chatEvent.Message.Split(' ').FirstOrDefault();
+                string[] commandParameters = this.GetCommandParameters(chatEvent.Message, commandName);
+
+                if (ChatCommands.ContainsKey(commandName))
+                    ChatCommands[commandName].Invoke(player, commandParameters);
+                else
+                    Logger.Warning("Unknow chat command '{0}'", commandName);
             }
             else
             {
                 WorldPacketFactory.SendChat(player, chatEvent.Message);
+            }
+        }
+
+        /// <summary>
+        /// Gets the command parameters.
+        /// </summary>
+        /// <param name="command">Command line</param>
+        /// <param name="commandName">Command name</param>
+        /// <returns></returns>
+        private string[] GetCommandParameters(string command, string commandName)
+        {
+            command = command.Remove(0, commandName.Length);
+
+            return Regex.Matches(command, @"[\""].+?[\""]|[^ ]+").Select(m => m.Value.Trim('"')).ToArray();
+        }
+
+        /// <summary>
+        /// Initialize chat commands.
+        /// </summary>
+        public static void InitializeCommands()
+        {
+            IEnumerable<MethodInfo> chatCommandsMethods = ReflectionHelper.GetMethodsWithAttributes<ChatCommandAttribute>();
+
+            foreach (MethodInfo chatMethod in chatCommandsMethods)
+            {
+                var action = chatMethod.CreateDelegate(typeof(Action<IPlayerEntity, string[]>)) as Action<IPlayerEntity, string[]>;
+                IEnumerable<ChatCommandAttribute> chatComandAttributes = chatMethod.GetCustomAttributes<ChatCommandAttribute>();
+
+                foreach (ChatCommandAttribute attribute in chatComandAttributes)
+                {
+                    if (!ChatCommands.ContainsKey(attribute.Command))
+                    {
+                        ChatCommands.Add(attribute.Command, action);
+                    }
+                }
             }
         }
     }

--- a/src/tools/Rhisis.CLI/Commands/DatabaseInitializeCommand.cs
+++ b/src/tools/Rhisis.CLI/Commands/DatabaseInitializeCommand.cs
@@ -43,7 +43,7 @@ namespace Rhisis.CLI.Commands
                     using (var rhisisDbContext = DatabaseService.GetContext())
                     {
                         if (!rhisisDbContext.DatabaseExists())
-                            rhisisDbContext.CreateDatabase;
+                            rhisisDbContext.CreateDatabase();
                     }
                 }
                 catch (FileNotFoundException fileNotFound)


### PR DESCRIPTION
- Add chat command system
- Add chat command dynamic loading using attributes and reflection

You can now create your own commands like this:

```c#
public static class CreateItemChatCommand
{
    [ChatCommand("/createitem")]
    [ChatCommand("/ci")]
    [ChatCommand("/item")]
    public static void CreateItem(IPlayerEntity player, string[] parameters)
    {
        // TODO
    }
}
```
So, when you will type in the chat : `/createitem`, `/ci` or `/item` it will redirect to the `CreateItem` method describes above.