### PR TITLE
Fix ping packet

### DIFF
--- a/src/Rhisis.Cluster/ClusterHandler.cs
+++ b/src/Rhisis.Cluster/ClusterHandler.cs
@@ -19,7 +19,8 @@ namespace Rhisis.Cluster
         {
             var pingPacket = new PingPacket(packet);
 
-            CommonPacketFactory.SendPong(client, pingPacket.Time);
+            if (!pingPacket.IsTimeOut)
+                CommonPacketFactory.SendPong(client, pingPacket.Time);
         }
 
         [PacketHandler(PacketType.GETPLAYERLIST)]

--- a/src/Rhisis.Core/Network/Packets/PingPacket.cs
+++ b/src/Rhisis.Core/Network/Packets/PingPacket.cs
@@ -7,14 +7,22 @@ namespace Rhisis.Core.Network.Packets
     {
         public int Time { get; }
 
+        public bool IsTimeOut { get; }
+
         public PingPacket(INetPacketStream packet)
         {
-            this.Time = packet.Read<int>();
+            try
+            {
+                this.Time = packet.Read<int>();
+                this.IsTimeOut = false;
+            }
+            catch (Exception)
+            {
+                this.Time = 0;
+                this.IsTimeOut = true;
+            }
         }
 
-        public bool Equals(PingPacket other)
-        {
-            return this.Time == other.Time;
-        }
+        public bool Equals(PingPacket other) => this.Time == other.Time && this.IsTimeOut == other.IsTimeOut;
     }
 }

--- a/src/Rhisis.Login/LoginHandler.cs
+++ b/src/Rhisis.Login/LoginHandler.cs
@@ -17,7 +17,8 @@ namespace Rhisis.Login
         {
             var pingPacket = new PingPacket(packet);
 
-            CommonPacketFactory.SendPong(client, pingPacket.Time);
+            if (!pingPacket.IsTimeOut)
+                CommonPacketFactory.SendPong(client, pingPacket.Time);
         }
 
         [PacketHandler(PacketType.CERTIFY)]


### PR DESCRIPTION
This PR fixes the ping packet handler for the Login and Cluster handlers. In fact, it seems that when the client time out while loging in, it sends only a `PACKETTYPE_PING` packet header to the server.