### PR TITLE
Add ILivingEntity with battle and health component

### DIFF
--- a/src/Rhisis.World/Game/Components/BattleComponent.cs
+++ b/src/Rhisis.World/Game/Components/BattleComponent.cs
@@ -1,0 +1,21 @@
+﻿using Rhisis.World.Game.Entities;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.World.Game.Components
+{
+    public class BattleComponent
+    {
+        /// <summary>
+        /// Gets or sets the fighting target.
+        /// </summary>
+        public ILivingEntity Target { get; set; }
+
+        public IList<ILivingEntity> Targets { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates if the object is currently fighting.
+        /// </summary>
+        public bool IsFighting => this.Target != null || this.Targets.Any();
+    }
+}

--- a/src/Rhisis.World/Game/Components/FollowComponent.cs
+++ b/src/Rhisis.World/Game/Components/FollowComponent.cs
@@ -1,11 +1,19 @@
 ﻿using Rhisis.World.Game.Core;
+using System.Collections;
+using System.Linq;
 
 namespace Rhisis.World.Game.Components
 {
     public class FollowComponent
     {
+        /// <summary>
+        /// Gets or sets the following target.
+        /// </summary>
         public IEntity Target { get; set; }
 
+        /// <summary>
+        /// Gets or sets if the object is following another.
+        /// </summary>
         public bool IsFollowing => this.Target != null;
     }
 }

--- a/src/Rhisis.World/Game/Components/HealthComponent.cs
+++ b/src/Rhisis.World/Game/Components/HealthComponent.cs
@@ -1,0 +1,25 @@
+﻿namespace Rhisis.World.Game.Components
+{
+    public class HealthComponent
+    {
+        /// <summary>
+        /// Gets or sets the base object's Hit Points.
+        /// </summary>
+        public int Hp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base object's Mana Points.
+        /// </summary>
+        public int Mp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base object's Fatigue Points.
+        /// </summary>
+        public int Fp { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates if the object is dead.
+        /// </summary>
+        public bool IsDead => this.Hp <= 0;
+    }
+}

--- a/src/Rhisis.World/Game/Components/ObjectComponent.cs
+++ b/src/Rhisis.World/Game/Components/ObjectComponent.cs
@@ -61,31 +61,6 @@ namespace Rhisis.World.Game.Components
         public int Level { get; set; }
 
         /// <summary>
-        /// Gets or sets the base object's Hit Points.
-        /// </summary>
-        public int Hp { get; set; }
-
-        /// <summary>
-        /// Gets or sets the base object's Mana Points.
-        /// </summary>
-        public int Mp { get; set; }
-
-        /// <summary>
-        /// Gets or sets the base object's Fatigue Points.
-        /// </summary>
-        public int Fp { get; set; }
-
-        /// <summary>
-        /// Gets or sets the object experience.
-        /// </summary>
-        public long Experience { get; set; }
-
-        /// <summary>
-        /// Gets a value that indicates if the object is dead.
-        /// </summary>
-        public bool IsDead => this.Hp <= 0;
-
-        /// <summary>
         /// Gets the list of the visible entities around.
         /// </summary>
         public IList<IEntity> Entities { get; }

--- a/src/Rhisis.World/Game/Components/ObjectComponent.cs
+++ b/src/Rhisis.World/Game/Components/ObjectComponent.cs
@@ -61,6 +61,31 @@ namespace Rhisis.World.Game.Components
         public int Level { get; set; }
 
         /// <summary>
+        /// Gets or sets the base object's Hit Points.
+        /// </summary>
+        public int Hp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base object's Mana Points.
+        /// </summary>
+        public int Mp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base object's Fatigue Points.
+        /// </summary>
+        public int Fp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the object experience.
+        /// </summary>
+        public long Experience { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates if the object is dead.
+        /// </summary>
+        public bool IsDead => this.Hp <= 0;
+
+        /// <summary>
         /// Gets the list of the visible entities around.
         /// </summary>
         public IList<IEntity> Entities { get; }

--- a/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
+++ b/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
@@ -4,14 +4,34 @@ namespace Rhisis.World.Game.Components
 {
     public class PlayerDataComponent
     {
+        /// <summary>
+        /// Gets or sets the player's id.
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the player's slot.
+        /// </summary>
         public int Slot { get; set; }
 
+        /// <summary>
+        /// Gets or sets the current amount of gold the player has.
+        /// </summary>
         public int Gold { get; set; }
 
+        /// <summary>
+        /// Gets or sets the current shop name that the player is visiting.
+        /// </summary>
         public string CurrentShopName { get; set; }
 
+        /// <summary>
+        /// Gets or sets the player's authority.
+        /// </summary>
         public AuthorityType Authority { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's experience.
+        /// </summary>
+        public long Experience { get; set; }
     }
 }

--- a/src/Rhisis.World/Game/Entities/ILivingEntity.cs
+++ b/src/Rhisis.World/Game/Entities/ILivingEntity.cs
@@ -1,0 +1,18 @@
+﻿using Rhisis.World.Game.Components;
+using Rhisis.World.Game.Core;
+
+namespace Rhisis.World.Game.Entities
+{
+    public interface ILivingEntity : IEntity, IMovableEntity
+    {
+        /// <summary>
+        /// Gets or sets the battle component.
+        /// </summary>
+        BattleComponent Battle { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Health component.
+        /// </summary>
+        HealthComponent Health { get; set; }
+    }
+}

--- a/src/Rhisis.World/Game/Entities/IMonsterEntity.cs
+++ b/src/Rhisis.World/Game/Entities/IMonsterEntity.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Maps.Regions;
 
 namespace Rhisis.World.Game.Entities
 {
-    public interface IMonsterEntity : IEntity, IMovableEntity
+    public interface IMonsterEntity : IEntity, IMovableEntity, ILivingEntity
     {
         /// <summary>
         /// Gets or sets the parent region of the monster.

--- a/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Core;
 
 namespace Rhisis.World.Game.Entities
 {
-    public interface IPlayerEntity : IEntity, IMovableEntity
+    public interface IPlayerEntity : IEntity, IMovableEntity, ILivingEntity
     {
         VisualAppearenceComponent VisualAppearance { get; set; }
 

--- a/src/Rhisis.World/Game/Entities/MonsterEntity.cs
+++ b/src/Rhisis.World/Game/Entities/MonsterEntity.cs
@@ -28,6 +28,12 @@ namespace Rhisis.World.Game.Entities
         /// <inheritdoc />
         public FollowComponent Follow { get; set; }
 
+        /// <inheritdoc />
+        public BattleComponent Battle { get; set; }
+
+        /// <inheritdoc />
+        public HealthComponent Health { get; set; }
+
         /// <summary>
         /// Creates a new <see cref="MonsterEntity"/> instance.
         /// </summary>
@@ -38,6 +44,8 @@ namespace Rhisis.World.Game.Entities
             this.MovableComponent = new MovableComponent();
             this.TimerComponent = new TimerComponent();
             this.Follow = new FollowComponent();
+            this.Battle = new BattleComponent();
+            this.Health = new HealthComponent();
         }
     }
 }

--- a/src/Rhisis.World/Game/Entities/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/PlayerEntity.cs
@@ -35,6 +35,12 @@ namespace Rhisis.World.Game.Entities
         public FollowComponent Follow { get; set; }
 
         /// <inheritdoc />
+        public BattleComponent Battle { get; set; }
+
+        /// <inheritdoc />
+        public HealthComponent Health { get; set; }
+
+        /// <inheritdoc />
         public IBehavior<IPlayerEntity> Behavior { get; set; }
 
         /// <summary>
@@ -48,6 +54,8 @@ namespace Rhisis.World.Game.Entities
             this.PlayerData = new PlayerDataComponent();
             this.Trade = new TradeComponent();
             this.Follow = new FollowComponent();
+            this.Battle = new BattleComponent();
+            this.Health = new HealthComponent();
         }
     }
 }

--- a/src/Rhisis.World/Game/Maps/MapLayer.cs
+++ b/src/Rhisis.World/Game/Maps/MapLayer.cs
@@ -124,6 +124,12 @@ namespace Rhisis.World.Game.Maps
                 Speed = moverData.Speed,
                 DestinationPosition = monster.Object.Position.Clone()
             };
+            monster.Health = new HealthComponent
+            {
+                Hp = moverData.MaxHP,
+                Mp = moverData.AddMp,
+                Fp = 0
+            };
             monster.Behavior = WorldServer.MonsterBehaviors.GetBehavior(monster.Object.ModelId);
             monster.Region = respawner;
 

--- a/src/Rhisis.World/Handlers/BattleHandler.cs
+++ b/src/Rhisis.World/Handlers/BattleHandler.cs
@@ -38,7 +38,7 @@ namespace Rhisis.World.Handlers
                 target.NotifySystem<FollowSystem>(new FollowEventArgs(client.Player.Id, 1f));
             }
 
-            client.Player.NotifySystem<BattleSystem>(new MeleeAttackEventArgs(meleePacket.AttackMessage, target, meleePacket.WeaponAttackSpeed);
+            client.Player.NotifySystem<BattleSystem>(new MeleeAttackEventArgs(meleePacket.AttackMessage, target, meleePacket.WeaponAttackSpeed));
         }
     }
 }

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -68,11 +68,14 @@ namespace Rhisis.World.Handlers
                 Size = 100,
                 Name = character.Name,
                 Spawned = false,
