### PR TITLE
Update Rhisis CLI

### DIFF
--- a/bin/rhisis-cli
+++ b/bin/rhisis-cli
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet ./tools/Rhisis.CLI/netcoreapp2.2/Rhisis.CLI.dll
+dotnet ./tools/Rhisis.CLI/netcoreapp2.2/Rhisis.CLI.dll $*

--- a/src/Rhisis.CLI/Application.cs
+++ b/src/Rhisis.CLI/Application.cs
@@ -1,12 +1,16 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
 using Rhisis.CLI.Commands.Database;
+using Rhisis.CLI.Commands.User;
 
 namespace Rhisis.CLI
 {
     [Command(ThrowOnUnexpectedArgument = false, Description = Program.Description)]
     [Subcommand(typeof(DatabaseCommand))]
+    [Subcommand(typeof(UserCommand))]
     public class Application
     {
+        public const string DefaultDatabaseConfigurationFile = "config/database.json";
+
         public void OnExecute(CommandLineApplication app, IConsole console)
         {
             app.ShowHelp();

--- a/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
@@ -16,7 +16,7 @@ namespace Rhisis.CLI.Commands.Database
         public void OnExecute(CommandLineApplication app, IConsole console)
         {
             if (string.IsNullOrEmpty(DatabaseConfigurationFile))
-                DatabaseConfigurationFile = "config/database.json";
+                DatabaseConfigurationFile = Application.DefaultDatabaseConfigurationFile;
 
             var dbConfiguration = new DatabaseConfiguration()
             {

--- a/src/Rhisis.CLI/Commands/Database/DatabaseUpdateCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseUpdateCommand.cs
@@ -13,7 +13,7 @@ namespace Rhisis.CLI.Commands.Database
         public void OnExecute(CommandLineApplication app, IConsole console)
         {
             if (string.IsNullOrEmpty(DatabaseConfigurationFile))
-                DatabaseConfigurationFile = "config/database.json";
+                DatabaseConfigurationFile = Application.DefaultDatabaseConfigurationFile;
 
             try
             {

--- a/src/Rhisis.CLI/Commands/User/UserCommand.cs
+++ b/src/Rhisis.CLI/Commands/User/UserCommand.cs
@@ -1,0 +1,14 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+
+namespace Rhisis.CLI.Commands.User
+{
+    [Command("user", Description = "Manages the database users")]
+    [Subcommand(typeof(UserCreateCommand))]
+    public sealed class UserCommand
+    {
+        public void OnExecute(CommandLineApplication app, IConsole console)
+        {
+            app.ShowHelp();
+        }
+    }
+}

--- a/src/Rhisis.CLI/Commands/User/UserCreateCommand.cs
+++ b/src/Rhisis.CLI/Commands/User/UserCreateCommand.cs
@@ -1,0 +1,88 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Rhisis.CLI.Helpers;
+using Rhisis.Core.Common;
+using Rhisis.Core.Extensions;
+using Rhisis.Database;
+using Rhisis.Database.Entities;
+using System;
+
+namespace Rhisis.CLI.Commands.User
+{
+    [Command("create", Description = "Created a new user")]
+    public sealed class UserCreateCommand : IDisposable
+    {
+        private IDatabase _database;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "configuration", Description = "Specify the database configuration file path.")]
+        public string DatabaseConfigurationFile { get; set; }
+
+        public void OnExecute(CommandLineApplication app, IConsole console)
+        {
+            if (string.IsNullOrEmpty(DatabaseConfigurationFile))
+                DatabaseConfigurationFile = Application.DefaultDatabaseConfigurationFile;
+
+            var user = new DbUser();
+
+            Console.Write("Username: ");
+            user.Username = Console.ReadLine();
+
+            Console.Write("Email: ");
+            user.Email = Console.ReadLine();
+
+            Console.Write("Password: ");
+            user.Password = ConsoleHelper.ReadPassword();
+
+            Console.Write("Password confirmation: ");
+            string passwordConfirmation = ConsoleHelper.ReadPassword();
+
+            Console.WriteLine("Authority: ");
+            ConsoleHelper.DisplayEnum<AuthorityType>();
+            user.Authority = (int)ConsoleHelper.ReadEnum<AuthorityType>();
+
+            Console.WriteLine("--------------------------------");
+            Console.WriteLine("User account informations:");
+            Console.WriteLine($"Username: {user.Username}");
+            Console.WriteLine($"Email: {user.Email}");
+            Console.WriteLine($"Authority: {(AuthorityType)user.Authority}");
+            Console.WriteLine("--------------------------------");
+
+            bool response = ConsoleHelper.AskConfirmation("Create user?");
+
+            if (response)
+            {
+                DatabaseFactory.Instance.Initialize(this.DatabaseConfigurationFile);
+                this._database = new Rhisis.Database.Database();
+
+                if (this._database.Users.HasAny(x => x.Username.Equals(user.Username, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Console.WriteLine($"User '{user.Username}' is already used.");
+                    return;
+                }
+
+                if (!user.Email.IsValidEmail())
+                {
+                    Console.WriteLine($"Email '{user.Email}' is not valid.");
+                    return;
+                }
+
+                if (_database.Users.HasAny(x => x.Email.Equals(user.Email, StringComparison.OrdinalIgnoreCase)))
+                {
+                    Console.WriteLine($"Email '{user.Email}' is already used.");
+                    return;
+                }
+
+                if (!user.Password.Equals(passwordConfirmation))
+                {
+                    Console.WriteLine("Passwords doesn't match.");
+                    return;
+                }
+
+                this._database.Users.Create(user);
+                this._database.Complete();
+                Console.WriteLine($"User '{user.Username}' created.");
+            }
+        }
+
+        public void Dispose() => this._database?.Dispose();
+    }
+}

--- a/src/Rhisis.CLI/Helpers/ConsoleHelper.cs
+++ b/src/Rhisis.CLI/Helpers/ConsoleHelper.cs
@@ -40,14 +40,13 @@ namespace Rhisis.CLI.Helpers
         /// <summary>
         /// Displays an enum as a numbered list.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        public static void DisplayEnum<T>()
+        /// <typeparam name="TEnum"></typeparam>
+        public static void DisplayEnum<TEnum>() where TEnum : struct
         {
-            string[] providerNames = Enum.GetNames(typeof(T));
-            int[] providerValues = (int[])Enum.GetValues(typeof(T));
+            string[] providerNames = Enum.GetNames(typeof(TEnum));
 
-            for (int i = 1; i < providerNames.Length; i++)
-                Console.WriteLine($"{providerValues[i]}. {providerNames[i]}");
+            for (int i = 0; i < providerNames.Length; i++)
+                Console.WriteLine($"{i}. {providerNames[i]}");
         }
 
         /// <summary>
@@ -58,11 +57,15 @@ namespace Rhisis.CLI.Helpers
         public static TEnum ReadEnum<TEnum>() where TEnum : struct
         {
             var value = default(TEnum);
-            int[] providerValues = (int[])Enum.GetValues(typeof(TEnum));
+            string[] providerNames = Enum.GetNames(typeof(TEnum));
             string selectedProvider = Console.ReadLine();
 
-            if (int.TryParse(selectedProvider, out int selectedProviderValue) && selectedProviderValue > 0 && selectedProviderValue < providerValues.Length)
-                value = (TEnum)(object)selectedProviderValue;
+            if (int.TryParse(selectedProvider, out int selectedProviderValue) && 
+                selectedProviderValue > 0)
+            {
+                if (selectedProviderValue < providerNames.Length)
+                    value = Enum.Parse<TEnum>(providerNames[selectedProviderValue], true);
+            }
             else if (Enum.TryParse(selectedProvider, true, out TEnum provider))
                 value = provider;
 

--- a/src/Rhisis.CLI/Properties/launchSettings.json
+++ b/src/Rhisis.CLI/Properties/launchSettings.json
@@ -2,8 +2,8 @@
   "profiles": {
     "Rhisis.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "database configure",
-      "workingDirectory": "../../../bin"
+      "commandLineArgs": "user create",
+      "workingDirectory": "../../bin"
     }
   }
 }

--- a/src/Rhisis.CLI/Rhisis.CLI.csproj
+++ b/src/Rhisis.CLI/Rhisis.CLI.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Core/Extensions/LinqExtensions.cs
+++ b/src/Rhisis.Core/Extensions/LinqExtensions.cs
@@ -12,7 +12,7 @@ namespace Rhisis.Core.Extensions
         /// <param name="source"></param>
         /// <param name="itemsPerGroup"></param>
         /// <returns></returns>
-        public static IEnumerable<IGrouping<int, TSource>> GroupBy<TSource> (this IEnumerable<TSource> source, int itemsPerGroup)
+        public static IEnumerable<IGrouping<int, TSource>> GroupBy<TSource>(this IEnumerable<TSource> source, int itemsPerGroup)
         {
             return source.Zip(Enumerable.Range(0, source.Count()), (s, r) => new { Group = r / itemsPerGroup, Item = s })
                         .GroupBy(i => i.Group, g => g.Item)

--- a/src/Rhisis.Core/Extensions/StringExtensions.cs
+++ b/src/Rhisis.Core/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Rhisis.Core.Extensions
+{
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Check if the string is a valid email address.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public static bool IsValidEmail(this string source) => new EmailAddressAttribute().IsValid(source);
+    }
+}

--- a/src/Rhisis.Database/Database.cs
+++ b/src/Rhisis.Database/Database.cs
@@ -61,6 +61,7 @@ namespace Rhisis.Database
             this.Characters = new CharacterRepository(this._databaseContext);
             this.Items = new ItemRepository(this._databaseContext);
             this.Mails = new MailRepository(this._databaseContext);
+            this.TaskbarShortcuts = new ShortcutRepository(this._databaseContext);
         }
     }
 }

--- a/test/Rhisis.Core.Test/Extensions/ArrayExtensions.cs
+++ b/test/Rhisis.Core.Test/Extensions/ArrayExtensions.cs
@@ -1,0 +1,36 @@
+﻿using Rhisis.Core.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Rhisis.Core.Test.Extensions
+{
+    public class ArrayExtensions
+    {
+        private readonly int[] integerArray = new[] { 2, 4, 5, 2, 5, 0, 7, 1 };
+        private readonly IList<int> integerList = new List<int>() { 2, 4, 5, 2, 5, 0, 7, 1 };
+
+        [Theory]
+        [InlineData(2, 6, 7, 5)]
+        [InlineData(6, 7, 1, 7)]
+        [InlineData(0, 4, 5, 2)]
+        public void SwapArrayElementTest(int source, int dest, int sourceValueAfterSwap, int destValueAfterSwap)
+        {
+            integerArray.Swap(source, dest);
+
+            Assert.Equal(sourceValueAfterSwap, integerArray[source]);
+            Assert.Equal(destValueAfterSwap, integerArray[dest]);
+        }
+
+        [Theory]
+        [InlineData(2, 6, 7, 5)]
+        [InlineData(6, 7, 1, 7)]
+        [InlineData(0, 4, 5, 2)]
+        public void SwapListElementTest(int source, int dest, int sourceValueAfterSwap, int destValueAfterSwap)
+        {
+            integerList.Swap(source, dest);
+
+            Assert.Equal(sourceValueAfterSwap, integerList[source]);
+            Assert.Equal(destValueAfterSwap, integerList[dest]);
+        }
+    }
+}

--- a/test/Rhisis.Core.Test/Extensions/LinqExtensions.cs
+++ b/test/Rhisis.Core.Test/Extensions/LinqExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Rhisis.Core.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Rhisis.Core.Test.Extensions
+{
+    public class LinqExtensions
+    {
+        private readonly IEnumerable<int> array = Enumerable.Repeat(new Random().Next(), 64);
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(32)]
+        [InlineData(64)]
+        public void GroupByAmount(int itemsPerGroup)
+        {
+            int numberOfGroups = (array.Count() / itemsPerGroup);
+
+            if (array.Count() % itemsPerGroup > 0)
+                numberOfGroups++;
+
+            var groups = array.GroupBy(itemsPerGroup);
+
+            Assert.Equal(numberOfGroups, groups.Count());
+            Assert.Equal(array.Count(), groups.Sum(x => x.Count()));
+        }
+    }
+}

--- a/test/Rhisis.Core.Test/Extensions/StringExtensionsTest.cs
+++ b/test/Rhisis.Core.Test/Extensions/StringExtensionsTest.cs
@@ -1,0 +1,18 @@
+﻿using Rhisis.Core.Extensions;
+using Xunit;
+
+namespace Rhisis.Core.Test.Extensions
+{
+    public class StringExtensionsTest
+    {
+        [Theory]
+        [InlineData("foo@bar.com", true)]
+        [InlineData("shade@rhisis-project.com", true)]
+        [InlineData("rhisis-at-project.com", false)]
+        [InlineData("rhisis-at-project.dotcom-", false)]
+        public void IsValidEmailTest(string email, bool valid)
+        {
+            Assert.Equal(valid, email.IsValidEmail());
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `user create` command to the Rhisis CLI. It allows you to create an user using the current database configuration.

Usage:
```
$> ./rhisis-cli user create
Username: ...
Email: ...
Password: ******
Password confirmation: ******
Authority:
0. Banned
1. Player
2. GameMaster
3. Administrator
....
Create user? (y/n)
```

Also, this PR adds some unit tests to the Rhisis.Core extensions.