### PR TITLE
Add API route for server statistics

### DIFF
--- a/src/Rhisis.API/Controllers/ServerController.cs
+++ b/src/Rhisis.API/Controllers/ServerController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Rhisis.Core.Models;
+using Rhisis.Core.Services;
 using Rhisis.Core.Structures.Configuration;
 using System;
 using System.Net.NetworkInformation;
@@ -16,16 +18,19 @@ namespace Rhisis.API.Controllers
     {
         private readonly ILogger<ServerController> _logger;
         private readonly IConfiguration _configuration;
+        private readonly IStatisticsService _statisticsService;
 
         /// <summary>
         /// Creates a new <see cref="ServerController"/> instance.
         /// </summary>
         /// <param name="logger">Logger</param>
         /// <param name="configuration">Configuration</param>
-        public ServerController(ILogger<ServerController> logger, IConfiguration configuration)
+        /// <param name="statisticsService">Statistics service</param>
+        public ServerController(ILogger<ServerController> logger, IConfiguration configuration, IStatisticsService statisticsService)
         {
             this._logger = logger;
             this._configuration = configuration;
+            this._statisticsService = statisticsService;
         }
 
         /// <summary>
@@ -51,6 +56,19 @@ namespace Rhisis.API.Controllers
             }
 
             return Ok(worldServerConnected);
+        }
+
+        [HttpGet("stats")]
+        public IActionResult GetServerStatistics()
+        {
+            var serverStats = new ServerStatisticsModel
+            {
+                NumberOfUsers = this._statisticsService.GetRegisteredUsers(),
+                NumberOfCharacters = this._statisticsService.GetNumberOfCharacters(),
+                NumberOfPlayersOnline = 0 // TODO: make request to server
+            };
+
+            return Ok(serverStats);
         }
     }
 }

--- a/src/Rhisis.API/Controllers/UserController.cs
+++ b/src/Rhisis.API/Controllers/UserController.cs
@@ -72,5 +72,18 @@ namespace Rhisis.API.Controllers
 
             return Ok(emailExists);
         }
+
+        /// <summary>
+        /// Authenticates the user.
+        /// </summary>
+        /// <param name="userLogin">User login model</param>
+        /// <returns></returns>
+        [AllowAnonymous]
+        [HttpPost("auth")]
+        public IActionResult Authenticate([FromBody] UserLoginModel userLogin)
+        {
+            // TODO: authenticate user and generate JWT
+            return Ok();
+        }
     }
 }

--- a/src/Rhisis.Business/Services/StatisticsService.cs
+++ b/src/Rhisis.Business/Services/StatisticsService.cs
@@ -1,0 +1,34 @@
+﻿using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Services;
+using Rhisis.Database;
+using System;
+
+namespace Rhisis.Core.Business.Services
+{
+    [Injectable]
+    public class StatisticsService : IStatisticsService
+    {
+        private readonly IDatabase _database;
+        
+        /// <summary>
+        /// Creates a new <see cref="StatisticsService"/> instance.
+        /// </summary>
+        /// <param name="database"></param>
+        public StatisticsService(IDatabase database)
+        {
+            this._database = database;
+        }
+
+        /// <inheritdoc />
+        public int GetNumberOfCharacters() => this._database.Characters.Count();
+
+        /// <inheritdoc />
+        public int GetOnlinePlayers()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public int GetRegisteredUsers() => this._database.Users.Count();
+    }
+}

--- a/src/Rhisis.Core/Models/ServerStatisticsModel.cs
+++ b/src/Rhisis.Core/Models/ServerStatisticsModel.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Models
+{
+    [DataContract]
+    public class ServerStatisticsModel
+    {
+        /// <summary>
+        /// Gets the number of users.
+        /// </summary>
+        [DataMember]
+        public int NumberOfUsers { get; set; }
+
+        /// <summary>
+        /// Gets the number of characters.
+        /// </summary>
+        [DataMember]
+        public int NumberOfCharacters { get; set; }
+
+        /// <summary>
+        /// Gets the number of connected players.
+        /// </summary>
+        [DataMember]
+        public int NumberOfPlayersOnline { get; set; }
+    }
+}

--- a/src/Rhisis.Core/Services/IStatisticsService.cs
+++ b/src/Rhisis.Core/Services/IStatisticsService.cs
@@ -1,0 +1,23 @@
+﻿namespace Rhisis.Core.Services
+{
+    public interface IStatisticsService
+    {
+        /// <summary>
+        /// Gets the number of registered Users.
+        /// </summary>
+        /// <returns></returns>
+        int GetRegisteredUsers();
+
+        /// <summary>
+        /// Gets the number of characters.
+        /// </summary>
+        /// <returns></returns>
+        int GetNumberOfCharacters();
+
+        /// <summary>
+        /// Gets the number of online players.
+        /// </summary>
+        /// <returns></returns>
+        int GetOnlinePlayers();
+    }
+}

--- a/src/Rhisis.Database/Repositories/RepositoryBase.cs
+++ b/src/Rhisis.Database/Repositories/RepositoryBase.cs
@@ -70,10 +70,10 @@ namespace Rhisis.Database.Repositories
         public IEnumerable<T> GetAll(Func<T, bool> func) => this.GetQueryable(this._context).Where(func).AsEnumerable();
 
         /// <inheritdoc />
-        public int Count() => this.GetQueryable(this._context).Count();
+        public int Count() => this._context.Set<T>().AsNoTracking().Count();
 
         /// <inheritdoc />
-        public int Count(Func<T, bool> func) => this.GetQueryable(this._context).Count(func);
+        public int Count(Func<T, bool> func) => this._context.Set<T>().AsNoTracking().Count(func);
 
         /// <inheritdoc />
         public bool HasAny(Func<T, bool> predicate) => this._context.Set<T>().AsNoTracking().Any(predicate);


### PR DESCRIPTION
This PR adds an API route to get the server statistics, such as the number of registered accounts, number of characters and number of players online. It will be used for the test server website.