-                Level = character.Level,
+                Level = character.Level
+            };
+
+            client.Player.Health = new HealthComponent
+            {
                 Hp = character.Hp,
                 Mp = character.Mp,
-                Fp = character.Fp,
-                Experience = character.Experience
+                Fp = character.Fp
             };
 
             client.Player.VisualAppearance = new VisualAppearenceComponent
@@ -89,7 +92,8 @@ namespace Rhisis.World.Handlers
                 Id = character.Id,
                 Slot = character.Slot,
                 Gold = character.Gold,
-                Authority = (AuthorityType)character.User.Authority
+                Authority = (AuthorityType)character.User.Authority,
+                Experience = character.Experience
             };
 
             client.Player.MovableComponent = new MovableComponent

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -68,7 +68,11 @@ namespace Rhisis.World.Handlers
                 Size = 100,
                 Name = character.Name,
                 Spawned = false,
-                Level = character.Level
+                Level = character.Level,
+                Hp = character.Hp,
+                Mp = character.Mp,
+                Fp = character.Fp,
+                Experience = character.Experience
             };
 
             client.Player.VisualAppearance = new VisualAppearenceComponent

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -44,7 +44,7 @@ namespace Rhisis.World.Packets
 
                 packet.Write<short>(0); // m_dwMotion
                 packet.Write<byte>(1); // m_bPlayer
