### PR TITLE
Move authentication process to AuthenticationService

### DIFF
--- a/src/Rhisis.Business/Services/AuthenticationService.cs
+++ b/src/Rhisis.Business/Services/AuthenticationService.cs
@@ -1,21 +1,37 @@
-﻿using Rhisis.Core.DependencyInjection;
+﻿using Rhisis.Core.Common;
+using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Services;
+using Rhisis.Database;
+using Rhisis.Database.Entities;
+using System;
 
 namespace Rhisis.Business.Services
 {
     [Injectable]
     public class AuthenticationService : IAuthenticationService
     {
-        private readonly IUserService _userService;
+        private readonly IDatabase _database;
 
-        public AuthenticationService(IUserService userService)
+        public AuthenticationService(IDatabase database)
         {
-            this._userService = userService;
+            this._database = database;
         }
 
-        public bool Authenticate(string username, string password)
+        public AuthenticationResult Authenticate(string username, string password)
         {
-            throw new System.NotImplementedException();
+            DbUser _dbUser = this._database.Users.Get(x => x.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+
+            if (_dbUser == null)
+            {
+                return AuthenticationResult.BadUsername;
+            }
+
+            if (!_dbUser.Password.Equals(password, StringComparison.OrdinalIgnoreCase))
+            {
+                return AuthenticationResult.BadPassword;
+            }
+
+            return AuthenticationResult.Success;
         }
     }
 }

--- a/src/Rhisis.Core/Common/AuthenticationResult.cs
+++ b/src/Rhisis.Core/Common/AuthenticationResult.cs
@@ -1,0 +1,11 @@
+﻿namespace Rhisis.Core.Common
+{
+    public enum AuthenticationResult
+    {
+        Success,
+        BadUsername,
+        BadPassword,
+        AccountSuspended,
+        AccountTemporarySuspended
+    }
+}

--- a/src/Rhisis.Core/Services/IAuthenticationService.cs
+++ b/src/Rhisis.Core/Services/IAuthenticationService.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Rhisis.Core.Common;
 
 namespace Rhisis.Core.Services
 {
     public interface IAuthenticationService
     {
-        bool Authenticate(string username, string password);
+        AuthenticationResult Authenticate(string username, string password);
     }
 }

--- a/src/Rhisis.Login/LoginServer.cs
+++ b/src/Rhisis.Login/LoginServer.cs
@@ -101,7 +101,10 @@ namespace Rhisis.Login
         /// <inheritdoc />
         protected override void OnClientDisconnected(LoginClient client)
         {
-            Logger.Info($"Client '{client.Username}' disconnected from {client.RemoteEndPoint}.");
+            if (string.IsNullOrEmpty(client.Username))
+                Logger.Info($"Unknwon client disconnected from {client.RemoteEndPoint}.");
+            else
+                Logger.Info($"Client '{client.Username}' disconnected from {client.RemoteEndPoint}.");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR moves the authentication process to its own service. This `AuthenticationService` can be used for the server and the API.