### PR TITLE
[POC] Add a IWorldServer interface to query the WorldServer

### DIFF
--- a/src/Rhisis.World/Handlers/ChatHandler.cs
+++ b/src/Rhisis.World/Handlers/ChatHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Ether.Network.Packets;
+using Rhisis.Core.IO;
 using Rhisis.Core.Network;
 using Rhisis.Core.Network.Packets;
 using Rhisis.Core.Network.Packets.World;
@@ -14,6 +15,10 @@ namespace Rhisis.World.Handlers
         {
             var chatPacket = new ChatPacket(packet);
             var chatEvent = new ChatEventArgs(chatPacket.Message);
+
+            var entity = client.Server.GetPlayerEntity(client.Player.Id);
+
+            Logger.Debug("is equal ? : {0}", entity == client.Player); // TRUE
 
             client.Player.Context.NotifySystem<ChatSystem>(client.Player, chatEvent);
         }

--- a/src/Rhisis.World/IWorldServer.cs
+++ b/src/Rhisis.World/IWorldServer.cs
@@ -1,0 +1,9 @@
+﻿using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World
+{
+    public interface IWorldServer
+    {
+        IPlayerEntity GetPlayerEntity(int id);
+    }
+}

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -25,6 +25,8 @@ namespace Rhisis.World
         /// </summary>
         public IPlayerEntity Player { get; set; }
 
+        public IWorldServer Server { get; private set; }
+
         /// <summary>
         /// Creates a new <see cref="WorldClient"/> instance.
         /// </summary>
@@ -36,8 +38,9 @@ namespace Rhisis.World
         /// <summary>
         /// Initialize the client and send welcome packet.
         /// </summary>
-        public void InitializeClient()
+        public void InitializeClient(IWorldServer server)
         {
+            this.Server = server;
             CommonPacketFactory.SendWelcome(this, this._sessionId);
         }
 

--- a/src/Rhisis.World/WorldServer.cs
+++ b/src/Rhisis.World/WorldServer.cs
@@ -7,12 +7,14 @@ using Rhisis.Core.Structures.Configuration;
 using Rhisis.Database;
 using Rhisis.Database.Exceptions;
 using Rhisis.World.Game;
+using Rhisis.World.Game.Entities;
 using Rhisis.World.ISC;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Rhisis.World
 {
-    public sealed partial class WorldServer : NetServer<WorldClient>
+    public sealed partial class WorldServer : NetServer<WorldClient>, IWorldServer
     {
         private static readonly string WorldConfigFile = "config/world.json";
         private static readonly string DatabaseConfigFile = "config/database.json";
@@ -73,7 +75,7 @@ namespace Rhisis.World
         /// <param name="connection"></param>
         protected override void OnClientConnected(WorldClient connection)
         {
-            connection.InitializeClient();
+            connection.InitializeClient(this);
 
             Logger.Info("New client connected: {0}", connection.Id);
         }
@@ -109,6 +111,13 @@ namespace Rhisis.World
             this.Configuration.MaximumNumberOfConnections = 1000;
             this.Configuration.Backlog = 100;
             this.Configuration.BufferSize = 4096;
+        }
+
+        public IPlayerEntity GetPlayerEntity(int id)
+        {
+            WorldClient client =  this.Clients.FirstOrDefault(x => x.Player.Id == id);
+
+            return client?.Player;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is for disscusion purposes only about the World Server global context.

### Let's remind the actual case
1 Map = 1 Context
The contexts have the references to every mover on the map (Players, NPC, monsters, etc...)

### Issue
Sometimes, we want to process some game logic on players that are not in the same context as us. For exemple, for the `FriendSystem`, we need to be able to send an invite to the player even if he is on another map. Actually, it's impossible, because there is no connection between the maps/contexts.

### Solution
What we've been thinking about with @Steve-Nzr is that we should be able to "query" every player on the server. So we would need to get a "Global Context" that hosts only the connected players. By doing this, we will increase code complexity and it might result sometimes in this question : in which context am I working on ?..."

So what I've done with this PR, is that I've created an interface named `IWorldServer` and made `WorldServer` inherit from it.
With this, we can easily add methods to get players or make every other process on the server, which in fact, is our Global Context.

I've created a `IWorldServer` property in the `WorldClient` class, so in every handler, we can access the `WorldServer` instance thanks to the `IWorldServer` property.
We could also pass the `NetServer<WorldClient>` reference, but it's not a good practice to pass the complete object, because we don't really need all of it.

What do you think about this? Don't hesitate to share your thoughts about this solution and if you have another solution, feel free to reply 😄 