### PR TITLE
Fix for Authorizations Visuals

### DIFF
--- a/src/Rhisis.Core/Common/AuthorityType.cs
+++ b/src/Rhisis.Core/Common/AuthorityType.cs
@@ -1,10 +1,10 @@
 ﻿namespace Rhisis.Core.Common
 {
-    public enum AuthorityType
+    public enum AuthorityType : byte
     {
         Banned = 0,
-        Player = 70,
-        GameMaster = 80,
-        Administrator = 100
+        Player = (byte)'F',
+        GameMaster = (byte)'L',
+        Administrator = (byte)'P'
     }
 }


### PR DESCRIPTION
This PR fixes the visualization above your player as the previous used values havent been recognized correctly by the game. 

The game actually uses ASCII codes for the authorization:
![image](https://user-images.githubusercontent.com/30114127/44255449-70286880-a206-11e8-9808-684ca93c9b2a.png)

I have modified Game Master and Normal Player to fit to the Game and now it is working properly.

![navicat_2018-08-17_10-09-52](https://user-images.githubusercontent.com/30114127/44255482-89311980-a206-11e8-99b3-64a1473b7b2a.png)
![navicat_2018-08-17_10-10-30](https://user-images.githubusercontent.com/30114127/44255485-8c2c0a00-a206-11e8-9cd0-50a3f0413440.png)
![navicat_2018-08-17_10-11-01](https://user-images.githubusercontent.com/30114127/44255487-8e8e6400-a206-11e8-8992-e78619f48aae.png)
