### PR TITLE
Fix world moves

### DIFF
--- a/src/Rhisis.Core/IO/Time.cs
+++ b/src/Rhisis.Core/IO/Time.cs
@@ -60,5 +60,7 @@ namespace Rhisis.Core.IO
         {
             return Environment.TickCount - Start;
         }
+
+        public static long GetTicks() => Environment.TickCount;
     }
 }

--- a/src/Rhisis.Core/Structures/Vector3.cs
+++ b/src/Rhisis.Core/Structures/Vector3.cs
@@ -111,7 +111,7 @@ namespace Rhisis.Core.Structures
         /// <returns></returns>
         public bool IsInCircle(Vector3 otherPosition, float circleRadius)
         {
-            return Math.Pow(otherPosition.X - this._x, 2) + Math.Pow(otherPosition.Z - this._z, 2) < Math.Pow(circleRadius, 2);
+            return Math.Pow(otherPosition.X - this._x, 2) + Math.Pow(otherPosition.Z - this._z, 2) < circleRadius;
         }
 
         /// <summary>

--- a/src/Rhisis.World/Game/Behaviors/DefaultNpcBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/DefaultNpcBehavior.cs
@@ -3,6 +3,7 @@ using Rhisis.Core.IO;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Packets;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -14,7 +15,7 @@ namespace Rhisis.World.Game.Behaviors
     [Behavior(BehaviorType.Npc, IsDefault: true)]
     public class DefaultNpcBehavior : IBehavior<INpcEntity>
     {
-        private const int OralTextRadius = 60;
+        private static readonly float OralTextRadius = (float)Math.Pow(60f, 2f);
 
         /// <inheritdoc />
         public void Update(INpcEntity entity)

--- a/src/Rhisis.World/Game/Entities/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/PlayerEntity.cs
@@ -44,6 +44,8 @@ namespace Rhisis.World.Game.Entities
         public PlayerEntity(IContext context)
             : base(context)
         {
+            this.MovableComponent = new MovableComponent();
+            this.PlayerData = new PlayerDataComponent();
             this.Trade = new TradeComponent();
             this.Follow = new FollowComponent();
         }

--- a/src/Rhisis.World/Game/Maps/MapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/MapInstance.cs
@@ -11,6 +11,7 @@ using Rhisis.World.Game.Regions;
 using Rhisis.World.Game.Structures;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -137,20 +138,21 @@ namespace Rhisis.World.Game.Maps
         /// <inheritdoc />
         public void StartUpdateTask(int delay)
         {
-            double previousTime = 0f;
-
             Task.Run(async () =>
             {
+                const double FrameRatePerSeconds = 0.6f;
+                double previousTime = 0;
+                
                 while (true)
                 {
                     if (this._cancellationToken.IsCancellationRequested)
                         break;
 
-                    double currentTime = Rhisis.Core.IO.Time.TimeInMilliseconds();
+                    double currentTime = Rhisis.Core.IO.Time.GetElapsedTime();
                     double deltaTime = currentTime - previousTime;
                     previousTime = currentTime;
 
-                    this.GameTime = deltaTime / 1000f;
+                    this.GameTime = (deltaTime * FrameRatePerSeconds) / 1000f;
 
                     try
                     {
@@ -173,6 +175,7 @@ namespace Rhisis.World.Game.Maps
                     {
                         Logger.Error(e);
                     }
+
                     await Task.Delay(delay, this._cancellationToken).ConfigureAwait(false);
                 }
             }, this._cancellationToken);

--- a/src/Rhisis.World/Systems/MobilitySystem.cs
+++ b/src/Rhisis.World/Systems/MobilitySystem.cs
@@ -1,4 +1,5 @@
-﻿using Rhisis.World.Game.Core;
+﻿using NLog;
+using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Entities;
 using System;
 
@@ -7,6 +8,8 @@ namespace Rhisis.World.Systems
     [System]
     public class MobilitySystem : SystemBase
     {
+        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+
         /// <inheritdoc />
         protected override WorldEntityType Type => WorldEntityType.Player | WorldEntityType.Monster;
 
@@ -42,10 +45,11 @@ namespace Rhisis.World.Systems
             if (entity.MovableComponent.DestinationPosition.IsInCircle(entity.Object.Position, 0.1f))
             {
                 entity.MovableComponent.DestinationPosition.Reset();
+                Logger.Debug($"Player {entity.Object.Name} has arrived.");
             }
             else
             {
-                double speed = ((entity.MovableComponent.Speed * 100) * this.Context.GameTime);
+                double speed = ((entity.MovableComponent.Speed * 100f) * this.Context.GameTime);
                 float distanceX = entity.MovableComponent.DestinationPosition.X - entity.Object.Position.X;
                 float distanceZ = entity.MovableComponent.DestinationPosition.Z - entity.Object.Position.Z;
                 double distance = Math.Sqrt(distanceX * distanceX + distanceZ * distanceZ);

--- a/src/Rhisis.World/Systems/VisibilitySystem.cs
+++ b/src/Rhisis.World/Systems/VisibilitySystem.cs
@@ -2,13 +2,14 @@
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Packets;
+using System;
 
 namespace Rhisis.World.Systems
 {
     [System]
     public class VisibilitySystem : SystemBase
     {
-        public static readonly float VisibilityRange = 75f;
+        public static readonly float VisibilityRange = (float)Math.Pow(75f, 2f);
 
         /// <inheritdoc />
         protected override WorldEntityType Type => WorldEntityType.Mover;

--- a/src/Rhisis.World/WorldLoader.cs
+++ b/src/Rhisis.World/WorldLoader.cs
@@ -374,7 +374,7 @@ namespace Rhisis.World
                     map.AddSystem(Activator.CreateInstance(type, map) as ISystem);
 
                 _maps.Add(mapId, map);
-                map.StartUpdateTask(100);
+                map.StartUpdateTask(50);
             }
 
             Logger.Info("-> {0} maps loaded.", _maps.Count);


### PR DESCRIPTION
This PR fixes issue #112 related with the `MobilitySystem`. In fact, the server was detecting the player already arrived to destination but the player was still moving on the client side.