### PR TITLE
Add dialog data structure and loading

### DIFF
--- a/bin/data/dialogs/en/MaFl_Lui.json
+++ b/bin/data/dialogs/en/MaFl_Lui.json
@@ -1,0 +1,22 @@
+//
+// MaFl_Lui dialog
+//
+
+{
+	"name": "MaFl_Lui",
+	"oralText": "Come one, come all! Get your supplies here! You're gonna need it!",
+	"introText": "Going somewhere? You look a little unprepared, so I'd think twice about leaving Flarine without stocking up on supplies. Good thing for you, I'm here. So, whaddya need?",
+	"byeText": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!",
+	"links": [
+		{
+			"id": "PRESENTATION",
+			"title": "Who are you?",
+			"text": "Who am I? I'm Lui Keraldine, of course. My friends call me Handsome Lui. Since we're not friends, why don't you just call me Lui. If you buy something from my General Store here, I *might* let you call me Handsome.",
+		},
+		{
+			"id": "BYE",
+			"title": "Goodbye",
+			"text": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!"
+		}
+	]
+}

--- a/src/Rhisis.Core/Structures/Configuration/WorldConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/WorldConfiguration.cs
@@ -10,6 +10,8 @@ namespace Rhisis.Core.Structures.Configuration
     [DataContract]
     public class WorldConfiguration : BaseConfiguration
     {
+        public const string DefaultLanguage = "en";
+
         /// <summary>
         /// Gets or sets the world's id.
         /// </summary>
@@ -41,6 +43,12 @@ namespace Rhisis.Core.Structures.Configuration
         public IEnumerable<string> Maps { get; set; }
 
         /// <summary>
+        /// Gets or sets the world server's language.
+        /// </summary>
+        [DataMember(Name = "language")]
+        public string Language { get; set; }
+
+        /// <summary>
         /// Gets or sets the IPC configuration.
         /// </summary>
         [DataMember(Name = "isc")]
@@ -51,6 +59,7 @@ namespace Rhisis.Core.Structures.Configuration
         /// </summary>
         public WorldConfiguration()
         {
+            this.Language = DefaultLanguage;
             this.Systems = new Dictionary<string, bool>();
             this.ISC = new ISCConfiguration();
         }

--- a/src/Rhisis.Core/Structures/Game/DialogData.cs
+++ b/src/Rhisis.Core/Structures/Game/DialogData.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Structures.Game
+{
+    [DataContract]
+    public class DialogData
+    {
+        /// <summary>
+        /// Gets or sets the dialog name.
+        /// </summary>
+        [DataMember(Name = "name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dialog's oral text.
+        /// </summary>
+        [DataMember(Name = "oralText")]
+        public string OralText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dialog's introduction text.
+        /// </summary>
+        [DataMember(Name = "introText")]
+        public string IntroText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dialog's goodbye text.
+        /// </summary>
+        [DataMember(Name = "byeText")]
+        public string ByeText { get; set; }
+
+        /// <summary>
+        /// Gets the dialog's links.
+        /// </summary>
+        [DataMember(Name = "links")]
+        public List<DialogLink> Links { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="DialogData"/> instance.
+        /// </summary>
+        public DialogData()
+            : this(string.Empty, string.Empty, string.Empty, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="DialogData"/> instance.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="oralText"></param>
+        /// <param name="introText"></param>
+        /// <param name="byeText"></param>
+        public DialogData(string name, string oralText, string introText, string byeText)
+        {
+            this.Name = name;
+            this.OralText = oralText;
+            this.IntroText = introText;
+            this.ByeText = byeText;
+            this.Links = new List<DialogLink>();
+        }
+    }
+
+    [DataContract]
+    public class DialogLink
+    {
+        /// <summary>
+        /// Gets or sets the dialog link id.
+        /// </summary>
+        [DataMember(Name = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dialog link title.
+        /// </summary>
+        [DataMember(Name = "title")]
+        public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the dialog link text.
+        /// </summary>
+        /// <remarks>
+        /// This text will appear once the client has clicked on the link title.
+        /// </remarks>
+        [DataMember(Name = "text")]
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Create an empty <see cref="DialogLink"/> instance.
+        /// </summary>
+        public DialogLink()
+            : this(string.Empty, string.Empty, string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Create a <see cref="DialogLink"/> instance.
+        /// </summary>
+        /// <param name="id">Dialog link id</param>
+        /// <param name="title">Dialog link title</param>
+        /// <param name="text">Dialog link text</param>
+        public DialogLink(string id, string title, string text)
+        {
+            this.Id = id;
+            this.Title = title;
+            this.Text = text;
+        }
+    }
+}

--- a/src/Rhisis.Core/Structures/Game/NpcData.cs
+++ b/src/Rhisis.Core/Structures/Game/NpcData.cs
@@ -50,13 +50,23 @@ namespace Rhisis.Core.Structures.Game
         public bool HasShop => this.Shop != null;
 
         /// <summary>
+        /// Gets the NPC Dialog.
+        /// </summary>
+        public DialogData Dialog { get; }
+
+        /// <summary>
+        /// Gets a value that indicates if the NPC has a dialog.
+        /// </summary>
+        public bool HasDialog => this.Dialog != null;
+
+        /// <summary>
         /// Creates a new <see cref="NpcData"/> instance.
         /// </summary>
         /// <param name="id">Npc id</param>
         /// <param name="name">Npc Name</param>
         public NpcData(string id, string name)
-            : this(id, name, null)
-        {   
+            : this(id, name, null, null)
+        {
         }
 
         /// <summary>
@@ -66,10 +76,23 @@ namespace Rhisis.Core.Structures.Game
         /// <param name="name">Npc Name</param>
         /// <param name="shop">Npc Shop</param>
         public NpcData(string id, string name, ShopData shop)
+            : this(id, name, shop, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="NpcData"/> instance.
+        /// </summary>
+        /// <param name="id">Npc id</param>
+        /// <param name="name">Npc Name</param>
+        /// <param name="shop">Npc Shop</param>
+        /// <param name="dialog">Npc dialog</param>
+        public NpcData(string id, string name, ShopData shop, DialogData dialog)
         {
             this.Id = id;
             this.Name = name;
             this.Shop = shop;
+            this.Dialog = dialog;
         }
     }
 }


### PR DESCRIPTION
This PR adds the dialog structure and the loading process in the WorldServer.

Every dialogs are JSON files structured as followed:

```json
{
    "name": "...",
    "oralText": "oral text of the NPC",
    "introText": "Introduction text of the NPC. The first text that appears when you open a dialog.",
    "byeText": "The text displayed when the player closes the dialog box.",
     "links": [
          {
               "id": "Link Id",
               "title": "Title of the link",
               "text": "Text displayed when the player clicks on the link",
          }
     ]
}
```