### PR TITLE
Add Rhisis-cli for linux users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ mono: none
 dist: xenial
 dotnet: 2.2
 
-env:
-  - DOTNET_CLI_TELEMETRY_OPTOUT=1
+matrix:
+  env:
+    - DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # Define the jobs
 jobs:

--- a/bin/rhisis-cli
+++ b/bin/rhisis-cli
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dotnet ./tools/Rhisis.CLI/netcoreapp2.2/Rhisis.CLI.dll


### PR DESCRIPTION
Add the `rhisis-cli` execution script for linux users.

To use it, first run the `chmod +x ./rhisis-cli`, then use it like: `./rhisis-cli [command]`