### PR TITLE
TaskbarSystem (Shortcuts, Actionslot)

### DIFF
--- a/bin/config/world.json
+++ b/bin/config/world.json
@@ -10,7 +10,11 @@
   "rates": {
     "gold": 1,
     "experience": 1,
-	"drop": 1
+    "drop": 1
+  },
+  "drops": {
+    "ownershipTime": 7,
+    "despawnTime": 120
   },
   "isc": {
     "password": "4fded1464736e77865df232cbcb4cd19",

--- a/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
+++ b/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
@@ -1,7 +1,6 @@
 ﻿using Ether.Network.Packets;
-using Rhisis.Core.Common;
 
-namespace Rhisis.World.Game.Structures
+namespace Rhisis.Core.Common.Game.Structures
 {
     public class Shortcut
     {

--- a/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
+++ b/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
@@ -6,11 +6,11 @@ namespace Rhisis.Core.Common.Game.Structures
     {
         public int SlotIndex { get; }
 
-        public ShortcutType ShortcutType { get; }
+        public ShortcutType Type { get; }
 
         public uint ObjId { get; }
 
-        public ShortcutObjType ObjType { get; }
+        public ShortcutObjectType ObjectType { get; }
 
         public uint ObjIndex { get; }
 
@@ -20,12 +20,12 @@ namespace Rhisis.Core.Common.Game.Structures
 
         public string Text { get; }
 
-        public Shortcut(int slotIndex, ShortcutType shortcutType, uint objId, ShortcutObjType shortcutObjType, uint objIndex, uint userId, uint objData, string text)
+        public Shortcut(int slotIndex, ShortcutType type, uint objId, ShortcutObjectType shortcutObjectType, uint objIndex, uint userId, uint objData, string text)
         {
             SlotIndex = slotIndex;
-            ShortcutType = shortcutType;
+            Type = type;
             ObjId = objId;
-            ObjType = shortcutObjType;
+            ObjectType = shortcutObjectType;
             ObjIndex = objIndex;
             UserId = userId;
             ObjData = objData;
@@ -35,14 +35,14 @@ namespace Rhisis.Core.Common.Game.Structures
         public void Serialize(INetPacketStream packet)
         {
             packet.Write(SlotIndex);
-            packet.Write((uint)ShortcutType);
+            packet.Write((uint)Type);
             packet.Write(ObjId);
-            packet.Write((uint)ObjType);
+            packet.Write((uint)ObjectType);
             packet.Write(ObjIndex);
             packet.Write(UserId);
             packet.Write(ObjData);
 
-            if (ShortcutType == ShortcutType.Chat)
+            if (Type == ShortcutType.Chat)
                 packet.Write(Text);
         }
     }

--- a/src/Rhisis.Core/Common/ShortcutType.cs
+++ b/src/Rhisis.Core/Common/ShortcutType.cs
@@ -1,0 +1,26 @@
+﻿namespace Rhisis.Core.Common
+{
+    public enum ShortcutType : uint
+    {
+        None,
+        Etc,
+        Applet,
+        Motion,
+        Script,
+        Item,
+        Skill,
+        Object,
+        Chat,
+        Skillfun,
+        Emoticon,
+        Lordskill
+    }
+
+    public enum ShortcutObjType : uint
+    {
+        Item,
+        Card,
+        Cube,
+        Pet
+    }
+}

--- a/src/Rhisis.Core/Common/ShortcutType.cs
+++ b/src/Rhisis.Core/Common/ShortcutType.cs
@@ -11,12 +11,12 @@
         Skill,
         Object,
         Chat,
-        Skillfun,
+        SkillFun,
         Emoticon,
-        Lordskill
+        LordSkill
     }
 
-    public enum ShortcutObjType : uint
+    public enum ShortcutObjectType : uint
     {
         Item,
         Card,

--- a/src/Rhisis.Core/Common/ShortcutType.cs
+++ b/src/Rhisis.Core/Common/ShortcutType.cs
@@ -23,4 +23,11 @@
         Cube,
         Pet
     }
+
+    public enum ShortcutTaskbarTarget
+    {
+        Applet,
+        Item,
+        Queue
+    }
 }

--- a/src/Rhisis.Database/Context/DatabaseContext.cs
+++ b/src/Rhisis.Database/Context/DatabaseContext.cs
@@ -38,6 +38,11 @@ namespace Rhisis.Database.Context
         public DbSet<DbMail> Mails { get; set; }
 
         /// <summary>
+        /// Gets or sets the taskbar shortcuts.
+        /// </summary>
+        public DbSet<DbShortcut> TaskbarShortcuts { get; set; }
+
+        /// <summary>
         /// Create a new <see cref="DatabaseContext"/> instance.
         /// </summary>
         /// <param name="options"></param>

--- a/src/Rhisis.Database/Database.cs
+++ b/src/Rhisis.Database/Database.cs
@@ -21,6 +21,9 @@ namespace Rhisis.Database
 
         public IMailRepository Mails { get; set; }
 
+        /// <inheritdoc />
+        public IShortcutRepository TaskbarShortcuts { get; private set; }
+
         /// <summary>
         /// Creates a new <see cref="Database"/> object instance.
         /// </summary>

--- a/src/Rhisis.Database/Entities/DbCharacter.cs
+++ b/src/Rhisis.Database/Entities/DbCharacter.cs
@@ -70,11 +70,14 @@ namespace Rhisis.Database.Entities
 
         public ICollection<DbMail> SentMails { get; set; }
 
+        public ICollection<DbShortcut> TaskbarShortcuts { get; set; }
+
         public DbCharacter()
         {
             this.Items = new HashSet<DbItem>();
             this.ReceivedMails = new HashSet<DbMail>();
             this.SentMails = new HashSet<DbMail>();
+            this.TaskbarShortcuts = new HashSet<DbShortcut>();
         }
     }
 }

--- a/src/Rhisis.Database/Entities/DbShortcut.cs
+++ b/src/Rhisis.Database/Entities/DbShortcut.cs
@@ -1,0 +1,56 @@
+﻿using Rhisis.Core.Common;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Rhisis.Database.Entities
+{
+    [Table("shortcuts")]
+    public sealed class DbShortcut : DbEntity
+    {
+        public int CharacterId { get; set; }
+
+        public ShortcutTaskbarTarget TargetTaskbar { get; set; }
+
+        public int? SlotLevelIndex { get; set; }
+
+        public int SlotIndex { get; set; }
+
+        public ShortcutType Type { get; set; }
+
+        public uint ObjectId { get; set; }
+
+        public ShortcutObjectType ObjectType { get; set; }
+
+        public uint ObjectIndex { get; set; }
+
+        public uint UserId { get; set; }
+
+        public uint ObjectData { get; set; }
+
+        public string Text { get; set; }
+
+        public DbCharacter Character { get; set; }
+
+        public DbShortcut()
+        {
+        }
+
+        public DbShortcut(ShortcutTaskbarTarget targetTaskbar, int slotIndex, ShortcutType type, uint objectId, ShortcutObjectType objectType, uint objectIndex, uint userId, uint objectData, string text)
+            : this(targetTaskbar, null, slotIndex, type, objectId, objectType, objectIndex, userId, objectData, text)
+        {
+        }
+
+        public DbShortcut(ShortcutTaskbarTarget targetTaskbar, int? slotLevelIndex, int slotIndex, ShortcutType type, uint objectId, ShortcutObjectType objectType, uint objectIndex, uint userId, uint objectData, string text)
+        {
+            TargetTaskbar = targetTaskbar;
+            SlotLevelIndex = slotLevelIndex;
+            SlotIndex = slotIndex;
+            Type = type;
+            ObjectId = objectId;
+            ObjectType = objectType;
+            ObjectIndex = objectIndex;
+            UserId = userId;
+            ObjectData = objectData;
+            Text = text;
+        }
+    }
+}

--- a/src/Rhisis.Database/IDatabase.cs
+++ b/src/Rhisis.Database/IDatabase.cs
@@ -27,6 +27,11 @@ namespace Rhisis.Database
         IMailRepository Mails { get; set; }
 
         /// <summary>
+        /// Gets the taskbar shortcuts.
+        /// </summary>
+        IShortcutRepository TaskbarShortcuts { get; }
+
+        /// <summary>
         /// Complete the pending database operations.
         /// </summary>
         void Complete();

--- a/src/Rhisis.Database/Migrations/20190208211502_Shortcuts.Designer.cs
+++ b/src/Rhisis.Database/Migrations/20190208211502_Shortcuts.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace Rhisis.Database.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20190208211502_Shortcuts")]
+    partial class Shortcuts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Rhisis.Database/Migrations/20190208211502_Shortcuts.cs
+++ b/src/Rhisis.Database/Migrations/20190208211502_Shortcuts.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace Rhisis.Database.Migrations
+{
+    public partial class Shortcuts : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "shortcuts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    CharacterId = table.Column<int>(nullable: false),
+                    ObjectData = table.Column<uint>(nullable: false),
+                    ObjectId = table.Column<uint>(nullable: false),
+                    ObjectIndex = table.Column<uint>(nullable: false),
+                    ObjectType = table.Column<uint>(nullable: false),
+                    SlotIndex = table.Column<int>(nullable: false),
+                    SlotLevelIndex = table.Column<int>(nullable: true),
+                    TargetTaskbar = table.Column<int>(nullable: false),
+                    Text = table.Column<string>(nullable: true),
+                    Type = table.Column<uint>(nullable: false),
+                    UserId = table.Column<uint>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_shortcuts", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_shortcuts_characters_CharacterId",
+                        column: x => x.CharacterId,
+                        principalTable: "characters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_shortcuts_CharacterId",
+                table: "shortcuts",
+                column: "CharacterId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "shortcuts");
+        }
+    }
+}

--- a/src/Rhisis.Database/Repositories/IShortcutRepository.cs
+++ b/src/Rhisis.Database/Repositories/IShortcutRepository.cs
@@ -1,0 +1,8 @@
+﻿using Rhisis.Database.Entities;
+
+namespace Rhisis.Database.Repositories
+{
+    public interface IShortcutRepository : IRepository<DbShortcut>
+    {
+    }
+}

