### PR TITLE
Custom Commands

### DIFF
--- a/src/Rhisis.World/Game/Chat/AddDamageCommand.cs
+++ b/src/Rhisis.World/Game/Chat/AddDamageCommand.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.Common;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.World.Game.Common;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Packets;
+using System;
+
+namespace Rhisis.World.Game.Chat
+{
+    public class AddDamageCommand
+    {
+        private static ILogger Logger => DependencyContainer.Instance.Resolve<ILogger<AddDamageCommand>>();
+
+        [ChatCommand(".adddamage", AuthorityType.Administrator)]
+        [ChatCommand(".ad", AuthorityType.Administrator)]
+        public static void AddDamage(IPlayerEntity player, string[] parameters)
+        {
+            if(parameters.Length < 1)
+            {
+                WorldPacketFactory.SendWorldMsg(player, "Syntax: .ad <atkFlag> <damage>");
+                return;
+            }
+
+            if(player.Interaction.TargetEntity == null)
+            {
+                WorldPacketFactory.SendWorldMsg(player, "Select target entity first.");
+                return;
+            }
+
+            Logger.LogDebug("Player {0} wants to execute AddDamage with effect to entity {1}.", player.Object.Name, player.Interaction.TargetEntity.Object.Name);
+
+            if(!(player.Interaction.TargetEntity is ILivingEntity livingEntity))
+            {
+                WorldPacketFactory.SendWorldMsg(player, "Target is not a living entity.");
+                return;
+            }
+
+            var atkFlag = AttackFlags.AF_GENERIC;
+            var damage = 0;
+
+            if (parameters.Length == 2)
+            {
+                if(!Enum.TryParse(parameters[0], out atkFlag) || !int.TryParse(parameters[1], out damage))
+                {
+                    WorldPacketFactory.SendWorldMsg(player, "Invalid atkFlags or damage parameter.");
+                    return;
+                }
+            }
+            else
+            {
+                if (!int.TryParse(parameters[0], out damage))
+                {
+                    WorldPacketFactory.SendWorldMsg(player, "Invalid damage parameter.");
+                    return;
+                }
+            }
+
+            WorldPacketFactory.SendAddDamage(player, livingEntity, player, atkFlag, damage);
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Chat/ChatSystem.cs
+++ b/src/Rhisis.World/Systems/Chat/ChatSystem.cs
@@ -56,7 +56,7 @@ namespace Rhisis.World.Systems.Chat
             if (!chatEvent.CheckArguments())
                 return;
 
-            if (chatEvent.Message.StartsWith("/"))
+            if (chatEvent.Message.StartsWith("/") || chatEvent.Message.StartsWith("."))
             {
                 string commandName = chatEvent.Message.Split(' ').FirstOrDefault();
                 string[] commandParameters = GetCommandParameters(chatEvent.Message, commandName);


### PR DESCRIPTION
This PR adds the ability to add custom commands starting with a dot. Custom commands are implemented the same way as normal Chat Commands except you prefix them with a dot instead of forward-slash.

This PR also contains a Custom Command called AddDamage which can be used for testing purposes.

e.g.: `.ad AF_GENERIC 1234`
Where as AF_GENERIC is the Attack Flags which are being parsed and 1234 is the damage count.
The `.ad` is the shortened version of `.adddamage` which also works.