-                packet.Write(230); // HP
+                packet.Write(player.Object.Hp); // HP
                 packet.Write(0); // moving flags
                 packet.Write(0); // motion flags
                 packet.Write<byte>(1); // m_dwBelligerence
@@ -101,12 +101,12 @@ namespace Rhisis.World.Packets
                 for (int i = 0; i < 26; ++i)
                     packet.Write(0);
 
-                packet.Write((short)0); // MP
-                packet.Write((short)0); // FP
+                packet.Write((short)player.Object.Mp); // MP
+                packet.Write((short)player.Object.Fp); // FP
                 packet.Write(0); // tutorial state
                 packet.Write(0); // fly experience
                 packet.Write(player.PlayerData.Gold); // Gold
-                packet.Write((long)0); // exp
+                packet.Write(player.Object.Experience); // exp
                 packet.Write(0); // skill level
                 packet.Write(0); // skill points
                 packet.Write<long>(0); // death exp
@@ -238,13 +238,13 @@ namespace Rhisis.World.Packets
 
                     packet.Write<short>(0);
                     packet.Write<byte>(1); // is player?
-                    packet.Write(230); // HP
+                    packet.Write(playerEntity.Object.Hp); // HP
                     packet.Write(0); // moving flags
                     packet.Write(0); // motion flags
                     packet.Write<byte>(0);
                     packet.Write(-1); // baby buffer
 
-                    packet.Write(entityToSpawn.Object.Name);
+                    packet.Write(playerEntity.Object.Name);
                     packet.Write(playerEntity.VisualAppearance.Gender);
                     packet.Write((byte)playerEntity.VisualAppearance.SkinSetId);
                     packet.Write((byte)playerEntity.VisualAppearance.HairId);