--- a/src/Rhisis.Database/Repositories/Implementation/CharacterRepository.cs
+++ b/src/Rhisis.Database/Repositories/Implementation/CharacterRepository.cs
@@ -35,7 +35,8 @@ namespace Rhisis.Database.Repositories.Implementation
                 .Include(x => x.SentMails)
                     .ThenInclude(x => x.Sender)
                 .Include(x => x.SentMails)
-                    .ThenInclude(x => x.Item);
+                    .ThenInclude(x => x.Item)
+                .Include(x => x.TaskbarShortcuts);
         }
     }
 }

--- a/src/Rhisis.Database/Repositories/Implementation/ShortcutRepository.cs
+++ b/src/Rhisis.Database/Repositories/Implementation/ShortcutRepository.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Rhisis.Database.Entities;
+using System.Linq;
+
+namespace Rhisis.Database.Repositories.Implementation
+{
+    /// <summary>
+    /// Shortcut repository.
+    /// </summary>
+    internal sealed class ShortcutRepository : RepositoryBase<DbShortcut>, IShortcutRepository
+    {
+        /// <summary>
+        /// Creates an initialize an <see cref="ShortcutRepository"/>.
+        /// </summary>
+        /// <param name="context"></param>
+        public ShortcutRepository(DbContext context)
+            : base(context)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override IQueryable<DbShortcut> GetQueryable(DbContext context)
+        {
+            return base.GetQueryable(context)
+                .Include(x => x.Character);
+        }
+    }
+}

--- a/src/Rhisis.Database/Repositories/Implementation/UserRepository.cs
+++ b/src/Rhisis.Database/Repositories/Implementation/UserRepository.cs
@@ -23,11 +23,13 @@ namespace Rhisis.Database.Repositories.Implementation
         {
             return base.GetQueryable(context)
                 .Include(x => x.Characters)
-                .ThenInclude(x => x.Items)
+                    .ThenInclude(x => x.Items)
                 .Include(x => x.Characters)
-                .ThenInclude(x => x.ReceivedMails)
+                    .ThenInclude(x => x.ReceivedMails)
                 .Include(x => x.Characters)
-                .ThenInclude(x => x.SentMails);
+                    .ThenInclude(x => x.SentMails)
+                .Include(x => x.Characters)
+                    .ThenInclude(x => x.TaskbarShortcuts);
         }
     }
 }

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
@@ -3,7 +3,7 @@ using Rhisis.Core.Common;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class AddTaskbarShortcutPacket
+    public class AddTaskbarAppletPacket
     {
         public int SlotIndex { get; }
 
@@ -21,7 +21,7 @@ namespace Rhisis.Network.Packets.World.Taskbar
 
         public string Text { get; }
 
-        public AddTaskbarShortcutPacket(INetPacketStream packet)
+        public AddTaskbarAppletPacket(INetPacketStream packet)
         {
             SlotIndex = packet.Read<byte>();
             ShortcutType = (ShortcutType)packet.Read<uint>();

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
@@ -1,38 +1,53 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
+using System;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class AddTaskbarAppletPacket
+    public struct AddTaskbarAppletPacket : IEquatable<AddTaskbarAppletPacket>
     {
         public int SlotIndex { get; }
 
-        public ShortcutType ShortcutType { get; }
+        public ShortcutType Type { get; }
 
-        public uint ObjId { get; }
+        public uint ObjectId { get; }
 
-        public ShortcutObjType ObjType { get; }
+        public ShortcutObjectType ObjectType { get; }
 
-        public uint ObjIndex { get; }
+        public uint ObjectIndex { get; }
 
         public uint UserId { get; }
 
-        public uint ObjData { get; }
+        public uint ObjectData { get; }
 
         public string Text { get; }
 
         public AddTaskbarAppletPacket(INetPacketStream packet)
         {
             SlotIndex = packet.Read<byte>();
-            ShortcutType = (ShortcutType)packet.Read<uint>();
-            ObjId = packet.Read<uint>();
-            ObjType = (ShortcutObjType)packet.Read<uint>();
-            ObjIndex = packet.Read<uint>();
+            Type = (ShortcutType)packet.Read<uint>();
+            ObjectId = packet.Read<uint>();
+            ObjectType = (ShortcutObjectType)packet.Read<uint>();
+            ObjectIndex = packet.Read<uint>();
             UserId = packet.Read<uint>();
-            ObjData = packet.Read<uint>();
+            ObjectData = packet.Read<uint>();
+            Text = null;
 
-            if (ShortcutType == ShortcutType.Chat)
+            if (Type == ShortcutType.Chat)
                 Text = packet.Read<string>();
+        }
+
+        public bool Equals(AddTaskbarAppletPacket other)
+        {
+            return
+                SlotIndex == other.SlotIndex &&
+                Type == other.Type &&
+                ObjectId == other.ObjectId &&
+                ObjectType == other.ObjectType &&
+                ObjectIndex == other.ObjectIndex &&
+                UserId == other.UserId &&
+                ObjectData == other.ObjectData &&
+                Text == other.Text;
         }
     }
 }

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
@@ -1,25 +1,26 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
+using System;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class AddTaskbarItemPacket
+    public struct AddTaskbarItemPacket : IEquatable<AddTaskbarItemPacket>
     {
         public int SlotLevelIndex { get; }
 
         public int SlotIndex { get; }
 
-        public ShortcutType ShortcutType { get; }
+        public ShortcutType Type { get; }
 
-        public uint ObjId { get; }
+        public uint ObjectId { get; }
 
-        public ShortcutObjType ObjType { get; }
+        public ShortcutObjectType ObjectType { get; }
 
-        public uint ObjIndex { get; }
+        public uint ObjectIndex { get; }
 
         public uint UserId { get; }
 
-        public uint ObjData { get; }
+        public uint ObjectData { get; }
 
         public string Text { get; }
 
@@ -27,15 +28,30 @@ namespace Rhisis.Network.Packets.World.Taskbar
         {
             SlotLevelIndex = packet.Read<byte>();
             SlotIndex = packet.Read<byte>();
-            ShortcutType = (ShortcutType)packet.Read<uint>();
-            ObjId = packet.Read<uint>();
-            ObjType = (ShortcutObjType)packet.Read<uint>();
-            ObjIndex = packet.Read<uint>();
+            Type = (ShortcutType)packet.Read<uint>();
+            ObjectId = packet.Read<uint>();
+            ObjectType = (ShortcutObjectType)packet.Read<uint>();
+            ObjectIndex = packet.Read<uint>();
             UserId = packet.Read<uint>();
-            ObjData = packet.Read<uint>();
+            ObjectData = packet.Read<uint>();
+            Text = null;
 
-            if (ShortcutType == ShortcutType.Chat)
+            if (Type == ShortcutType.Chat)
                 Text = packet.Read<string>();
+        }
+
+        public bool Equals(AddTaskbarItemPacket other)
+        {
+            return
+                SlotLevelIndex == other.SlotLevelIndex &&
+                SlotIndex == other.SlotIndex &&
+                Type == other.Type &&
+                ObjectId == other.ObjectId &&
+                ObjectType == other.ObjectType &&
+                ObjectIndex == other.ObjectIndex &&
+                UserId == other.UserId &&
+                ObjectData == other.ObjectData &&
+                Text == other.Text;
         }
     }
 }

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
@@ -1,0 +1,41 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+
+namespace Rhisis.Network.Packets.World.Taskbar
+{
+    public class AddTaskbarItemPacket
+    {
+        public int SlotLevelIndex { get; }
+
+        public int SlotIndex { get; }
+
+        public ShortcutType ShortcutType { get; }
+
+        public uint ObjId { get; }
+
+        public ShortcutObjType ObjType { get; }
+
+        public uint ObjIndex { get; }
+
+        public uint UserId { get; }
+
+        public uint ObjData { get; }
+
+        public string Text { get; }
+
+        public AddTaskbarItemPacket(INetPacketStream packet)
+        {
+            SlotLevelIndex = packet.Read<byte>();
+            SlotIndex = packet.Read<byte>();
+            ShortcutType = (ShortcutType)packet.Read<uint>();
+            ObjId = packet.Read<uint>();
+            ObjType = (ShortcutObjType)packet.Read<uint>();
+            ObjIndex = packet.Read<uint>();
+            UserId = packet.Read<uint>();
+            ObjData = packet.Read<uint>();
+
+            if (ShortcutType == ShortcutType.Chat)
+                Text = packet.Read<string>();
+        }
+    }
+}

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarShortcutPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarShortcutPacket.cs
@@ -1,0 +1,38 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+
+namespace Rhisis.Network.Packets.World.Taskbar
+{
+    public class AddTaskbarShortcutPacket
+    {
+        public int SlotIndex { get; }
+
+        public ShortcutType ShortcutType { get; }
+
+        public uint ObjId { get; }
+
+        public ShortcutObjType ObjType { get; }
+
+        public uint ObjIndex { get; }
+
+        public uint UserId { get; }
+
+        public uint ObjData { get; }
+
+        public string Text { get; }
+
+        public AddTaskbarShortcutPacket(INetPacketStream packet)
+        {
+            SlotIndex = packet.Read<byte>();
+            ShortcutType = (ShortcutType)packet.Read<uint>();
+            ObjId = packet.Read<uint>();
+            ObjType = (ShortcutObjType)packet.Read<uint>();
+            ObjIndex = packet.Read<uint>();
+            UserId = packet.Read<uint>();
+            ObjData = packet.Read<uint>();
+
+            if (ShortcutType == ShortcutType.Chat)
+                Text = packet.Read<string>();
+        }
+    }
+}

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
@@ -1,0 +1,14 @@
+﻿using Ether.Network.Packets;
+
+namespace Rhisis.Network.Packets.World.Taskbar
+{
+    public class RemoveTaskbarAppletPacket
+    {
+        public int SlotIndex { get; }
+
+        public RemoveTaskbarAppletPacket(INetPacketStream packet)
+        {
+            SlotIndex = packet.Read<byte>();
+        }
+    }
+}

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
@@ -1,14 +1,20 @@
 ﻿using Ether.Network.Packets;
