### PR TITLE
#114 Prevent users to login with an account already connected

### DIFF
--- a/src/Rhisis.Login/ILoginServer.cs
+++ b/src/Rhisis.Login/ILoginServer.cs
@@ -11,5 +11,19 @@ namespace Rhisis.Login
         /// </summary>
         /// <returns>Collection of <see cref="ClusterServerInfo"/></returns>
         IEnumerable<ClusterServerInfo> GetConnectedClusters();
+
+        /// <summary>
+        /// Gets a connected client by his username.
+        /// </summary>
+        /// <param name="username">Client username</param>
+        /// <returns></returns>
+        LoginClient GetClientByUsername(string username);
+
+        /// <summary>
+        /// Verify if a client is connected to the login server.
+        /// </summary>
+        /// <param name="username">Client username</param>
+        /// <returns></returns>
+        bool IsClientConnected(string username);
     }
 }

--- a/src/Rhisis.Login/LoginClient.cs
+++ b/src/Rhisis.Login/LoginClient.cs
@@ -32,6 +32,11 @@ namespace Rhisis.Login
         public string RemoteEndPoint => this.Socket.RemoteEndPoint.ToString();
 
         /// <summary>
+        /// Check if the client is connected.
+        /// </summary>
+        public bool IsConnected => !string.IsNullOrEmpty(this.Username);
+
+        /// <summary>
         /// Creates a new <see cref="LoginClient"/> instance.
         /// </summary>
         public LoginClient()

--- a/src/Rhisis.Login/LoginServer.cs
+++ b/src/Rhisis.Login/LoginServer.cs
@@ -8,6 +8,7 @@ using Rhisis.Network.ISC.Structures;
 using Rhisis.Network.Packets;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Rhisis.Login
 {
@@ -100,5 +101,14 @@ namespace Rhisis.Login
 
         /// <inheritdoc />
         public IEnumerable<ClusterServerInfo> GetConnectedClusters() => InterServer?.ClusterServers;
+
+        /// <inheritdoc />
+        public LoginClient GetClientByUsername(string username)
+            => this.Clients.FirstOrDefault(x =>
+                x.IsConnected &&
+                x.Username.Equals(username, StringComparison.OrdinalIgnoreCase));
+
+        /// <inheritdoc />
+        public bool IsClientConnected(string username) => this.GetClientByUsername(username) != null;
     }
 }

--- a/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
+++ b/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
@@ -1,0 +1,22 @@
+﻿using Ether.Network.Packets;
+using System;
+
+namespace Rhisis.Network.Packets.Login
+{
+    public struct CloseConnectionPacket : IEquatable<CloseConnectionPacket>
+    {
+        public string Username { get; }
+
+        public string Password { get; }
+
+        public CloseConnectionPacket(INetPacketStream packet)
+        {
+            this.Username = packet.Read<string>();
+            this.Password = packet.Read<string>();
+        }
+
+        public bool Equals(CloseConnectionPacket other) =>
+            this.Username.Equals(other.Username, StringComparison.OrdinalIgnoreCase) &&
+            this.Password.Equals(other.Password, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
This PR fixes halfway issue #114. It prevents users to login with an account already connected, but when the `CLOSE_EXISTING_CONNECTION` packet handler is invoked, the LoginServer doesn't disconnects the player.

What should be done now, is disconnect the player on the cluster and world server using the ISC. This part will be done at the same time we rework the the ISC (#167)