### PR TITLE
Add server controller and server status route

### DIFF
--- a/src/Rhisis.API/Controllers/ServerController.cs
+++ b/src/Rhisis.API/Controllers/ServerController.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Rhisis.Core.Structures.Configuration;
+using System;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace Rhisis.API.Controllers
+{
+    /// <summary>
+    /// Provides API routes to manage the server.
+    /// </summary>
+    [Route("api/[controller]")]
+    public class ServerController : ControllerBase
+    {
+        private readonly ILogger<ServerController> _logger;
+        private readonly IConfiguration _configuration;
+
+        /// <summary>
+        /// Creates a new <see cref="ServerController"/> instance.
+        /// </summary>
+        /// <param name="logger">Logger</param>
+        /// <param name="configuration">Configuration</param>
+        public ServerController(ILogger<ServerController> logger, IConfiguration configuration)
+        {
+            this._logger = logger;
+            this._configuration = configuration;
+        }
+
+        /// <summary>
+        /// Gets the world sever's status.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet("world/status")]
+        public IActionResult GetWorldServerStatus()
+        {
+            bool worldServerConnected = false;
+
+            try
+            {
+                var worldServerConfguration = this._configuration.GetSection("WorldServer").Get<BaseConfiguration>();
+
+                using (var client = new TcpClient(worldServerConfguration.Host, worldServerConfguration.Port))
+                    worldServerConnected = true;
+            }
+            catch (Exception e)
+            {
+                this._logger.LogError(e, "An error occured while reaching for world server.");
+                worldServerConnected = false;
+            }
+
+            return Ok(worldServerConnected);
+        }
+    }
+}

--- a/src/Rhisis.API/Controllers/UserController.cs
+++ b/src/Rhisis.API/Controllers/UserController.cs
@@ -53,11 +53,8 @@ namespace Rhisis.API.Controllers
             this._logger.LogInformation($"An unknown user want to check if user '{username}' exists.");
 
             bool exists = this._userService.HasUser(username);
-
-            if (!exists)
-                return NotFound();
-
-            return Ok();
+            
+            return Ok(exists);
         }
     }
 }

--- a/src/Rhisis.API/Startup.cs
+++ b/src/Rhisis.API/Startup.cs
@@ -27,6 +27,13 @@ namespace Rhisis.API
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddCors(options =>
+            {
+                options.AddPolicy("DevAllowAllOrigins", policy =>
+                {
+                    policy.AllowAnyHeader().AllowAnyOrigin().AllowAnyMethod();
+                });
+            });
             services.AddMvc();
 
             var databaseConfiguration = this.Configuration.GetSection(nameof(DatabaseConfiguration)).Get<DatabaseConfiguration>();
@@ -34,6 +41,7 @@ namespace Rhisis.API
             DependencyContainer.Instance.SetServiceCollection(services);
             DatabaseFactory.Instance.Initialize(databaseConfiguration);
             BusinessLayer.Initialize();
+            services.AddSingleton(this.Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -42,6 +50,7 @@ namespace Rhisis.API
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseCors("DevAllowAllOrigins");
             }
 
             app.UseMvc();

--- a/src/Rhisis.API/appsettings.json
+++ b/src/Rhisis.API/appsettings.json
@@ -16,5 +16,9 @@
     "Database": "rhisis",
     "Port": 3306,
     "Provider": 1
+  },
+  "WorldServer": {
+    "Host": "127.0.0.1",
+    "Port": 5400
   }
 }


### PR DESCRIPTION
This PR adds an API route (`/api/server/world/status`) to get the world server status. This API route will be used on the official rhisis web site to indicate the test server status.