@@ -252,11 +252,11 @@ namespace Rhisis.World.Packets
                     packet.Write((byte)playerEntity.VisualAppearance.FaceId);
                     packet.Write(playerEntity.PlayerData.Id);
                     packet.Write((byte)1);
-                    packet.Write((short)0); // STR
-                    packet.Write((short)0); // STA
-                    packet.Write((short)0); // DEX
-                    packet.Write((short)0); // INT
-                    packet.Write((short)1); // Level
+                    packet.Write((short)playerEntity.Statistics.Strenght); // STR
+                    packet.Write((short)playerEntity.Statistics.Stamina); // STA
+                    packet.Write((short)playerEntity.Statistics.Dexterity); // DEX
+                    packet.Write((short)playerEntity.Statistics.Intelligence); // INT
+                    packet.Write((short)playerEntity.Object.Level); // Level
 
                     packet.Write(-1);
                     packet.Write(0);

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -3,9 +3,9 @@ using Rhisis.Network.Packets;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Inventory;
 using System.Collections.Generic;
 using System.Linq;
-using Rhisis.World.Systems.Inventory;
 
 namespace Rhisis.World.Packets
 {
@@ -44,7 +44,7 @@ namespace Rhisis.World.Packets
 
                 packet.Write<short>(0); // m_dwMotion
                 packet.Write<byte>(1); // m_bPlayer
-                packet.Write(player.Object.Hp); // HP
+                packet.Write(player.Health.Hp); // HP
                 packet.Write(0); // moving flags
                 packet.Write(0); // motion flags
                 packet.Write<byte>(1); // m_dwBelligerence
@@ -65,7 +65,7 @@ namespace Rhisis.World.Packets
                 packet.Write((short) player.Statistics.Dexterity);
                 packet.Write((short) player.Statistics.Intelligence);
 
-                packet.Write((short)1); // Levels
+                packet.Write((short)player.Object.Level); // Level
                 packet.Write(-1); // Fuel
                 packet.Write(0); // Actuel fuel
 
@@ -101,12 +101,12 @@ namespace Rhisis.World.Packets
                 for (int i = 0; i < 26; ++i)
                     packet.Write(0);
 
-                packet.Write((short)player.Object.Mp); // MP
-                packet.Write((short)player.Object.Fp); // FP
+                packet.Write((short)player.Health.Mp); // MP
+                packet.Write((short)player.Health.Fp); // FP
                 packet.Write(0); // tutorial state
                 packet.Write(0); // fly experience
                 packet.Write(player.PlayerData.Gold); // Gold
-                packet.Write(player.Object.Experience); // exp
+                packet.Write(player.PlayerData.Experience); // exp
                 packet.Write(0); // skill level
                 packet.Write(0); // skill points
                 packet.Write<long>(0); // death exp
@@ -238,7 +238,7 @@ namespace Rhisis.World.Packets
 
                     packet.Write<short>(0);
                     packet.Write<byte>(1); // is player?
-                    packet.Write(playerEntity.Object.Hp); // HP
+                    packet.Write(playerEntity.Health.Hp); // HP
                     packet.Write(0); // moving flags
                     packet.Write(0); // motion flags
                     packet.Write<byte>(0);
@@ -305,9 +305,11 @@ namespace Rhisis.World.Packets
                 }
                 else if (entityToSpawn.Type == WorldEntityType.Monster)
                 {
+                    var monsterEntity = entityToSpawn as IMonsterEntity;
+
                     packet.Write<short>(5);
                     packet.Write<byte>(0);
-                    packet.Write(WorldServer.Movers[entityToSpawn.Object.ModelId].MaxHP);
+                    packet.Write(monsterEntity.Health.Hp);
                     packet.Write(1);
                     packet.Write(0);
                     packet.Write((byte)WorldServer.Movers[entityToSpawn.Object.ModelId].Belligerence);
@@ -329,7 +331,7 @@ namespace Rhisis.World.Packets
                     packet.Write((byte)0);
                     packet.Write((byte)0);
                     packet.Write(0);
-                    packet.Write(1f); // speed factor
+                    packet.Write(monsterEntity.MovableComponent.SpeedFactor); // speed factor
                     packet.Write(0);
                 }
                 else if (entityToSpawn.Type == WorldEntityType.Npc)

