### PR TITLE
Chat Command Authorization

### DIFF
--- a/src/Rhisis.World/Game/Chat/ChatCommandAttribute.cs
+++ b/src/Rhisis.World/Game/Chat/ChatCommandAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rhisis.Core.Common;
+using System;
 
 namespace Rhisis.World.Game.Chat
 {
@@ -11,12 +12,19 @@ namespace Rhisis.World.Game.Chat
         public string Command { get; }
 
         /// <summary>
+        /// Gets the chat commands minimum authorization.
+        /// </summary>
+        public AuthorityType MinAuthorization { get; }
+
+        /// <summary>
         /// Creates a new <see cref="ChatCommandAttribute"/> instance.
         /// </summary>
         /// <param name="command">Chat command</param>
-        public ChatCommandAttribute(string command)
+        /// <param name="minAuthorization">Minimum Authorization</param>
+        public ChatCommandAttribute(string command, AuthorityType minAuthorization)
         {
             this.Command = command;
+            this.MinAuthorization = minAuthorization;
         }
     }
 }

--- a/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
+++ b/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
@@ -14,9 +14,9 @@ namespace Rhisis.World.Game.Chat
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-        [ChatCommand("/createitem", AuthorityType.GameMaster)]
-        [ChatCommand("/ci", AuthorityType.GameMaster)]
-        [ChatCommand("/item", AuthorityType.GameMaster)]
+        [ChatCommand("/createitem", AuthorityType.Administrator)]
+        [ChatCommand("/ci", AuthorityType.Administrator)]
+        [ChatCommand("/item", AuthorityType.Administrator)]
         public static void CreateItem(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to create an item", player.Object.Name);

--- a/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
+++ b/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Entities;
@@ -19,6 +20,12 @@ namespace Rhisis.World.Game.Chat
         public static void CreateItem(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to create an item", player.Object.Name);
+
+            if (player.PlayerData.Authority != AuthorityType.Administrator)
+            {
+                Logger.Warn("{0} used CreateItem Command as a non-authorative player.", player.Object.Name);
+                return;
+            }
 
             if (parameters.Length <= 0)
             {

--- a/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
+++ b/src/Rhisis.World/Game/Chat/CreateItemCommand.cs
@@ -14,18 +14,12 @@ namespace Rhisis.World.Game.Chat
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-        [ChatCommand("/createitem")]
-        [ChatCommand("/ci")]
-        [ChatCommand("/item")]
+        [ChatCommand("/createitem", AuthorityType.GameMaster)]
+        [ChatCommand("/ci", AuthorityType.GameMaster)]
+        [ChatCommand("/item", AuthorityType.GameMaster)]
         public static void CreateItem(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to create an item", player.Object.Name);
-
-            if (player.PlayerData.Authority != AuthorityType.Administrator)
-            {
-                Logger.Warn("{0} used CreateItem Command as a non-authorative player.", player.Object.Name);
-                return;
-            }
 
             if (parameters.Length <= 0)
             {

--- a/src/Rhisis.World/Game/Chat/GetGoldCommand.cs
+++ b/src/Rhisis.World/Game/Chat/GetGoldCommand.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Packets;
@@ -13,6 +14,12 @@ namespace Rhisis.World.Game.Chat
         public static void GetGoldCommand(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to get penyas", player.Object.Name);
+
+            if (player.PlayerData.Authority != AuthorityType.Administrator)
+            {
+                Logger.Warn("{0} used GetGold Command as a non-authorative player.", player.Object.Name);
+                return;
+            }
 
             if (parameters.Length == 1)
             {

--- a/src/Rhisis.World/Game/Chat/GetGoldCommand.cs
+++ b/src/Rhisis.World/Game/Chat/GetGoldCommand.cs
@@ -10,16 +10,10 @@ namespace Rhisis.World.Game.Chat
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-        [ChatCommand("/getgold")]
+        [ChatCommand("/getgold", AuthorityType.Administrator)]
         public static void GetGoldCommand(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to get penyas", player.Object.Name);
-
-            if (player.PlayerData.Authority != AuthorityType.Administrator)
-            {
-                Logger.Warn("{0} used GetGold Command as a non-authorative player.", player.Object.Name);
-                return;
-            }
 
             if (parameters.Length == 1)
             {

--- a/src/Rhisis.World/Game/Chat/TeleportCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TeleportCommand.cs
@@ -11,17 +11,11 @@ namespace Rhisis.World.Game.Chat
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
-        [ChatCommand("/tp")]
-        [ChatCommand("/teleport")]
+        [ChatCommand("/tp", AuthorityType.GameMaster)]
+        [ChatCommand("/teleport", AuthorityType.GameMaster)]
         public static void TeleportCommand(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to teleport", player.Object.Name);
-
-            if (player.PlayerData.Authority < AuthorityType.GameMaster)
-            {
-                Logger.Warn("{0} used Teleport Command as a non-authorative player.", player.Object.Name);
-                return;
-            }
 
             switch (parameters.Length)
             {

--- a/src/Rhisis.World/Game/Chat/TeleportCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TeleportCommand.cs
@@ -19,7 +19,7 @@ namespace Rhisis.World.Game.Chat
 
             if (player.PlayerData.Authority < AuthorityType.GameMaster)
             {
-                Logger.Warn("{0} used CreateItem Command as a non-authorative player.", player.Object.Name);
+                Logger.Warn("{0} used Teleport Command as a non-authorative player.", player.Object.Name);
                 return;
             }
 

--- a/src/Rhisis.World/Game/Chat/TeleportCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TeleportCommand.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using Rhisis.Core.Common;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Packets;
@@ -15,6 +16,13 @@ namespace Rhisis.World.Game.Chat
         public static void TeleportCommand(IPlayerEntity player, string[] parameters)
         {
             Logger.Debug("{0} want to teleport", player.Object.Name);
+
+            if (player.PlayerData.Authority < AuthorityType.GameMaster)
+            {
+                Logger.Warn("{0} used CreateItem Command as a non-authorative player.", player.Object.Name);
+                return;
+            }
+
             switch (parameters.Length)
             {
                 case 2: // when you write 2 parameters in the command

--- a/src/Rhisis.World/Systems/Chat/ChatSystem.cs
+++ b/src/Rhisis.World/Systems/Chat/ChatSystem.cs
@@ -16,7 +16,7 @@ namespace Rhisis.World.Systems.Chat
     [System]
     public class ChatSystem : NotifiableSystemBase
     {
-        internal sealed class ChatCommand
+        private sealed class ChatCommandDefinition
         {
             /// <summary>
             /// The method to invoke.
@@ -29,11 +29,11 @@ namespace Rhisis.World.Systems.Chat
             public AuthorityType MinAuthorization { get; }
 
             /// <summary>
-            /// Creates a new <see cref="ChatCommand"/> instance.
+            /// Creates a new <see cref="ChatCommandDefinition"/> instance.
             /// </summary>
             /// <param name="method"></param>
             /// <param name="minAuthorization"></param>
-            public ChatCommand(Action<IPlayerEntity, string[]> method, AuthorityType minAuthorization)
+            public ChatCommandDefinition(Action<IPlayerEntity, string[]> method, AuthorityType minAuthorization)
             {
                 Method = method;
                 MinAuthorization = minAuthorization;
@@ -41,7 +41,7 @@ namespace Rhisis.World.Systems.Chat
         }
 
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
-        private static readonly IDictionary<string, ChatCommand> ChatCommands = new Dictionary<string, ChatCommand>();
+        private static readonly IDictionary<string, ChatCommandDefinition> ChatCommands = new Dictionary<string, ChatCommandDefinition>();
 
         /// <inheritdoc />
         protected override WorldEntityType Type => WorldEntityType.Player;
@@ -114,7 +114,7 @@ namespace Rhisis.World.Systems.Chat
                 {
                     if (!ChatCommands.ContainsKey(attribute.Command))
                     {
-                        ChatCommands.Add(attribute.Command, new ChatCommand(action, attribute.MinAuthorization));
+                        ChatCommands.Add(attribute.Command, new ChatCommandDefinition(action, attribute.MinAuthorization));
                     }
                 }
             }


### PR DESCRIPTION
This PR adds authorization checks to the CreateItem, GetGold and Teleport Chat Commands where as the CreateItem and GetGold is only available as Administrator and Teleport only as GM or Admin.