+using System;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class RemoveTaskbarAppletPacket
+    public struct RemoveTaskbarAppletPacket : IEquatable<RemoveTaskbarAppletPacket>
     {
         public int SlotIndex { get; }
 
         public RemoveTaskbarAppletPacket(INetPacketStream packet)
         {
             SlotIndex = packet.Read<byte>();
+        }
+
+        public bool Equals(RemoveTaskbarAppletPacket other)
+        {
+            return SlotIndex == other.SlotIndex;
         }
     }
 }

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
@@ -1,0 +1,17 @@
+﻿using Ether.Network.Packets;
+
+namespace Rhisis.Network.Packets.World.Taskbar
+{
+    public class RemoveTaskbarItemPacket
+    {
+        public int SlotLevelIndex { get; }
+
+        public int SlotIndex { get; }
+
+        public RemoveTaskbarItemPacket(INetPacketStream packet)
+        {
+            SlotLevelIndex = packet.Read<byte>();
+            SlotIndex = packet.Read<byte>();
+        }
+    }
+}

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
@@ -1,8 +1,9 @@
 ﻿using Ether.Network.Packets;
+using System;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class RemoveTaskbarItemPacket
+    public struct RemoveTaskbarItemPacket : IEquatable<RemoveTaskbarItemPacket>
     {
         public int SlotLevelIndex { get; }
 
@@ -12,6 +13,11 @@ namespace Rhisis.Network.Packets.World.Taskbar
         {
             SlotLevelIndex = packet.Read<byte>();
             SlotIndex = packet.Read<byte>();
+        }
+
+        public bool Equals(RemoveTaskbarItemPacket other)
+        {
+            return SlotLevelIndex == other.SlotLevelIndex && SlotIndex == other.SlotIndex;
         }
     }
 }

--- a/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
@@ -1,0 +1,37 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+using Rhisis.Core.Common.Game.Structures;
+using System.Collections.Generic;
+
+namespace Rhisis.Network.Packets.World.Taskbar
+{
+    public class TaskbarSkillPacket
+    {
+        public List<Shortcut> Skills { get; }
+
+        public TaskbarSkillPacket(INetPacketStream packet)
+        {
+            Skills = new List<Shortcut>(new Shortcut[packet.Read<int>()]);
+
+            for(int i = 0; i < Skills.Count; i++)
+            {
+                var index = packet.Read<byte>();
+                if (index >= Skills.Count)
+                    return;
+
+                var type = (ShortcutType)packet.Read<uint>();
+                var objId = packet.Read<uint>();
+                var objType = (ShortcutObjType)packet.Read<uint>();
+                var objIndex = packet.Read<uint>();
+                var userId = packet.Read<uint>();
+                var objData = packet.Read<uint>();
+                string text = null;
+
+                if (type == ShortcutType.Chat)
+                    text = packet.Read<string>();
+
+                Skills[i] = new Shortcut(index, type, objId, objType, objIndex, userId, objData, text);
+            }
+        }
+    }
+}

--- a/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
@@ -1,11 +1,12 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
+using System;
 using System.Collections.Generic;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {
-    public class TaskbarSkillPacket
+    public struct TaskbarSkillPacket : IEquatable<TaskbarSkillPacket>
     {
         public List<Shortcut> Skills { get; }
 
@@ -21,7 +22,7 @@ namespace Rhisis.Network.Packets.World.Taskbar
 
                 var type = (ShortcutType)packet.Read<uint>();
                 var objId = packet.Read<uint>();
-                var objType = (ShortcutObjType)packet.Read<uint>();
+                var objType = (ShortcutObjectType)packet.Read<uint>();
                 var objIndex = packet.Read<uint>();
                 var userId = packet.Read<uint>();
                 var objData = packet.Read<uint>();
@@ -32,6 +33,11 @@ namespace Rhisis.Network.Packets.World.Taskbar
 
                 Skills[i] = new Shortcut(index, type, objId, objType, objIndex, userId, objData, text);
             }
+        }
+
+        public bool Equals(TaskbarSkillPacket other)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Rhisis.World/Game/Chat/TestCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TestCommand.cs
@@ -1,15 +1,21 @@
 ﻿using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.World.Game.Entities;
+using System;
 
 namespace Rhisis.World.Game.Chat
 {
     public class TestCommand
     {
-        struct SKILL
+        struct SKILL : IEquatable<SKILL>
         {
             public uint dwSkill;
             public uint dwLevel;
+
+            public bool Equals(SKILL other)
+            {
+                return dwSkill == other.dwSkill && dwLevel == other.dwLevel;
+            }
         }
 
         [ChatCommand(".test", Rhisis.Core.Common.AuthorityType.Administrator)]

--- a/src/Rhisis.World/Game/Chat/TestCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TestCommand.cs
@@ -1,21 +1,72 @@
 ﻿using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.World.Game.Entities;
-using Rhisis.World.Packets;
 
 namespace Rhisis.World.Game.Chat
 {
     public class TestCommand
     {
+        struct SKILL
+        {
+            public uint dwSkill;
+            public uint dwLevel;
+        }
+
         [ChatCommand(".test", Rhisis.Core.Common.AuthorityType.Administrator)]
         public static void OnTest(IPlayerEntity player, string[] parameters)
         {
-            if (int.TryParse(parameters[0], out var nAP))
+            using (var packet = new FFPacket())
             {
-                WorldPacketFactory.SendSetActionPoint(player, nAP);
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SETEXPERIENCE);
+
+                packet.Write((long)0);
+                packet.Write((ushort)5);
+                packet.Write(5);
+                packet.Write(10);
+                packet.Write((long)0);
+                packet.Write((ushort)0);
+
+                player.Connection.Send(packet);
             }
-            else
-                WorldPacketFactory.SendWorldMsg(player, "Not a valid integer.");
+
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SET_JOB_SKILL);
+
+                const int MAX_JOB_SKILL = 45;
+
+                packet.Write(0); // JOB ID
+                
+                for(int i = 0; i < MAX_JOB_SKILL; i++)
+                {
+                    SKILL skill;
+                    if (i == 0)
+                    {
+                        skill.dwSkill = 1;
+                        skill.dwLevel = 3;
+                    }
+                    else if(i == 1)
+                    {
+                        skill.dwSkill = 2;
+                        skill.dwLevel = 1;
+                    }
+                    else
+                    {
+                        skill.dwSkill = 0xffffffff;
+                        skill.dwLevel = 0;
+                    }
+
+                    packet.Write(skill.dwSkill);
+                    packet.Write(skill.dwLevel);
+                }
+
+                for (int i = 0; i < 32; i++)
+                    packet.Write(0);
+
+                player.Connection.Send(packet);
+            }
+
+
         }
     }
 }

