### PR TITLE
Fixed monster AI when a player is attacking a monster

### DIFF
--- a/src/Rhisis.World/Game/Behaviors/DefaultMonsterBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/DefaultMonsterBehavior.cs
@@ -13,14 +13,14 @@ namespace Rhisis.World.Game.Behaviors
     [Behavior(BehaviorType.Monster, IsDefault: true)]
     public class DefaultMonsterBehavior : IBehavior<IMonsterEntity>
     {
-        private const float MovingRange = 30f;
+        private const float MovingRange = 40f;
 
         /// <inheritdoc />
         public virtual void Update(IMonsterEntity entity)
         {
             this.UpdateArivalState(entity);
 
-            if (!entity.Follow.IsFollowing)
+            if (!entity.Follow.IsFollowing && !entity.Battle.IsFighting)
                 this.UpdateMoves(entity);
             else
                 this.Follow(entity);
@@ -34,7 +34,7 @@ namespace Rhisis.World.Game.Behaviors
         /// <param name="monster"></param>
         private void UpdateMoves(IMonsterEntity monster)
         {
-            if (monster.Timers.LastMoveTimer <= Time.TimeInSeconds() && monster.MovableComponent.HasArrived && !monster.Follow.IsFollowing)
+            if (monster.Timers.NextMoveTime <= Time.TimeInSeconds() && monster.MovableComponent.HasArrived)
             {
                 this.MoveToPosition(monster, monster.Region.GetRandomPosition());
             }
@@ -94,7 +94,7 @@ namespace Rhisis.World.Game.Behaviors
         /// <param name="destPosition"></param>
         private void MoveToPosition(IMonsterEntity monster, Vector3 destPosition)
         {
-            monster.Timers.LastMoveTimer = Time.TimeInSeconds() + RandomHelper.LongRandom(8, 20);
+            monster.Timers.NextMoveTime = Time.TimeInSeconds() + RandomHelper.LongRandom(8, 20);
             monster.MovableComponent.DestinationPosition = destPosition.Clone();
             monster.Object.Angle = Vector3.AngleBetween(monster.Object.Position, destPosition);
 
@@ -103,7 +103,10 @@ namespace Rhisis.World.Game.Behaviors
 
         private void Fight(IMonsterEntity monster)
         {
-            // TODO
+            if (!monster.Battle.IsFighting)
+                return;
+
+
         }
     }
 }

--- a/src/Rhisis.World/Game/Components/MovableComponent.cs
+++ b/src/Rhisis.World/Game/Components/MovableComponent.cs
@@ -13,7 +13,7 @@ namespace Rhisis.World.Game.Components
 
         public Vector3 DestinationPosition { get; set; }
 
-        public bool HasArrived => this.DestinationPosition.IsZero();
+        public bool HasArrived { get; set; }
 
         public float Speed { get; set; }
 

--- a/src/Rhisis.World/Game/Components/TimerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TimerComponent.cs
@@ -2,7 +2,7 @@
 {
     public class TimerComponent
     {
-        public long LastMoveTimer { get; set; }
+        public long NextMoveTime { get; set; }
 
         public long DespawnTime { get; set; }
 

--- a/src/Rhisis.World/Game/Maps/MapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/MapInstance.cs
@@ -150,7 +150,7 @@ namespace Rhisis.World.Game.Maps
         {
             Task.Run(async () =>
             {
-                const double FrameRatePerSeconds = 0.6f;
+                const double FrameRatePerSeconds = 0.66666f;
                 double previousTime = 0;
                 
                 while (true)

--- a/src/Rhisis.World/Game/Maps/MapLayer.cs
+++ b/src/Rhisis.World/Game/Maps/MapLayer.cs
@@ -121,7 +121,7 @@ namespace Rhisis.World.Game.Maps
             };
             monster.Timers = new TimerComponent
             {
-                LastMoveTimer = RandomHelper.LongRandom(8, 20)
+                NextMoveTime = RandomHelper.LongRandom(8, 20)
             };
             monster.MovableComponent = new MovableComponent
             {

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -1,4 +1,5 @@
-﻿using NLog;
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.IO;
 using Rhisis.World.Game.Common;
 using Rhisis.World.Game.Core;
@@ -11,7 +12,7 @@ namespace Rhisis.World.Systems.Battle
     [System(SystemType.Notifiable)]
     public class BattleSystem : ISystem
     {
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
+        private static readonly ILogger<BattleSystem> Logger = DependencyContainer.Instance.Resolve<ILogger<BattleSystem>>();
 
         /// <inheritdoc />
         public WorldEntityType Type => WorldEntityType.Player | WorldEntityType.Monster;
@@ -21,13 +22,13 @@ namespace Rhisis.World.Systems.Battle
         {
             if (!args.CheckArguments())
             {
-                Logger.Error("Cannot execute battle action: {0} due to invalid arguments.", args.GetType());
+                Logger.LogError("Cannot execute battle action: {0} due to invalid arguments.", args.GetType());
                 return;
             }
 
             if (!(entity is ILivingEntity livingEntity))
             {
-                Logger.Error($"The non living entity {entity.Object.Name} tried to execute a battle action.");
+                Logger.LogError($"The non living entity {entity.Object.Name} tried to execute a battle action.");
                 return;
             }
 
@@ -50,13 +51,18 @@ namespace Rhisis.World.Systems.Battle
 
             if (defender.Health.IsDead)
             {
-                Logger.Error($"{attacker.Object.Name} cannot attack {defender.Object.Name} because target is already dead.");
+                Logger.LogError($"{attacker.Object.Name} cannot attack {defender.Object.Name} because target is already dead.");
+                this.ClearBattleTargets(defender);
+                this.ClearBattleTargets(attacker);
                 return;
             }
 
+            attacker.Battle.Target = defender;
+            defender.Battle.Target = attacker;
+
             AttackResult meleeAttackResult = new MeleeAttackArbiter(attacker, defender).OnDamage();
 
-            Logger.Debug($"{attacker.Object.Name} inflicted {meleeAttackResult.Damages} to {defender.Object.Name}");
+            Logger.LogDebug($"{attacker.Object.Name} inflicted {meleeAttackResult.Damages} to {defender.Object.Name}");
 
             if (!(attacker is IPlayerEntity player))
                 return;
@@ -70,14 +76,10 @@ namespace Rhisis.World.Systems.Battle
 
             if (defender.Health.IsDead)
             {
-                Logger.Debug($"{attacker.Object.Name} killed {defender.Object.Name}.");
+                Logger.LogDebug($"{attacker.Object.Name} killed {defender.Object.Name}.");
                 defender.Health.Hp = 0;
-                defender.Follow.Target = null;
-                defender.Battle.Target = null;
-                defender.Battle.Targets.Clear();
-                attacker.Follow.Target = null;
-                attacker.Battle.Target = null;
-                attacker.Battle.Targets.Clear();
+                this.ClearBattleTargets(defender);
+                this.ClearBattleTargets(attacker);
                 WorldPacketFactory.SendDie(player, defender, attacker, e.AttackType);
 
                 if (defender is IMonsterEntity deadMonster)
@@ -86,6 +88,13 @@ namespace Rhisis.World.Systems.Battle
                     // TODO: give exp and drop items.
                 }
             }
+        }
+
+        private void ClearBattleTargets(ILivingEntity entity)
+        {
+            entity.Follow.Target = null;
+            entity.Battle.Target = null;
+            entity.Battle.Targets.Clear();
         }
     }
 }

--- a/src/Rhisis.World/Systems/Follow/FollowSystem.cs
+++ b/src/Rhisis.World/Systems/Follow/FollowSystem.cs
@@ -50,7 +50,7 @@ namespace Rhisis.World.Systems.Follow
 
             if (entity is IMonsterEntity monster)
             {
-                monster.Timers.LastMoveTimer = Time.TimeInSeconds() + 5;
+                monster.Timers.NextMoveTime = Time.TimeInSeconds() + 5;
             }
 
             WorldPacketFactory.SendFollowTarget(entity, entityToFollow, e.Distance);

--- a/src/Rhisis.World/Systems/MobilitySystem.cs
+++ b/src/Rhisis.World/Systems/MobilitySystem.cs
@@ -36,10 +36,12 @@ namespace Rhisis.World.Systems
         {
             if (entity.MovableComponent.DestinationPosition.IsInCircle(entity.Object.Position, 0.1f))
             {
-                entity.MovableComponent.DestinationPosition.Reset();
+                entity.MovableComponent.HasArrived = true;
+                entity.MovableComponent.DestinationPosition = entity.Object.Position.Clone();
             }
             else
             {
+                entity.MovableComponent.HasArrived = false;
                 double entitySpeed = entity.MovableComponent.Speed * entity.MovableComponent.SpeedFactor;
                 double speed = ((entitySpeed * 100f) * entity.Context.GameTime);
                 float distanceX = entity.MovableComponent.DestinationPosition.X - entity.Object.Position.X;

--- a/src/Rhisis.World/Systems/RespawnSystem.cs
+++ b/src/Rhisis.World/Systems/RespawnSystem.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Helpers;
 using Rhisis.Core.IO;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
@@ -28,17 +29,19 @@ namespace Rhisis.World.Systems
                 {
                     Logger.LogDebug($"Respawning {monster.Object.Name}...");
                     this.ResetMonster(monster);
-                    monster.Object.Spawned = true;
                 }
             }
         }
 
         private void ResetMonster(IMonsterEntity monster)
         {
-            monster.Health.Hp = monster.Data.AddHp;
-            monster.Health.Mp = monster.Data.AddMp;
+            monster.Timers.NextMoveTime = Time.TimeInSeconds() + RandomHelper.LongRandom(5, 15);
+            monster.Object.Spawned = true;
             monster.Object.Position = monster.Region.GetRandomPosition();
             monster.MovableComponent.DestinationPosition = monster.Object.Position.Clone();
+            monster.MovableComponent.SpeedFactor = 1;
+            monster.Health.Hp = monster.Data.AddHp;
+            monster.Health.Mp = monster.Data.AddMp;
         }
     }
 }


### PR DESCRIPTION
This PR fixes the monster's AI. There was a problem that when a player attacks a monster, sometimes, the monsters runs back to it's original position or was going to position (0,0,0) when knocked-back. This was due to the reset of the `DestinationPosition`.