### PR TITLE
Reduce CPU usage while invoking a packet

### DIFF
--- a/src/Rhisis.Login/LoginClient.cs
+++ b/src/Rhisis.Login/LoginClient.cs
@@ -86,14 +86,15 @@ namespace Rhisis.Login
 
                 this._logger.LogTrace("Received {0} packet from {1}.", (PacketType)packetHeaderNumber, this.RemoteEndPoint);
 
-                PacketHandler<LoginClient>.Invoke(this, packet, (PacketType)packetHeaderNumber);
-            }
-            catch (KeyNotFoundException)
-            {
-                if (Enum.IsDefined(typeof(PacketType), packetHeaderNumber))
-                    this._logger.LogWarning("Received an unimplemented Login packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(PacketType), packetHeaderNumber), packetHeaderNumber.ToString("X2"), this.RemoteEndPoint);
-                else
-                    this._logger.LogWarning("Received an unknown Login packet 0x{0} from {1}.", packetHeaderNumber.ToString("X2"), this.RemoteEndPoint);
+                bool packetInvokSuccess = PacketHandler<LoginClient>.Invoke(this, packet, (PacketType)packetHeaderNumber);
+
+                if (!packetInvokSuccess)
+                {
+                    if (Enum.IsDefined(typeof(PacketType), packetHeaderNumber))
+                        this._logger.LogWarning("Received an unimplemented Login packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(PacketType), packetHeaderNumber), packetHeaderNumber.ToString("X2"), this.RemoteEndPoint);
+                    else
+                        this._logger.LogWarning("Received an unknown Login packet 0x{0} from {1}.", packetHeaderNumber.ToString("X2"), this.RemoteEndPoint);
+                }
             }
             catch (RhisisPacketException packetException)
             {

--- a/src/Rhisis.Network/PacketHandlers.cs
+++ b/src/Rhisis.Network/PacketHandlers.cs
@@ -58,19 +58,21 @@ namespace Rhisis.Network
             }
         }
 
-        public static void Invoke(T invoker, INetPacketStream packet, object packetHeader)
+        public static bool Invoke(T invoker, INetPacketStream packet, object packetHeader)
         {
-            if (!Handlers.ContainsKey(packetHeader))
-                throw new KeyNotFoundException();
+            if (!Handlers.TryGetValue(packetHeader, out Action<T, INetPacketStream> packetHandler))
+                return false;
 
             try
             {
-                Handlers[packetHeader].Invoke(invoker, packet);
+                packetHandler.Invoke(invoker, packet);
             }
             catch (Exception e)
             {
                 throw new RhisisPacketException($"An error occured during the execution of packet handler: {packetHeader}", e);
             }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This PR changes the way unhandled packet are processed. Instead of throwing an exception, we return a simple boolean if the packet isn't handled.

This reduces CPU usage when a lot of unhandled packets are received.