--- a/src/Rhisis.World/Game/Chat/TestCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TestCommand.cs
@@ -1,0 +1,21 @@
+﻿using Rhisis.Network;
+using Rhisis.Network.Packets;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Packets;
+
+namespace Rhisis.World.Game.Chat
+{
+    public class TestCommand
+    {
+        [ChatCommand(".test", Rhisis.Core.Common.AuthorityType.Administrator)]
+        public static void OnTest(IPlayerEntity player, string[] parameters)
+        {
+            if (int.TryParse(parameters[0], out var nAP))
+            {
+                WorldPacketFactory.SendSetActionPoint(player, nAP);
+            }
+            else
+                WorldPacketFactory.SendWorldMsg(player, "Not a valid integer.");
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
@@ -1,6 +1,7 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
+using Rhisis.World.Game.Entities;
 using Rhisis.World.Systems.Taskbar;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
@@ -1,0 +1,69 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Taskbar;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.World.Game.Components
+{
+    public class TaskbarAppletContainerComponent
+    {
+        public int MaxCapacity { get; }
+
+        public List<Shortcut> Shortcuts { get; }
+
+        public TaskbarAppletContainerComponent(int maxCapacity)
+        {
+            MaxCapacity = maxCapacity;
+            Shortcuts = new List<Shortcut>(new Shortcut[maxCapacity]);
+        }
+
+        public bool IsSlotAvailable(int slotIndex)
+        {
+            if (slotIndex < 0 || slotIndex >= TaskbarSystem.MaxTaskbarApplets)
+                return false;
+
+            return Shortcuts[slotIndex] == null;
+        }
+
+        public void CreateShortcut(Shortcut shortcut)
+        {
+            if (shortcut.SlotIndex < 0 || shortcut.SlotIndex >= TaskbarSystem.MaxTaskbarApplets)
+                return;
+
+            if (Shortcuts[shortcut.SlotIndex] != null)
+                return;
+
+            Shortcuts[shortcut.SlotIndex] = shortcut;
+        }
+
+        public void RemoveShortcut(int slotIndex)
+        {
+            if (slotIndex < 0 || slotIndex >= TaskbarSystem.MaxTaskbarApplets)
+                return;
+
+            Shortcuts[slotIndex] = null;
+        }
+
+        public int Count
+        {
+            get
+            {
+                return Shortcuts.Count(x => x != null && x.ShortcutType != ShortcutType.None);
+            }
+        }
+
+        public void Serialize(INetPacketStream packet)
+        {
+            packet.Write(Count);
+            for(int i = 0; i < MaxCapacity; i++)
+            {
+                if(Shortcuts[i] != null && Shortcuts[i].ShortcutType != ShortcutType.None)
+                {
+                    Shortcuts[i].Serialize(packet);
+                }
+            }
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
@@ -46,20 +46,14 @@ namespace Rhisis.World.Game.Components
             Shortcuts[slotIndex] = null;
         }
 
-        public int Count
-        {
-            get
-            {
-                return Shortcuts.Count(x => x != null && x.ShortcutType != ShortcutType.None);
-            }
-        }
+        public int Count => this.Shortcuts.Count(x => x != null && x.Type != ShortcutType.None);
 
         public void Serialize(INetPacketStream packet)
         {
             packet.Write(Count);
             for(int i = 0; i < MaxCapacity; i++)
             {
-                if(Shortcuts[i] != null && Shortcuts[i].ShortcutType != ShortcutType.None)
+                if(Shortcuts[i] != null && Shortcuts[i].Type != ShortcutType.None)
                 {
                     Shortcuts[i].Serialize(packet);
                 }

--- a/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
@@ -1,6 +1,6 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
-using Rhisis.World.Game.Structures;
+using Rhisis.Core.Common.Game.Structures;
 using Rhisis.World.Systems.Taskbar;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Rhisis.World/Game/Components/TaskbarComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarComponent.cs
@@ -1,0 +1,32 @@
+﻿using Ether.Network.Packets;
+using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Taskbar;
+
+namespace Rhisis.World.Game.Components
+{
+    public class TaskbarComponent
+    {
+        public TaskbarAppletContainerComponent Applets { get; }
+
+        public TaskbarItemContainerComponent Items { get; }
+
+        //public AppletContainerComponent Queue { get; }
+
+        public int ActionPoints { get; set; } = 100;
+
+        public TaskbarComponent()
+        {
+            Applets = new TaskbarAppletContainerComponent(TaskbarSystem.MaxTaskbarApplets);
+            Items = new TaskbarItemContainerComponent(TaskbarSystem.MaxTaskbarItems, TaskbarSystem.MaxTaskbarItemLevels);
+            //Queue = new AppletContainerComponent(TaskbarSystem.MaxTaskbarQueue);
+        }
+
+        public void Serialize(INetPacketStream packet)
+        {
+            Applets.Serialize(packet);
+            Items.Serialize(packet);
+            packet.Write(0); // count Queue
+            packet.Write(ActionPoints);
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Components/TaskbarComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarComponent.cs
@@ -1,5 +1,4 @@
 ﻿using Ether.Network.Packets;
-using Rhisis.World.Game.Structures;
 using Rhisis.World.Systems.Taskbar;
 
 namespace Rhisis.World.Game.Components
@@ -10,7 +9,7 @@ namespace Rhisis.World.Game.Components
 
         public TaskbarItemContainerComponent Items { get; }
 
-        //public AppletContainerComponent Queue { get; }
+        public TaskbarQueueContainerComponent Queue { get; }
 
         public int ActionPoints { get; set; } = 100;
 
@@ -18,14 +17,14 @@ namespace Rhisis.World.Game.Components
         {
             Applets = new TaskbarAppletContainerComponent(TaskbarSystem.MaxTaskbarApplets);
             Items = new TaskbarItemContainerComponent(TaskbarSystem.MaxTaskbarItems, TaskbarSystem.MaxTaskbarItemLevels);
-            //Queue = new AppletContainerComponent(TaskbarSystem.MaxTaskbarQueue);
+            Queue = new TaskbarQueueContainerComponent(TaskbarSystem.MaxTaskbarQueue);
         }
 
         public void Serialize(INetPacketStream packet)
         {
             Applets.Serialize(packet);
             Items.Serialize(packet);
-            packet.Write(0); // count Queue
+            Queue.Serialize(packet);
             packet.Write(ActionPoints);
         }
     }

--- a/src/Rhisis.World/Game/Components/TaskbarComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Ether.Network.Packets;
+using Rhisis.World.Game.Entities;
 using Rhisis.World.Systems.Taskbar;
 
 namespace Rhisis.World.Game.Components

--- a/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
@@ -1,0 +1,74 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Taskbar;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.World.Game.Components
+{
+    public class TaskbarItemContainerComponent
+    {
+        public int MaxItemCapacity { get; }
+
+        public int MaxLevelCapacity { get; }
+
+        public List<List<Shortcut>> Shortcuts { get; }
+
+        public TaskbarItemContainerComponent(int maxItemCapacity, int maxLevelCapacity)
+        {
+            MaxItemCapacity = maxItemCapacity;
+            MaxLevelCapacity = maxLevelCapacity;
+            Shortcuts = new List<List<Shortcut>>(new List<Shortcut>[maxLevelCapacity]);
+
+            for(int i = 0; i < Shortcuts.Count; i++)
+                Shortcuts[i] = new List<Shortcut>(new Shortcut[maxItemCapacity]);
+        }
+
+        public void CreateShortcut(Shortcut shortcut, int slotLevelIndex)
+        {
+            if (slotLevelIndex < 0 || slotLevelIndex >= TaskbarSystem.MaxTaskbarItemLevels)
+                return;
+
+            if (shortcut.SlotIndex < 0 || shortcut.SlotIndex >= TaskbarSystem.MaxTaskbarItems)
+                return;
+
+            Shortcuts[slotLevelIndex][shortcut.SlotIndex] = shortcut;
+        }
+
+        public void RemoveShortcut(int slotLevelIndex, int slotIndex)
+        {
+            if (slotLevelIndex < 0 || slotLevelIndex >= TaskbarSystem.MaxTaskbarItemLevels)
+                return;
+
+            if (slotIndex < 0 || slotIndex >= TaskbarSystem.MaxTaskbarItems)
+                return;
+
+            Shortcuts[slotLevelIndex][slotIndex] = null;
+        }
+
+        public int Count
+        {
+            get
+            {
+                return Shortcuts.Sum(x => x.Count(y => y != null && y.ShortcutType != ShortcutType.None));
+            }
+        }
+
+        public void Serialize(INetPacketStream packet)
+        {
+            packet.Write(Count);
+            for(int level = 0; level < TaskbarSystem.MaxTaskbarItemLevels; level++)
+            {
+                for(int slot = 0; slot < TaskbarSystem.MaxTaskbarItems; slot++)
+                {
+                    if(Shortcuts[level][slot] != null && Shortcuts[level][slot].ShortcutType != ShortcutType.None)
+                    {
+                        packet.Write(level);
+                        Shortcuts[level][slot].Serialize(packet);
+                    }                    
+                }
+            }
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
@@ -48,13 +48,7 @@ namespace Rhisis.World.Game.Components
             Shortcuts[slotLevelIndex][slotIndex] = null;
         }
 
-        public int Count
-        {
-            get
-            {
-                return Shortcuts.Sum(x => x.Count(y => y != null && y.ShortcutType != ShortcutType.None));
-            }
-        }
+        public int Count => Shortcuts.Sum(x => x.Count(y => y != null && y.Type != ShortcutType.None));
 
         public void Serialize(INetPacketStream packet)
         {
@@ -63,7 +57,7 @@ namespace Rhisis.World.Game.Components
             {
                 for(int slot = 0; slot < TaskbarSystem.MaxTaskbarItems; slot++)
                 {
-                    if(Shortcuts[level][slot] != null && Shortcuts[level][slot].ShortcutType != ShortcutType.None)
+                    if(Shortcuts[level][slot] != null && Shortcuts[level][slot].Type != ShortcutType.None)
                     {
                         packet.Write(level);
                         Shortcuts[level][slot].Serialize(packet);

--- a/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Ether.Network.Packets;
 using Rhisis.Core.Common;
+using Rhisis.Core.Common.Game.Structures;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Systems.Taskbar;
 using System.Collections.Generic;

--- a/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
@@ -1,0 +1,56 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+using Rhisis.Core.Common.Game.Structures;
+using Rhisis.World.Systems.Taskbar;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.World.Game.Components
+{
+    public class TaskbarQueueContainerComponent
+    {
+        public int MaxCapacity { get; }
+
+        public List<Shortcut> Shortcuts { get; }
+
+        public TaskbarQueueContainerComponent(int maxCapacity)
+        {
+            MaxCapacity = maxCapacity;
+            Shortcuts = new List<Shortcut>(new Shortcut[maxCapacity]);
+        }
+
+        public void ClearQueue()
+        {
+            Shortcuts.ForEach(x => x = null);
+        }
+
+        public void CreateShortcuts(List<Shortcut> shortcuts)
+        {
+            if (shortcuts.Count > Shortcuts.Count)
+                return;
+
+            for (int i = 0; i < shortcuts.Count; i++)
+                Shortcuts[i] = shortcuts.FirstOrDefault(x => x.SlotIndex == i);
+        }
+
+        public int Count
+        {
+            get
+            {
+                return Shortcuts.Count(x => x != null && x.ShortcutType != ShortcutType.None);
+            }
+        }
+
+        public void Serialize(INetPacketStream packet)
+        {
+            packet.Write(Count);
+            for (int i = 0; i < MaxCapacity; i++)
+            {
+                if (Shortcuts[i] != null && Shortcuts[i].ShortcutType != ShortcutType.None)
+                {
+                    Shortcuts[i].Serialize(packet);
+                }
+            }
+        }
+    }
+}

--- a/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
@@ -33,20 +33,14 @@ namespace Rhisis.World.Game.Components
                 Shortcuts[i] = shortcuts.FirstOrDefault(x => x.SlotIndex == i);
         }
 
-        public int Count
-        {
-            get
-            {
-                return Shortcuts.Count(x => x != null && x.ShortcutType != ShortcutType.None);
-            }
-        }
+        public int Count => Shortcuts.Count(x => x != null && x.Type != ShortcutType.None);
 
         public void Serialize(INetPacketStream packet)
         {
             packet.Write(Count);
             for (int i = 0; i < MaxCapacity; i++)
             {
-                if (Shortcuts[i] != null && Shortcuts[i].ShortcutType != ShortcutType.None)
+                if (Shortcuts[i] != null && Shortcuts[i].Type != ShortcutType.None)
                 {
                     Shortcuts[i].Serialize(packet);
                 }

--- a/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
@@ -21,7 +21,8 @@ namespace Rhisis.World.Game.Components
 
         public void ClearQueue()
         {
-            Shortcuts.ForEach(x => x = null);
+            for (int i = 0; i < Shortcuts.Count; i++)
+                Shortcuts[i] = null;
         }
 
         public void CreateShortcuts(List<Shortcut> shortcuts)

--- a/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
@@ -16,7 +16,9 @@ namespace Rhisis.World.Game.Entities
         TradeComponent Trade { get; set; }
 
         PartyComponent Party { get; set; }
-        
+
+        TaskbarComponent Taskbar { get; set; }
+
         NetUser Connection { get; set; }
 
         IBehavior<IPlayerEntity> Behavior { get; set; }

--- a/src/Rhisis.World/Game/Entities/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/PlayerEntity.cs
@@ -32,6 +32,9 @@ namespace Rhisis.World.Game.Entities
         public PartyComponent Party { get; set; }
 
         /// <inheritdoc />
+        public TaskbarComponent Taskbar { get; set; }
+
+        /// <inheritdoc />
         public NetUser Connection { get; set; }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/Game/Entities/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/PlayerEntity.cs
@@ -63,6 +63,7 @@ namespace Rhisis.World.Game.Entities
             this.PlayerData = new PlayerDataComponent();
             this.Trade = new TradeComponent();
             this.Party = new PartyComponent();
+            this.Taskbar = new TaskbarComponent();
             this.Follow = new FollowComponent();
             this.Interaction = new InteractionComponent();
             this.Battle = new BattleComponent();

--- a/src/Rhisis.World/Game/Structures/Shortcut.cs
+++ b/src/Rhisis.World/Game/Structures/Shortcut.cs
@@ -1,0 +1,50 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+
+namespace Rhisis.World.Game.Structures
+{
+    public class Shortcut
+    {
+        public int SlotIndex { get; }
+
+        public ShortcutType ShortcutType { get; }
+
+        public uint ObjId { get; }
+
+        public ShortcutObjType ObjType { get; }
+
+        public uint ObjIndex { get; }
+
+        public uint UserId { get; }
+
+        public uint ObjData { get; }
+
+        public string Text { get; }
+
+        public Shortcut(int slotIndex, ShortcutType shortcutType, uint objId, ShortcutObjType shortcutObjType, uint objIndex, uint userId, uint objData, string text)
+        {
+            SlotIndex = slotIndex;
+            ShortcutType = shortcutType;
+            ObjId = objId;
+            ObjType = shortcutObjType;
+            ObjIndex = objIndex;
+            UserId = userId;
+            ObjData = objData;
+            Text = text;
+        }
+
+        public void Serialize(INetPacketStream packet)
+        {
+            packet.Write(SlotIndex);
+            packet.Write((uint)ShortcutType);
+            packet.Write(ObjId);
+            packet.Write((uint)ObjType);
+            packet.Write(ObjIndex);
+            packet.Write(UserId);
+            packet.Write(ObjData);
+
+            if (ShortcutType == ShortcutType.Chat)
+                packet.Write(Text);
+        }
+    }
+}

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -11,6 +11,7 @@ using Rhisis.Database.Entities;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World;
+using Rhisis.World.Game.Chat;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Loaders;
@@ -148,12 +149,14 @@ namespace Rhisis.World.Handlers
                     client.Player.Taskbar.Items.CreateShortcut(new Shortcut(item.SlotIndex, item.Type, item.ObjectId, item.ObjectType, item.ObjectIndex, item.UserId, item.ObjectData, item.Text), item.SlotLevelIndex.HasValue ? item.SlotLevelIndex.Value : -1);
             }
 
-            //var list = new List<Shortcut>();
-            //foreach(var skill in character.TaskbarShortcuts.Where(x => x.TargetTaskbar == ShortcutTaskbarTarget.Queue))
-            //{
-            //    list.Add(new Shortcut(skill.SlotIndex, skill.Type, skill.ObjectId, skill.ObjectType, skill.ObjectIndex, skill.UserId, skill.ObjectData, skill.Text));
-            //}
-            //client.Player.Taskbar.Queue.CreateShortcuts(list);
+            TestCommand.OnTest(client.Player, new string[] { });
+
+            var list = new List<Shortcut>();
+            foreach (var skill in character.TaskbarShortcuts.Where(x => x.TargetTaskbar == ShortcutTaskbarTarget.Queue))
+            {
+                list.Add(new Shortcut(skill.SlotIndex, skill.Type, skill.ObjectId, skill.ObjectType, skill.ObjectIndex, skill.UserId, skill.ObjectData, skill.Text));
+            }
+            client.Player.Taskbar.Queue.CreateShortcuts(list);
 
             // 3rd: spawn the player
             WorldPacketFactory.SendPlayerSpawn(client.Player);

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Ether.Network.Packets;
 using NLog;
 using Rhisis.Core.Common;
+using Rhisis.Core.Common.Game.Structures;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.IO;
 using Rhisis.Core.Resources;
@@ -17,6 +18,7 @@ using Rhisis.World.Game.Maps;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Inventory;
 using Rhisis.World.Systems.Inventory.EventArgs;
+using System.Linq;
 
 namespace Rhisis.World.Handlers
 {
@@ -110,6 +112,16 @@ namespace Rhisis.World.Handlers
             };
 
             client.Player.Statistics = new StatisticsComponent(character);
+
+            // Taskbar
+            foreach (var applet in character.TaskbarShortcuts.Where(x => x.TargetTaskbar == ShortcutTaskbarTarget.Applet))
+                client.Player.Taskbar.Applets.CreateShortcut(new Shortcut(applet.SlotIndex, applet.Type, applet.ObjectId, applet.ObjectType, applet.ObjectIndex, applet.UserId, applet.ObjectData, applet.Text));
+
+            foreach (var item in character.TaskbarShortcuts.Where(x => x.TargetTaskbar == ShortcutTaskbarTarget.Item))
+                client.Player.Taskbar.Items.CreateShortcut(new Shortcut(item.SlotIndex, item.Type, item.ObjectId, item.ObjectType, item.ObjectIndex, item.UserId, item.ObjectData, item.Text), item.SlotLevelIndex.HasValue ? item.SlotLevelIndex.Value : -1);
+
+            foreach (var queueItem in character.TaskbarShortcuts.Where(x => x.TargetTaskbar == ShortcutTaskbarTarget.Queue))
+                client.Player.Taskbar.Applets.CreateShortcut(new Shortcut(queueItem.SlotIndex, queueItem.Type, queueItem.ObjectId, queueItem.ObjectType, queueItem.ObjectIndex, queueItem.UserId, queueItem.ObjectData, queueItem.Text));
 
             var behaviors = DependencyContainer.Instance.Resolve<BehaviorLoader>();
             client.Player.Behavior = behaviors.PlayerBehaviors.DefaultBehavior;

--- a/src/Rhisis.World/Handlers/TaskbarHandler.cs
+++ b/src/Rhisis.World/Handlers/TaskbarHandler.cs
@@ -14,7 +14,7 @@ namespace Rhisis.World.Handlers
         public static void OnAddTaskbarApplet(WorldClient client, INetPacketStream packet)
         {
             var addTaskbarAppletPacket = new AddTaskbarAppletPacket(packet);
-            var addTaskbarAppletEventArgs = new AddTaskbarAppletEventArgs(addTaskbarAppletPacket.SlotIndex, addTaskbarAppletPacket.ShortcutType, addTaskbarAppletPacket.ObjId, addTaskbarAppletPacket.ObjType, addTaskbarAppletPacket.ObjIndex, addTaskbarAppletPacket.UserId, addTaskbarAppletPacket.ObjData, addTaskbarAppletPacket.Text);
+            var addTaskbarAppletEventArgs = new AddTaskbarAppletEventArgs(addTaskbarAppletPacket.SlotIndex, addTaskbarAppletPacket.Type, addTaskbarAppletPacket.ObjectId, addTaskbarAppletPacket.ObjectType, addTaskbarAppletPacket.ObjectIndex, addTaskbarAppletPacket.UserId, addTaskbarAppletPacket.ObjectData, addTaskbarAppletPacket.Text);
 
             client.Player.NotifySystem<TaskbarSystem>(addTaskbarAppletEventArgs);
         }
@@ -32,7 +32,7 @@ namespace Rhisis.World.Handlers
         public static void OnAddTaskbarItem(WorldClient client, INetPacketStream packet)
         {
             var addTaskbarItemPacket = new AddTaskbarItemPacket(packet);
-            var addTaskbarItemEventArgs = new AddTaskbarItemEventArgs(addTaskbarItemPacket.SlotLevelIndex, addTaskbarItemPacket.SlotIndex, addTaskbarItemPacket.ShortcutType, addTaskbarItemPacket.ObjId, addTaskbarItemPacket.ObjType, addTaskbarItemPacket.ObjIndex, addTaskbarItemPacket.UserId, addTaskbarItemPacket.ObjData, addTaskbarItemPacket.Text);
+            var addTaskbarItemEventArgs = new AddTaskbarItemEventArgs(addTaskbarItemPacket.SlotLevelIndex, addTaskbarItemPacket.SlotIndex, addTaskbarItemPacket.Type, addTaskbarItemPacket.ObjectId, addTaskbarItemPacket.ObjectType, addTaskbarItemPacket.ObjectIndex, addTaskbarItemPacket.UserId, addTaskbarItemPacket.ObjectData, addTaskbarItemPacket.Text);
                        
             client.Player.NotifySystem<TaskbarSystem>(addTaskbarItemEventArgs);
         }

--- a/src/Rhisis.World/Handlers/TaskbarHandler.cs
+++ b/src/Rhisis.World/Handlers/TaskbarHandler.cs
@@ -1,0 +1,49 @@
+﻿using Ether.Network.Packets;
+using Rhisis.Core.Common;
+using Rhisis.Network;
+using Rhisis.Network.Packets;
+using Rhisis.Network.Packets.World.Taskbar;
+using Rhisis.World.Systems.Taskbar;
+using Rhisis.World.Systems.Taskbar.EventArgs;
+
+namespace Rhisis.World.Handlers
+{
+    public static class TaskbarHandler
+    {
+        [PacketHandler(PacketType.ADDAPPLETTASKBAR)]
+        public static void OnAddTaskbarApplet(WorldClient client, INetPacketStream packet)
+        {
+            var addTaskbarShortcutPacket = new AddTaskbarShortcutPacket(packet);
+            var addTaskbarShortcutEventArgs = new AddTaskbarAppletEventArgs(addTaskbarShortcutPacket.SlotIndex, addTaskbarShortcutPacket.ShortcutType, addTaskbarShortcutPacket.ObjId, addTaskbarShortcutPacket.ObjType, addTaskbarShortcutPacket.ObjIndex, addTaskbarShortcutPacket.UserId, addTaskbarShortcutPacket.ObjData, addTaskbarShortcutPacket.Text);
+
+            client.Player.NotifySystem<TaskbarSystem>(addTaskbarShortcutEventArgs);
+        }
+
+        [PacketHandler(PacketType.REMOVEAPPLETTASKBAR)]
+        public static void OnRemoveTaskbarApplet(WorldClient client, INetPacketStream packet)
+        {
+            var removeTaskbarAppletPacket = new RemoveTaskbarAppletPacket(packet);
+            var removeTaskbarAppletEventArgs = new RemoveTaskbarAppletEventArgs(removeTaskbarAppletPacket.SlotIndex);
+
+            client.Player.NotifySystem<TaskbarSystem>(removeTaskbarAppletEventArgs);
+        }
+
+        [PacketHandler(PacketType.ADDITEMTASKBAR)]
+        public static void OnAddTaskbarItem(WorldClient client, INetPacketStream packet)
+        {
+            var addTaskbarItemPacket = new AddTaskbarItemPacket(packet);
+            var addTaskbarItemEventArgs = new AddTaskbarItemEventArgs(addTaskbarItemPacket.SlotLevelIndex, addTaskbarItemPacket.SlotIndex, addTaskbarItemPacket.ShortcutType, addTaskbarItemPacket.ObjId, addTaskbarItemPacket.ObjType, addTaskbarItemPacket.ObjIndex, addTaskbarItemPacket.UserId, addTaskbarItemPacket.ObjData, addTaskbarItemPacket.Text);
+                       
+            client.Player.NotifySystem<TaskbarSystem>(addTaskbarItemEventArgs);
+        }
+
+        [PacketHandler(PacketType.REMOVEITEMTASKBAR)]
+        public static void OnRemoveTaskbarItem(WorldClient client, INetPacketStream packet)
+        {
+            var removeTaskbarItemPacket = new RemoveTaskbarItemPacket(packet);
+            var removeTaskbarItemEventArgs = new RemoveTaskbarItemEventArgs(removeTaskbarItemPacket.SlotLevelIndex, removeTaskbarItemPacket.SlotIndex);
+
+            client.Player.NotifySystem<TaskbarSystem>(removeTaskbarItemEventArgs);
+        }
+    }
+}

--- a/src/Rhisis.World/Handlers/TaskbarHandler.cs
+++ b/src/Rhisis.World/Handlers/TaskbarHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Ether.Network.Packets;
-using Rhisis.Core.Common;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World.Taskbar;
@@ -15,7 +14,7 @@ namespace Rhisis.World.Handlers
         {
             var addTaskbarAppletPacket = new AddTaskbarAppletPacket(packet);
             var addTaskbarAppletEventArgs = new AddTaskbarAppletEventArgs(addTaskbarAppletPacket.SlotIndex, addTaskbarAppletPacket.Type, addTaskbarAppletPacket.ObjectId, addTaskbarAppletPacket.ObjectType, addTaskbarAppletPacket.ObjectIndex, addTaskbarAppletPacket.UserId, addTaskbarAppletPacket.ObjectData, addTaskbarAppletPacket.Text);
-
+            
             client.Player.NotifySystem<TaskbarSystem>(addTaskbarAppletEventArgs);
         }
 

--- a/src/Rhisis.World/Handlers/TaskbarHandler.cs
+++ b/src/Rhisis.World/Handlers/TaskbarHandler.cs
@@ -13,10 +13,10 @@ namespace Rhisis.World.Handlers
         [PacketHandler(PacketType.ADDAPPLETTASKBAR)]
         public static void OnAddTaskbarApplet(WorldClient client, INetPacketStream packet)
         {
-            var addTaskbarShortcutPacket = new AddTaskbarShortcutPacket(packet);
-            var addTaskbarShortcutEventArgs = new AddTaskbarAppletEventArgs(addTaskbarShortcutPacket.SlotIndex, addTaskbarShortcutPacket.ShortcutType, addTaskbarShortcutPacket.ObjId, addTaskbarShortcutPacket.ObjType, addTaskbarShortcutPacket.ObjIndex, addTaskbarShortcutPacket.UserId, addTaskbarShortcutPacket.ObjData, addTaskbarShortcutPacket.Text);
+            var addTaskbarAppletPacket = new AddTaskbarAppletPacket(packet);
+            var addTaskbarAppletEventArgs = new AddTaskbarAppletEventArgs(addTaskbarAppletPacket.SlotIndex, addTaskbarAppletPacket.ShortcutType, addTaskbarAppletPacket.ObjId, addTaskbarAppletPacket.ObjType, addTaskbarAppletPacket.ObjIndex, addTaskbarAppletPacket.UserId, addTaskbarAppletPacket.ObjData, addTaskbarAppletPacket.Text);
 
-            client.Player.NotifySystem<TaskbarSystem>(addTaskbarShortcutEventArgs);
+            client.Player.NotifySystem<TaskbarSystem>(addTaskbarAppletEventArgs);
         }
 
         [PacketHandler(PacketType.REMOVEAPPLETTASKBAR)]
@@ -44,6 +44,15 @@ namespace Rhisis.World.Handlers
             var removeTaskbarItemEventArgs = new RemoveTaskbarItemEventArgs(removeTaskbarItemPacket.SlotLevelIndex, removeTaskbarItemPacket.SlotIndex);
 
             client.Player.NotifySystem<TaskbarSystem>(removeTaskbarItemEventArgs);
+        }
+
+        [PacketHandler(PacketType.SKILLTASKBAR)]
+        public static void OnTaskbarSkill(WorldClient client, INetPacketStream packet)
+        {
+            var taskbarSkillPacket = new TaskbarSkillPacket(packet);
+            var taskbarSkillEventArgs = new TaskbarSkillEventArgs(taskbarSkillPacket.Skills);
+
+            client.Player.NotifySystem<TaskbarSystem>(taskbarSkillEventArgs);
         }
     }
 }

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -210,10 +210,7 @@ namespace Rhisis.World.Packets
                 
                 player.Connection.Send(packet);
             }
-
-            // test only
-            TestCommand.OnTest(player, new string[] { });
-                       
+                                   
             // Taskbar
             using (var packet = new FFPacket())
             {

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -1,6 +1,7 @@
 ﻿using Rhisis.Core.Resources;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
+using Rhisis.World.Game.Chat;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
@@ -209,6 +210,9 @@ namespace Rhisis.World.Packets
                 
                 player.Connection.Send(packet);
             }
+
+            // test only
+            TestCommand.OnTest(player, new string[] { });
                        
             // Taskbar
             using (var packet = new FFPacket())

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -206,6 +206,15 @@ namespace Rhisis.World.Packets
 
                 // buffs
                 packet.Write(0); // count
+                
+                player.Connection.Send(packet);
+            }
+                       
+            // Taskbar
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.TASKBAR);
+                player.Taskbar.Serialize(packet);
 
                 player.Connection.Send(packet);
             }

--- a/src/Rhisis.World/Packets/TaskbarPackets.cs
+++ b/src/Rhisis.World/Packets/TaskbarPackets.cs
@@ -1,0 +1,20 @@
+﻿using Rhisis.Network;
+using Rhisis.Network.Packets;
+using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World.Packets
+{
+    public partial class WorldPacketFactory
+    {
+        public static void SendSetActionPoint(IPlayerEntity player, int actionPoint)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SETACTIONPOINT);
+                packet.Write(actionPoint);
+
+                player.Connection.Send(packet);
+            }
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarItemEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarItemEventArgs.cs
@@ -13,7 +13,7 @@ namespace Rhisis.World.Systems.Taskbar.EventArgs
 
         public uint ObjId { get; }
 
-        public ShortcutObjType ObjType { get; }
+        public ShortcutObjectType ObjectType { get; }
 
         public uint ObjIndex { get; }
 
@@ -23,13 +23,13 @@ namespace Rhisis.World.Systems.Taskbar.EventArgs
 
         public string Text { get; }
 
-        public AddTaskbarItemEventArgs(int slotLevelIndex, int slotIndex, ShortcutType type, uint objId, ShortcutObjType objType, uint objIndex, uint userId, uint objData, string text)
+        public AddTaskbarItemEventArgs(int slotLevelIndex, int slotIndex, ShortcutType type, uint objId, ShortcutObjectType objectType, uint objIndex, uint userId, uint objData, string text)
         {
             SlotLevelIndex = slotLevelIndex;
             SlotIndex = slotIndex;
             Type = type;
             ObjId = objId;
-            ObjType = objType;
+            ObjectType = objectType;
             ObjIndex = objIndex;
             UserId = userId;
             ObjData = objData;

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarItemEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarItemEventArgs.cs
@@ -1,0 +1,44 @@
+﻿using Rhisis.Core.Common;
+using Rhisis.World.Game.Core.Systems;
+
+namespace Rhisis.World.Systems.Taskbar.EventArgs
+{
+    public class AddTaskbarItemEventArgs : SystemEventArgs
+    {
+        public int SlotLevelIndex { get; }
+
+        public int SlotIndex { get; }
+
+        public ShortcutType Type { get; }
+
+        public uint ObjId { get; }
+
+        public ShortcutObjType ObjType { get; }
+
+        public uint ObjIndex { get; }
+
+        public uint UserId { get; }
+
+        public uint ObjData { get; }
+
+        public string Text { get; }
+
+        public AddTaskbarItemEventArgs(int slotLevelIndex, int slotIndex, ShortcutType type, uint objId, ShortcutObjType objType, uint objIndex, uint userId, uint objData, string text)
+        {
+            SlotLevelIndex = slotLevelIndex;
+            SlotIndex = slotIndex;
+            Type = type;
+            ObjId = objId;
+            ObjType = objType;
+            ObjIndex = objIndex;
+            UserId = userId;
+            ObjData = objData;
+            Text = text;
+        }
+
+        public override bool CheckArguments()
+        {
+            return SlotIndex >= 0 && SlotIndex < TaskbarSystem.MaxTaskbarItems && SlotLevelIndex >= 0 && SlotLevelIndex < TaskbarSystem.MaxTaskbarItemLevels;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarShortcutEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarShortcutEventArgs.cs
@@ -1,0 +1,42 @@
+﻿using Rhisis.Core.Common;
+using Rhisis.World.Game.Core.Systems;
+using System;
+
+namespace Rhisis.World.Systems.Taskbar.EventArgs
+{
+    public class AddTaskbarAppletEventArgs : SystemEventArgs
+    {
+        public int SlotIndex { get; }
+
+        public ShortcutType Type { get; }
+
+        public uint ObjId { get; }
+
+        public ShortcutObjType ObjType { get; }
+
+        public uint ObjIndex { get; }
+
+        public uint UserId { get; }
+
+        public uint ObjData { get; }
+
+        public string Text { get; }
+
+        public AddTaskbarAppletEventArgs(int slotIndex, ShortcutType type, uint objId, ShortcutObjType objType, uint objIndex, uint userId, uint objData, string text)
+        {
+            SlotIndex = slotIndex;
+            Type = type;
+            ObjId = objId;
+            ObjType = objType;
+            ObjIndex = objIndex;
+            UserId = userId;
+            ObjData = objData;
+            Text = text;
+        }
+
+        public override bool CheckArguments()
+        {
+            return SlotIndex >= 0 && SlotIndex < TaskbarSystem.MaxTaskbarApplets;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarShortcutEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/AddTaskbarShortcutEventArgs.cs
@@ -12,7 +12,7 @@ namespace Rhisis.World.Systems.Taskbar.EventArgs
 
         public uint ObjId { get; }
 
-        public ShortcutObjType ObjType { get; }
+        public ShortcutObjectType ObjectType { get; }
 
         public uint ObjIndex { get; }
 
@@ -22,12 +22,12 @@ namespace Rhisis.World.Systems.Taskbar.EventArgs
 
         public string Text { get; }
 
-        public AddTaskbarAppletEventArgs(int slotIndex, ShortcutType type, uint objId, ShortcutObjType objType, uint objIndex, uint userId, uint objData, string text)
+        public AddTaskbarAppletEventArgs(int slotIndex, ShortcutType type, uint objId, ShortcutObjectType objectType, uint objIndex, uint userId, uint objData, string text)
         {
             SlotIndex = slotIndex;
             Type = type;
             ObjId = objId;
-            ObjType = objType;
+            ObjectType = objectType;
             ObjIndex = objIndex;
             UserId = userId;
             ObjData = objData;

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/RemoveTaskbarAppletEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/RemoveTaskbarAppletEventArgs.cs
@@ -1,0 +1,19 @@
+﻿using Rhisis.World.Game.Core.Systems;
+
+namespace Rhisis.World.Systems.Taskbar.EventArgs
+{
+    public class RemoveTaskbarAppletEventArgs : SystemEventArgs
+    {
+        public int SlotIndex { get; }
+
+        public RemoveTaskbarAppletEventArgs(int slotIndex)
+        {
+            SlotIndex = slotIndex;
+        }
+
+        public override bool CheckArguments()
+        {
+            return SlotIndex >= 0 && SlotIndex < TaskbarSystem.MaxTaskbarApplets;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/RemoveTaskbarItemEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/RemoveTaskbarItemEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using Rhisis.World.Game.Core.Systems;
+
+namespace Rhisis.World.Systems.Taskbar.EventArgs
+{
+    public class RemoveTaskbarItemEventArgs : SystemEventArgs
+    {
+        public int SlotLevelIndex { get; }
+
+        public int SlotIndex { get; }
+
+        public RemoveTaskbarItemEventArgs(int slotLevelIndex, int slotIndex)
+        {
+            SlotLevelIndex = slotLevelIndex;
+            SlotIndex = slotIndex;
+        }
+
+        public override bool CheckArguments()
+        {
+            return SlotIndex >= 0 && SlotIndex < TaskbarSystem.MaxTaskbarItems && SlotLevelIndex >= 0 && SlotLevelIndex < TaskbarSystem.MaxTaskbarItemLevels;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/EventArgs/TaskbarSkillEventArgs.cs
+++ b/src/Rhisis.World/Systems/Taskbar/EventArgs/TaskbarSkillEventArgs.cs
@@ -1,0 +1,22 @@
+﻿using Rhisis.Core.Common.Game.Structures;
+using Rhisis.World.Game.Core.Systems;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.World.Systems.Taskbar.EventArgs
+{
+    public class TaskbarSkillEventArgs : SystemEventArgs
+    {
+        public List<Shortcut> Skills { get; }
+
+        public TaskbarSkillEventArgs(List<Shortcut> skills)
+        {
+            Skills = skills;
+        }
+
+        public override bool CheckArguments()
+        {
+            return Skills != null && !Skills.Any(x => x.SlotIndex >= TaskbarSystem.MaxTaskbarQueue);
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
+++ b/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.Common;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Taskbar.EventArgs;
+using System;
+
+namespace Rhisis.World.Systems.Taskbar
+{
+    [System(SystemType.Notifiable)]
+    public class TaskbarSystem : ISystem
+    {
+        private static ILogger Logger => DependencyContainer.Instance.Resolve<ILogger<TaskbarSystem>>();
+
+        public const int MaxTaskbarApplets = 18;
+        public const int MaxTaskbarItems = 9;
+        public const int MaxTaskbarItemLevels = 8;
+        public const int MaxTaskbarQueue = 5;
+
+        public WorldEntityType Type => WorldEntityType.Player;
+
+        public void Execute(IEntity entity, SystemEventArgs args)
+        {
+            if (!(entity is IPlayerEntity player))
+                return;
+
+            if (!args.CheckArguments())
+            {
+                Logger.LogWarning("Invalid arguments received.");
+                return;
+            }
+
+            switch (args)
+            {
+                case AddTaskbarAppletEventArgs e:
+                    HandleAddTaskbarApplet(player, e);
+                    break;
+                case RemoveTaskbarAppletEventArgs e:
+                    HandleRemoveTaskbarApplet(player, e);
+                    break;
+                case AddTaskbarItemEventArgs e:
+                    HandleAddTaskbarItem(player, e);
+                    break;
+                case RemoveTaskbarItemEventArgs e:
+                    HandleRemoveTaskbarItem(player, e);
+                    break;
+            }
+        }
+
+        private void HandleAddTaskbarApplet(IPlayerEntity player, AddTaskbarAppletEventArgs e)
+        {
+            player.Taskbar.Applets.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjType, e.ObjIndex, e.UserId, e.ObjData, e.Text));
+            Logger.LogDebug("Created Applet Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
+        }
+
+        private void HandleRemoveTaskbarApplet(IPlayerEntity player, RemoveTaskbarAppletEventArgs e)
+        {
+            player.Taskbar.Applets.RemoveShortcut(e.SlotIndex);
+            Logger.LogDebug("Removed Applet Shortcut on slot {0} of player {1}", e.SlotIndex, player.Object.Name);
+        }
+
+        private void HandleAddTaskbarItem(IPlayerEntity player, AddTaskbarItemEventArgs e)
+        {
+            player.Taskbar.Items.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjType, e.ObjIndex, e.UserId, e.ObjData, e.Text), e.SlotLevelIndex);
+            Logger.LogDebug("Created Item Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
+        }
+
+        private void HandleRemoveTaskbarItem(IPlayerEntity player, RemoveTaskbarItemEventArgs e)
+        {
+            player.Taskbar.Items.RemoveShortcut(e.SlotLevelIndex, e.SlotIndex);
+            Logger.LogDebug("Removed Item Shortcut on slot {0}-{1} of player {2}", e.SlotLevelIndex, e.SlotIndex, player.Object.Name);
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
+++ b/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
@@ -1,10 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhisis.Core.Common;
+using Rhisis.Core.Common.Game.Structures;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
-using Rhisis.World.Game.Structures;
 using Rhisis.World.Systems.Taskbar.EventArgs;
 using System;
 
@@ -47,6 +47,9 @@ namespace Rhisis.World.Systems.Taskbar
                 case RemoveTaskbarItemEventArgs e:
                     HandleRemoveTaskbarItem(player, e);
                     break;
+                case TaskbarSkillEventArgs e:
+                    HandleTaskbarSkill(player, e);
+                    break;
             }
         }
 
@@ -72,6 +75,13 @@ namespace Rhisis.World.Systems.Taskbar
         {
             player.Taskbar.Items.RemoveShortcut(e.SlotLevelIndex, e.SlotIndex);
             Logger.LogDebug("Removed Item Shortcut on slot {0}-{1} of player {2}", e.SlotLevelIndex, e.SlotIndex, player.Object.Name);
+        }
+
+        private void HandleTaskbarSkill(IPlayerEntity player, TaskbarSkillEventArgs e)
+        {
+            player.Taskbar.Queue.ClearQueue();
+            player.Taskbar.Queue.CreateShortcuts(e.Skills);
+            Logger.LogDebug("Handled Actionslot Shortcuts of player {0}", player.Object.Name);
         }
     }
 }

--- a/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
+++ b/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
@@ -55,7 +55,7 @@ namespace Rhisis.World.Systems.Taskbar
 
         private void HandleAddTaskbarApplet(IPlayerEntity player, AddTaskbarAppletEventArgs e)
         {
-            player.Taskbar.Applets.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjType, e.ObjIndex, e.UserId, e.ObjData, e.Text));
+            player.Taskbar.Applets.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjectType, e.ObjIndex, e.UserId, e.ObjData, e.Text));
             Logger.LogDebug("Created Applet Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
         }
 
@@ -67,7 +67,7 @@ namespace Rhisis.World.Systems.Taskbar
 
         private void HandleAddTaskbarItem(IPlayerEntity player, AddTaskbarItemEventArgs e)
         {
-            player.Taskbar.Items.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjType, e.ObjIndex, e.UserId, e.ObjData, e.Text), e.SlotLevelIndex);
+            player.Taskbar.Items.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjectType, e.ObjIndex, e.UserId, e.ObjData, e.Text), e.SlotLevelIndex);
             Logger.LogDebug("Created Item Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
         }
 

--- a/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
+++ b/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
@@ -36,48 +36,48 @@ namespace Rhisis.World.Systems.Taskbar
             switch (args)
             {
                 case AddTaskbarAppletEventArgs e:
-                    HandleAddTaskbarApplet(player, e);
+                    HandleAddAppletTaskbarShortcut(player, e);
                     break;
                 case RemoveTaskbarAppletEventArgs e:
-                    HandleRemoveTaskbarApplet(player, e);
+                    HandleRemoveAppletTaskbarShortcut(player, e);
                     break;
                 case AddTaskbarItemEventArgs e:
-                    HandleAddTaskbarItem(player, e);
+                    HandleAddItemTaskbarShortcut(player, e);
                     break;
                 case RemoveTaskbarItemEventArgs e:
-                    HandleRemoveTaskbarItem(player, e);
+                    HandleRemoveItemTaskbarShortcut(player, e);
                     break;
                 case TaskbarSkillEventArgs e:
-                    HandleTaskbarSkill(player, e);
+                    HandleActionSlot(player, e);
                     break;
             }
         }
 
-        private void HandleAddTaskbarApplet(IPlayerEntity player, AddTaskbarAppletEventArgs e)
+        private void HandleAddAppletTaskbarShortcut(IPlayerEntity player, AddTaskbarAppletEventArgs e)
         {
             player.Taskbar.Applets.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjectType, e.ObjIndex, e.UserId, e.ObjData, e.Text));
-            Logger.LogDebug("Created Applet Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
+            Logger.LogDebug("Created Shortcut of type {0} on slot {1} for player {2} on the Applet Taskbar", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
         }
 
-        private void HandleRemoveTaskbarApplet(IPlayerEntity player, RemoveTaskbarAppletEventArgs e)
+        private void HandleRemoveAppletTaskbarShortcut(IPlayerEntity player, RemoveTaskbarAppletEventArgs e)
         {
             player.Taskbar.Applets.RemoveShortcut(e.SlotIndex);
-            Logger.LogDebug("Removed Applet Shortcut on slot {0} of player {1}", e.SlotIndex, player.Object.Name);
+            Logger.LogDebug("Removed Shortcut on slot {0} of player {1} on the Applet Taskbar", e.SlotIndex, player.Object.Name);
         }
 
-        private void HandleAddTaskbarItem(IPlayerEntity player, AddTaskbarItemEventArgs e)
+        private void HandleAddItemTaskbarShortcut(IPlayerEntity player, AddTaskbarItemEventArgs e)
         {
             player.Taskbar.Items.CreateShortcut(new Shortcut(e.SlotIndex, e.Type, e.ObjId, e.ObjectType, e.ObjIndex, e.UserId, e.ObjData, e.Text), e.SlotLevelIndex);
-            Logger.LogDebug("Created Item Shortcut of type {0} on slot {1} for player {2}", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
+            Logger.LogDebug("Created Shortcut of type {0} on slot {1} for player {2} on the Item Taskbar", Enum.GetName(typeof(ShortcutType), e.Type), e.SlotIndex, player.Object.Name);
         }
 
-        private void HandleRemoveTaskbarItem(IPlayerEntity player, RemoveTaskbarItemEventArgs e)
+        private void HandleRemoveItemTaskbarShortcut(IPlayerEntity player, RemoveTaskbarItemEventArgs e)
         {
             player.Taskbar.Items.RemoveShortcut(e.SlotLevelIndex, e.SlotIndex);
-            Logger.LogDebug("Removed Item Shortcut on slot {0}-{1} of player {2}", e.SlotLevelIndex, e.SlotIndex, player.Object.Name);
+            Logger.LogDebug("Removed Shortcut on slot {0}-{1} of player {2} on the Item Taskbar", e.SlotLevelIndex, e.SlotIndex, player.Object.Name);
         }
 
-        private void HandleTaskbarSkill(IPlayerEntity player, TaskbarSkillEventArgs e)
+        private void HandleActionSlot(IPlayerEntity player, TaskbarSkillEventArgs e)
         {
             player.Taskbar.Queue.ClearQueue();
             player.Taskbar.Queue.CreateShortcuts(e.Skills);

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -233,13 +233,13 @@ namespace Rhisis.World
                         }
                     }
 
-                    //foreach (var queueItem in Player.Taskbar.Queue.Shortcuts)
-                    //{
-                    //    if (queueItem == null)
-                    //        continue;
+                    foreach (var queueItem in Player.Taskbar.Queue.Shortcuts)
+                    {
+                        if (queueItem == null)
+                            continue;
 
-                    //    character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Queue, queueItem.SlotIndex, queueItem.Type, queueItem.ObjId, queueItem.ObjectType, queueItem.ObjIndex, queueItem.UserId, queueItem.ObjData, queueItem.Text));
-                    //}
+                        character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Queue, queueItem.SlotIndex, queueItem.Type, queueItem.ObjId, queueItem.ObjectType, queueItem.ObjIndex, queueItem.UserId, queueItem.ObjData, queueItem.Text));
+                    }
                 }
 
                 database.Complete();

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -1,6 +1,7 @@
 ﻿using Ether.Network.Common;
 using Ether.Network.Packets;
 using NLog;
+using Rhisis.Core.Common;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Exceptions;
 using Rhisis.Core.Helpers;
@@ -190,6 +191,37 @@ namespace Rhisis.World
 
                             database.Items.Create(dbItem);
                         }
+                    }
+
+                    // Taskbar
+                    character.TaskbarShortcuts.Clear();
+
+                    foreach (var applet in Player.Taskbar.Applets.Shortcuts)
+                    {
+                        if (applet == null)
+                            continue;
+
+                        character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Applet, applet.SlotIndex, applet.Type, applet.ObjId, applet.ObjectType, applet.ObjIndex, applet.UserId, applet.ObjData, applet.Text));
+                    }
+
+                    for(int slotLevel = 0; slotLevel < Player.Taskbar.Items.Shortcuts.Count; slotLevel++)
+                    {
+                        for (int slot = 0; slot < Player.Taskbar.Items.Shortcuts[slotLevel].Count; slot++)
+                        {
+                            var item = Player.Taskbar.Items.Shortcuts[slotLevel][slot];
+                            if (item == null)
+                                continue;
+
+                            character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Item, slotLevel, slot, item.Type, item.ObjId, item.ObjectType, item.ObjIndex, item.UserId, item.ObjData, item.Text));
+                        }
+                    }
+
+                    foreach (var queueItem in Player.Taskbar.Queue.Shortcuts)
+                    {
+                        if (queueItem == null)
+                            continue;
+
+                        character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Queue, queueItem.SlotIndex, queueItem.Type, queueItem.ObjId, queueItem.ObjectType, queueItem.ObjIndex, queueItem.UserId, queueItem.ObjData, queueItem.Text));
                     }
                 }
 

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -195,34 +195,51 @@ namespace Rhisis.World
 
                     // Taskbar
                     character.TaskbarShortcuts.Clear();
-
+                    
                     foreach (var applet in Player.Taskbar.Applets.Shortcuts)
                     {
                         if (applet == null)
                             continue;
 
-                        character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Applet, applet.SlotIndex, applet.Type, applet.ObjId, applet.ObjectType, applet.ObjIndex, applet.UserId, applet.ObjData, applet.Text));
+                        var dbApplet = new DbShortcut(ShortcutTaskbarTarget.Applet, applet.SlotIndex, applet.Type, applet.ObjId, applet.ObjectType, applet.ObjIndex, applet.UserId, applet.ObjData, applet.Text);
+
+                        if (applet.Type == ShortcutType.Item)
+                        {
+                            var item = this.Player.Inventory.GetItem((int)applet.ObjId);
+                            dbApplet.ObjectId = (uint)item.Slot;
+                        }
+
+                        character.TaskbarShortcuts.Add(dbApplet);
                     }
 
-                    for(int slotLevel = 0; slotLevel < Player.Taskbar.Items.Shortcuts.Count; slotLevel++)
+
+                    for (int slotLevel = 0; slotLevel < Player.Taskbar.Items.Shortcuts.Count; slotLevel++)
                     {
                         for (int slot = 0; slot < Player.Taskbar.Items.Shortcuts[slotLevel].Count; slot++)
                         {
-                            var item = Player.Taskbar.Items.Shortcuts[slotLevel][slot];
-                            if (item == null)
+                            var itemShortcut = Player.Taskbar.Items.Shortcuts[slotLevel][slot];
+                            if (itemShortcut == null)
                                 continue;
 
-                            character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Item, slotLevel, slot, item.Type, item.ObjId, item.ObjectType, item.ObjIndex, item.UserId, item.ObjData, item.Text));
+                            var dbItem = new DbShortcut(ShortcutTaskbarTarget.Item, slotLevel, itemShortcut.SlotIndex, itemShortcut.Type, itemShortcut.ObjId, itemShortcut.ObjectType, itemShortcut.ObjIndex, itemShortcut.UserId, itemShortcut.ObjData, itemShortcut.Text);
+
+                            if (itemShortcut.Type == ShortcutType.Item)
+                            {
+                                var item = this.Player.Inventory.GetItem((int)itemShortcut.ObjId);
+                                dbItem.ObjectId = (uint)item.Slot;
+                            }
+
+                            character.TaskbarShortcuts.Add(dbItem);
                         }
                     }
 
