### PR TITLE
Fix login server login with same account.

### DIFF
--- a/src/Rhisis.Login/ILoginServer.cs
+++ b/src/Rhisis.Login/ILoginServer.cs
@@ -1,0 +1,34 @@
+﻿using Ether.Network.Server;
+using Rhisis.Core.Structures.Configuration;
+using Rhisis.Network.ISC.Structures;
+using System.Collections.Generic;
+
+namespace Rhisis.Login
+{
+    public interface ILoginServer : INetServer
+    {
+        /// <summary>
+        /// Gets the login server configuration.
+        /// </summary>
+        LoginConfiguration ServerConfiguration { get; }
+
+        /// <summary>
+        /// Gets the list of the connected clusters.
+        /// </summary>
+        IEnumerable<ClusterServerInfo> ClustersConnected { get; }
+
+        /// <summary>
+        /// Gets a connected client by his username.
+        /// </summary>
+        /// <param name="username">Client username</param>
+        /// <returns></returns>
+        LoginClient GetClientByUsername(string username);
+
+        /// <summary>
+        /// Verify if a client is connected to the login server.
+        /// </summary>
+        /// <param name="username">Client username</param>
+        /// <returns></returns>
+        bool IsClientConnected(string username);
+    }
+}

--- a/src/Rhisis.Login/LoginClient.cs
+++ b/src/Rhisis.Login/LoginClient.cs
@@ -3,10 +3,8 @@ using Ether.Network.Packets;
 using NLog;
 using Rhisis.Core.Exceptions;
 using Rhisis.Core.Helpers;
-using Rhisis.Network.ISC.Structures;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
-using Rhisis.Core.Structures.Configuration;
 using System;
 using System.Collections.Generic;
 
@@ -15,7 +13,6 @@ namespace Rhisis.Login
     public sealed class LoginClient : NetUser
     {
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
-        private LoginServer _loginServer;
 
         /// <summary>
         /// Gets the ID assigned to this session.
@@ -28,14 +25,14 @@ namespace Rhisis.Login
         public string Username { get; private set; }
 
         /// <summary>
-        /// Gets the list of connected clusters.
+        /// Check if the client is connected.
         /// </summary>
-        public IEnumerable<ClusterServerInfo> ClustersConnected => this._loginServer.ClustersConnected;
+        public bool IsConnected => !string.IsNullOrEmpty(this.Username);
 
         /// <summary>
-        /// Gets the login server's configuration.
+        /// Gets the Login server's reference.
         /// </summary>
-        public LoginConfiguration ServerConfiguration => this._loginServer.LoginConfiguration;
+        public ILoginServer LoginServer { get; private set; }
 
         /// <summary>
         /// Gets the remote end point (IP and port) for this client.
@@ -54,9 +51,9 @@ namespace Rhisis.Login
         /// Initialize the client.
         /// </summary>
         /// <param name="loginServer"></param>
-        public void Initialize(LoginServer loginServer)
+        public void Initialize(ILoginServer loginServer)
         {
-            this._loginServer = loginServer;
+            this.LoginServer = loginServer;
             this.RemoteEndPoint = this.Socket.RemoteEndPoint.ToString();
         }
 
@@ -65,7 +62,7 @@ namespace Rhisis.Login
         /// </summary>
         public void Disconnect()
         {
-            this._loginServer.DisconnectClient(this.Id);
+            this.LoginServer.DisconnectClient(this.Id);
             this.Dispose();
         }
 

--- a/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
+++ b/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
@@ -1,0 +1,22 @@
+﻿using Ether.Network.Packets;
+using System;
+
+namespace Rhisis.Network.Packets.Login
+{
+    public struct CloseConnectionPacket : IEquatable<CloseConnectionPacket>
+    {
+        public string Username { get; }
+
+        public string Password { get; }
+
+        public CloseConnectionPacket(INetPacketStream packet)
+        {
+            this.Username = packet.Read<string>();
+            this.Password = packet.Read<string>();
+        }
+
+        public bool Equals(CloseConnectionPacket other) => 
+            this.Username.Equals(other.Username, StringComparison.OrdinalIgnoreCase) &&
+            this.Password.Equals(other.Password, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
This PR fixes issue #114 and prevents other players to login with the same account.

As we discussed in the issue, we shall also check if the player is connected to the ClusterServer and the WorldServer. To do so, we will need to rework the ISC process to make efficient calls between the servers.

Plus, I've added a `ILoginServer` interface that inherits from the `INetServer` of Ether and implement some custom methods to retrieve clients and check if clients are connected or not. This helps us to get rid of the concret implementations and makes the code more scalable.