### PR TITLE
Restore CertifyPacket structure.

### DIFF
--- a/src/Rhisis.Login/LoginClient.cs
+++ b/src/Rhisis.Login/LoginClient.cs
@@ -21,6 +21,11 @@ namespace Rhisis.Login
         /// Gets the ID assigned to this session.
         /// </summary>
         public uint SessionId { get; }
+        
+        /// <summary>
+        /// Gets the client's logged username.
+        /// </summary>
+        public string Username { get; private set; }
 
         /// <summary>
         /// Gets the list of connected clusters.
@@ -36,9 +41,7 @@ namespace Rhisis.Login
         /// Gets the remote end point (IP and port) for this client.
         /// </summary>
         public string RemoteEndPoint { get; private set; }
-
         
-
         /// <summary>
         /// Creates a new <see cref="LoginClient"/> instance.
         /// </summary>
@@ -66,6 +69,19 @@ namespace Rhisis.Login
             this.Dispose();
         }
 
+        /// <summary>
+        /// Sets the client's username.
+        /// </summary>
+        /// <param name="username"></param>
+        public void SetClientUsername(string username)
+        {
+            if (!string.IsNullOrEmpty(this.Username))
+                throw new InvalidOperationException("Client username already set.");
+
+            this.Username = username;
+        }
+
+        /// <inheritdoc />
         public override void Send(INetPacketStream packet)
         {
             if (Logger.IsTraceEnabled)
@@ -81,7 +97,6 @@ namespace Rhisis.Login
         /// <inheritdoc />
         public override void HandleMessage(INetPacketStream packet)
         {
-            FFPacket pak = null;
             uint packetHeaderNumber = 0;
 
             if (Socket == null)
@@ -92,13 +107,12 @@ namespace Rhisis.Login
 
             try
             {
-                pak = packet as FFPacket;
                 packetHeaderNumber = packet.Read<uint>();
 
                 if (Logger.IsTraceEnabled)
                     Logger.Trace("Received {0} packet from {1}.", (PacketType)packetHeaderNumber, this.RemoteEndPoint);
 
-                PacketHandler<LoginClient>.Invoke(this, pak, (PacketType)packetHeaderNumber);
+                PacketHandler<LoginClient>.Invoke(this, packet, (PacketType)packetHeaderNumber);
             }
             catch (KeyNotFoundException)
             {

--- a/src/Rhisis.Login/LoginServer.cs
+++ b/src/Rhisis.Login/LoginServer.cs
@@ -1,6 +1,7 @@
 ﻿using Ether.Network.Packets;
 using Ether.Network.Server;
 using NLog;
+using Rhisis.Business;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Helpers;
 using Rhisis.Core.Structures.Configuration;
@@ -11,8 +12,6 @@ using Rhisis.Network.ISC.Structures;
 using Rhisis.Network.Packets;
 using System;
 using System.Collections.Generic;
-using Rhisis.Business;
-using Rhisis.Core.DependencyInjection;
 
 namespace Rhisis.Login
 {
@@ -79,9 +78,7 @@ namespace Rhisis.Login
             Logger.Debug("Loading database configuration from '{0}'...", DatabaseConfigFile);
             DatabaseFactory.Instance.Initialize(DatabaseConfigFile);
             Logger.Trace($"Database config -> {DatabaseFactory.Instance.Configuration}");
-
-            DependencyContainer.Instance.Initialize().BuildServiceProvider();
-
+            
             BusinessLayer.Initialize();
             DependencyContainer.Instance.Initialize().BuildServiceProvider();
 
@@ -97,14 +94,14 @@ namespace Rhisis.Login
         protected override void OnClientConnected(LoginClient client)
         {
             client.Initialize(this);
-            Logger.Info("New client connected from {0}.", client.RemoteEndPoint);
+            Logger.Info($"New client connected from {client.RemoteEndPoint}.");
             CommonPacketFactory.SendWelcome(client, client.SessionId);
         }
 
         /// <inheritdoc />
         protected override void OnClientDisconnected(LoginClient client)
         {
-            Logger.Info("Client disconnected from {0}.", client.RemoteEndPoint);
+            Logger.Info($"Client '{client.Username}' disconnected from {client.RemoteEndPoint}.");
         }
 
         /// <inheritdoc />
@@ -124,7 +121,5 @@ namespace Rhisis.Login
 
             base.Dispose(disposing);
         }
-
-       
     }
 }

--- a/src/Rhisis.Network/Packets/Login/CertifyPacket.cs
+++ b/src/Rhisis.Network/Packets/Login/CertifyPacket.cs
@@ -1,0 +1,38 @@
+﻿using Ether.Network.Packets;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace Rhisis.Network.Packets.Login
+{
+    public struct CertifyPacket : IEquatable<CertifyPacket>
+    {
+        public string BuildVersion { get; }
+
+        public string Username { get; }
+
+        public string Password { get; }
+
+        public byte[] EncryptedPassword { get; }
+
+        public CertifyPacket(INetPacketStream packet, bool useEncryptedPassword)
+        {
+            this.BuildVersion = packet.Read<string>();
+            this.Username = packet.Read<string>();
+            this.Password = null;
+            this.EncryptedPassword = null;
+
+            if (useEncryptedPassword)
+                this.EncryptedPassword = packet.ReadArray<byte>(16 * 42);
+            else
+                this.Password = packet.Read<string>();
+        }
+
+        public bool Equals(CertifyPacket other)
+        {
+            return this.BuildVersion == other.BuildVersion &&
+                this.Username == other.Username &&
+                this.Password == other.Password;
+        }
+    }
+}


### PR DESCRIPTION
This PR restores the `CertifyPacket` structure.
After a discussion with @Steve-Nzr we thought it was better and clean to keep the packet structure as it is. One packet defined in a structure.