--- a/src/Rhisis.World/Systems/Battle/BattleHelper.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleHelper.cs
@@ -1,0 +1,21 @@
+﻿using Rhisis.World.Game.Core;
+
+namespace Rhisis.World.Systems.Battle
+{
+    /// <summary>
+    /// This class provides methods to calculate everything related to the <see cref="BattleSystem"/>.
+    /// </summary>
+    public static class BattleHelper
+    {
+        /// <summary>
+        /// Gets the melee damages inflicted by an attacker to a defender.
+        /// </summary>
+        /// <param name="attacker">Attacker entity</param>
+        /// <param name="defender">Defender entity</param>
+        /// <returns>Damages</returns>
+        public static int GetMeeleAttackDamages(IEntity attacker, IEntity defender)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -32,7 +32,15 @@ namespace Rhisis.World.Systems.Battle
 
         private void ProcessMeleeAttack(IEntity attacker, MeleeAttackEventArgs e)
         {
-            Logger.Debug($"{attacker.Object.Name} is attacking {e.Target.Object.Name}");
+            if (!e.Target.Object.IsDead)
+            {
+                Logger.Error($"{attacker.Object.Name} cannot attack {e.Target.Object.Name} because target is already dead.");
+                return;
+            }
+
+            int attackDamages = BattleHelper.GetMeeleAttackDamages(attacker, e.Target);
+
+            Logger.Debug($"{attacker.Object.Name} inflicted {attackDamages} to {e.Target.Object.Name}");
         }
     }
 }

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -1,6 +1,7 @@
 ﻿using NLog;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
 using System;
 
 namespace Rhisis.World.Systems.Battle
@@ -22,17 +23,23 @@ namespace Rhisis.World.Systems.Battle
                 return;
             }
 
+            if (!(entity is ILivingEntity livingEntity))
+            {
+                Logger.Error($"The non living entity {entity.Object.Name} tried to execute a battle action.");
+                return;
+            }
+
             switch (args)
             {
                 case MeleeAttackEventArgs meleeAttackEventArgs:
-                    this.ProcessMeleeAttack(entity, meleeAttackEventArgs);
+                    this.ProcessMeleeAttack(livingEntity, meleeAttackEventArgs);
                     break;
             }
         }
 
-        private void ProcessMeleeAttack(IEntity attacker, MeleeAttackEventArgs e)
+        private void ProcessMeleeAttack(ILivingEntity attacker, MeleeAttackEventArgs e)
         {
-            if (!e.Target.Object.IsDead)
+            if (!e.Target.Health.IsDead)
             {
                 Logger.Error($"{attacker.Object.Name} cannot attack {e.Target.Object.Name} because target is already dead.");
                 return;

--- a/src/Rhisis.World/Systems/Battle/MeleeAttackEventArgs.cs
+++ b/src/Rhisis.World/Systems/Battle/MeleeAttackEventArgs.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
 
 namespace Rhisis.World.Systems.Battle
 {
@@ -7,11 +8,11 @@ namespace Rhisis.World.Systems.Battle
     {
         public int AttackType { get; }
 
-        public IEntity Target { get; }
+        public ILivingEntity Target { get; }
 
         public float AttackSpeed { get; }
 
-        public MeleeAttackEventArgs(int attackType, IEntity target, float attackSpeed)
+        public MeleeAttackEventArgs(int attackType, ILivingEntity target, float attackSpeed)
         {
             this.AttackType = attackType;
             this.Target = target;


### PR DESCRIPTION
This PR adds new components for the battle system:
- `BattleComponent`: Contains the fighting target(s) and a boolean that indicates if the object is fighting or not.
- `HealthComponent`: Contains everything related to hp, mp and fp. 

And also an entity:
- `ILivingEntity`: wraps the two components described above.

Plus, a `IPlayerEntity` and a `IMonsterEntity` both inherits from `ILivingEntity`.