-                    foreach (var queueItem in Player.Taskbar.Queue.Shortcuts)
-                    {
-                        if (queueItem == null)
-                            continue;
+                    //foreach (var queueItem in Player.Taskbar.Queue.Shortcuts)
+                    //{
+                    //    if (queueItem == null)
+                    //        continue;
 
-                        character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Queue, queueItem.SlotIndex, queueItem.Type, queueItem.ObjId, queueItem.ObjectType, queueItem.ObjIndex, queueItem.UserId, queueItem.ObjData, queueItem.Text));
-                    }
+                    //    character.TaskbarShortcuts.Add(new DbShortcut(ShortcutTaskbarTarget.Queue, queueItem.SlotIndex, queueItem.Type, queueItem.ObjId, queueItem.ObjectType, queueItem.ObjIndex, queueItem.UserId, queueItem.ObjData, queueItem.Text));
+                    //}
                 }
 
                 database.Complete();


### PR DESCRIPTION
This PR adds the Taskbar System.
As of now (and what I am aware of) : The Taskbar System handles Shortcuts (i.e. Chat Scripts, Items, Skills) that are being dragged onto the Taskbar of the player. 

As of writing this, the left side of the taskbar (which is called the Applet Bar) and the middle (which is called the Item Bar) are implemented for communication with the game client. Adding Shortcuts and Removing Shortcuts are working. However, they are not yet saved to the database which is the next step as for the right side (called the Actionslot) I first need to be able to put skills in there to (not implement) but test it. (It's not yet implemented).

The Taskbar System is not yet finished so I dont want it to be merged as it would not make sense anyways at this state.

However feedback n' stuff is greatly appreciated and requested.

Oh and btw: Documentation will be added as the last commit if the system is finished.