### PR TITLE
Update database schema

### DIFF
--- a/bin/config/database.json
+++ b/bin/config/database.json
@@ -5,5 +5,5 @@
   "password": "hello_world",
   "database": "rhisis",
   "provider": 1,
-  "encryptionKey": "EDxYEMekA59b1GEqA2KoZDzhVTfF/adRuebqMVSXAoA="
+  "encryptionKey": "5gzlpRQIceJazRG67pywnPDnfcR90ACFFeJRcWLKi+c="
 }

--- a/src/Rhisis.CLI/Commands/User/UserCreateCommand.cs
+++ b/src/Rhisis.CLI/Commands/User/UserCreateCommand.cs
@@ -35,6 +35,9 @@ namespace Rhisis.CLI.Commands.User
             Console.Write("Password confirmation: ");
             string passwordConfirmation = ConsoleHelper.ReadPassword();
 
+            Console.WriteLine("Password salt:");
+            string passwordSalt = ConsoleHelper.ReadStringOrDefault();
+
             Console.WriteLine("Authority: ");
             ConsoleHelper.DisplayEnum<AuthorityType>();
             user.Authority = (int)ConsoleHelper.ReadEnum<AuthorityType>();
@@ -76,6 +79,9 @@ namespace Rhisis.CLI.Commands.User
                     Console.WriteLine("Passwords doesn't match.");
                     return;
                 }
+
+                if (!string.IsNullOrEmpty(passwordSalt))
+                    user.Password = passwordSalt + user.Password;
 
                 this._database.Users.Create(user);
                 this._database.Complete();

--- a/src/Rhisis.CLI/Properties/launchSettings.json
+++ b/src/Rhisis.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Rhisis.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "user create",
+      "commandLineArgs": "database update",
       "workingDirectory": "../../bin"
     }
   }

--- a/src/Rhisis.Database/Context/DatabaseContext.cs
+++ b/src/Rhisis.Database/Context/DatabaseContext.cs
@@ -98,6 +98,10 @@ namespace Rhisis.Database.Context
             if (string.IsNullOrEmpty(this._configuration.EncryptionKey))
                 throw new RhisisConfigurationException($"Database configuration doesn't contain a valid encryption key.");
 
+            modelBuilder.Entity<DbUser>()
+                .HasIndex(c => new { c.Username, c.Email })
+                .IsUnique();
+
             modelBuilder.Entity<DbCharacter>()
                 .HasMany(x => x.ReceivedMails).WithOne(x => x.Receiver);
             modelBuilder.Entity<DbCharacter>()

--- a/src/Rhisis.Database/Entities/DbCharacter.cs
+++ b/src/Rhisis.Database/Entities/DbCharacter.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Rhisis.Database.Attributes;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -8,79 +10,193 @@ namespace Rhisis.Database.Entities
     [Table("characters")]
     public sealed class DbCharacter : DbEntity
     {
-        public int UserId { get; set; }
-
+        /// <summary>
+        /// Gets or sets the character name.
+        /// </summary>
         [Required]
+        [Encrypted]
         public string Name { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character gender.
+        /// </summary>
         [Required]
         public byte Gender { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character level.
+        /// </summary>
         [Required]
         [DefaultValue(1)]
         public int Level { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character level experience progression.
+        /// </summary>
         public long Experience { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character class.
+        /// </summary>
         public int ClassId { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character gold amount.
+        /// </summary>
         public int Gold { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character slot.
+        /// </summary>
         [Required]
         public int Slot { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character strength.
+        /// </summary>
         public int Strength { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character stamina.
+        /// </summary>
         public int Stamina { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character dexterity.
+        /// </summary>
         public int Dexterity { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character intelligence.
+        /// </summary>
         public int Intelligence { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character hit points.
+        /// </summary>
         public int Hp { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character magic points.
+        /// </summary>
         public int Mp { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character fatigue points.
+        /// </summary>
         public int Fp { get; set; }
 
+        /// <summary>
+        /// Gets or sets the character skin set id.
+        /// </summary>
         [Required]
         public int SkinSetId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the character hair id.
+        /// </summary>
         [Required]
         public int HairId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the character hair color.
+        /// </summary>
         [Required]
         public int HairColor { get; set; }
 
+        /// <summary>
+        /// Gets or sets the character hair id.
+        /// </summary>
         [Required]
         public int FaceId { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character map id.
+        /// </summary>
         public int MapId { get; set; }
 
+        /// <summary>
+        /// Gets or sets character map layer id.
+        /// </summary>
         public int MapLayerId { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character X position.
+        /// </summary>
         public float PosX { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character Y position.
+        /// </summary>
         public float PosY { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character Z position.
+        /// </summary>
         public float PosZ { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character orientation angle.
+        /// </summary>
         public float Angle { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character bank code.
+        /// </summary>
         public int BankCode { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character remaining statistics points.
+        /// </summary>
         public int StatPoints { get; set; }
         
+        /// <summary>
+        /// Gets or sets the character remaining skill points.
+        /// </summary>
         public int SkillPoints { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the last connection time.
+        /// </summary>
+        [Column(TypeName = "DATETIME")]
+        public DateTime LastConnectionTime { get; set; }
 
+        /// <summary>
+        /// Gets or sets the play time amount in seconds.
+        /// </summary>
+        [Column(TypeName = "BIGINT")]
+        public long PlayTime { get; set; }
+
+        /// <summary>
+        /// Gets the character associated user id.
+        /// </summary>
+        [Required]
+        public int UserId { get; set; }
+
+        /// <summary>
+        /// Gets the character associated user.
+        /// </summary>
+        [ForeignKey(nameof(UserId))]
         public DbUser User { get; set; }
 
+        /// <summary>
+        /// Gets the character items.
+        /// </summary>
         public ICollection<DbItem> Items { get; set; }
 
+        /// <summary>
+        /// Gets the character received mails.
+        /// </summary>
         public ICollection<DbMail> ReceivedMails { get; set; }
 
+        /// <summary>
+        /// Gets the character sent mails.
+        /// </summary>
         public ICollection<DbMail> SentMails { get; set; }
 
+        /// <summary>
+        /// Gets the character shortcuts.
+        /// </summary>
         public ICollection<DbShortcut> TaskbarShortcuts { get; set; }
 
         public DbCharacter()

--- a/src/Rhisis.Database/Entities/DbItem.cs
+++ b/src/Rhisis.Database/Entities/DbItem.cs
@@ -1,26 +1,61 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Rhisis.Database.Entities
 {
     [Table("items")]
     public sealed class DbItem : DbEntity
     {        
+        /// <summary>
+        /// Gets or sets the real item Id.
+        /// </summary>
+        [Required]
         public int ItemId { get; set; }
         
-        public int CharacterId { get; set; }
-        
+        /// <summary>
+        /// Gets or sets the amount of items.
+        /// </summary>
+        [Required]
         public int ItemCount { get; set; }
         
+        /// <summary>
+        /// Gets or sets the item slot.
+        /// </summary>
         public int ItemSlot { get; set; }
         
+        /// <summary>
+        /// Gets or sets the item creator id.
+        /// </summary>
         public int CreatorId { get; set; }
         
+        /// <summary>
+        /// Gets or sets the item refine.
+        /// </summary>
+        [DefaultValue(0)]
         public byte Refine { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the item element.
+        /// </summary>
+        [DefaultValue(0)]
         public byte Element { get; set; }
-        
+
+        /// <summary>
+        /// Gets or sets the item element refine.
+        /// </summary>
+        [DefaultValue(0)]
         public byte ElementRefine { get; set; }
 
+        /// <summary>
+        /// Gets or sets the character Id associated to this item.
+        /// </summary>
+        public int CharacterId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the character associated to this item.
+        /// </summary>
+        [ForeignKey(nameof(CharacterId))]
         public DbCharacter Character { get; set; }
 
         public DbItem()

--- a/src/Rhisis.Database/Entities/DbMail.cs
+++ b/src/Rhisis.Database/Entities/DbMail.cs
@@ -8,21 +8,22 @@ namespace Rhisis.Database.Entities
     [Table("mails")]
     public sealed class DbMail : DbEntity
     {
-        [Column(TypeName = "BIGINT")]
-        public uint Gold { get; set; }
-
-        public int? ItemId { get; set; }
-
-        public DbItem Item { get; set; }
-
-        public short ItemQuantity { get; set; }
-
         [Required]
         [Encrypted]
         public string Title { get; set; }
 
         [Encrypted]
         public string Text { get; set; }
+
+        [Column(TypeName = "BIGINT")]
+        public uint Gold { get; set; }
+
+        public int? ItemId { get; set; }
+
+        [ForeignKey(nameof(ItemId))]
+        public DbItem Item { get; set; }
+
+        public short ItemQuantity { get; set; }
 
         public bool HasBeenRead { get; set; }
 
@@ -35,9 +36,13 @@ namespace Rhisis.Database.Entities
         public DateTime CreateTime { get; set; }
         
         public int SenderId { get; set; }
+
+        [ForeignKey(nameof(SenderId))]
         public DbCharacter Sender { get; set; }
 
         public int ReceiverId { get; set; }
+
+        [ForeignKey(nameof(ReceiverId))]
         public DbCharacter Receiver { get; set; }
 
         public DbMail()

--- a/src/Rhisis.Database/Entities/DbShortcut.cs
+++ b/src/Rhisis.Database/Entities/DbShortcut.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Core.Common;
 using Rhisis.Database.Attributes;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Rhisis.Database.Entities
@@ -7,8 +8,6 @@ namespace Rhisis.Database.Entities
     [Table("shortcuts")]
     public sealed class DbShortcut : DbEntity
     {
-        public int CharacterId { get; set; }
-
         public ShortcutTaskbarTarget TargetTaskbar { get; set; }
 
         public int? SlotLevelIndex { get; set; }
@@ -30,6 +29,10 @@ namespace Rhisis.Database.Entities
         [Encrypted]
         public string Text { get; set; }
 
+        [Required]
+        public int CharacterId { get; set; }
+
+        [ForeignKey(nameof(CharacterId))]
         public DbCharacter Character { get; set; }
 
         public DbShortcut()

--- a/src/Rhisis.Database/Entities/DbUser.cs
+++ b/src/Rhisis.Database/Entities/DbUser.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 
 namespace Rhisis.Database.Entities
 {
@@ -31,16 +32,28 @@ namespace Rhisis.Database.Entities
         public string Email { get; set; }
 
         /// <summary>
+        /// Gets or sets the user's creation date.
+        /// </summary>
+        [Column(TypeName = "DATETIME")]
+        public DateTime CreatedAt { get; private set; }
+
+        /// <summary>
         /// Gets or sets the last time the user logged in.
         /// </summary>
         [Column(TypeName = "DATETIME")]
         public DateTime LastConnectionTime { get; set; }
-
+        
         /// <summary>
         /// Gets or sets the user's authority.
         /// </summary>
         [Required]
         public int Authority { get; set; }
+
+        /// <summary>
+        /// Gets the total play time of this user in seconds.
+        /// </summary>
+        [NotMapped]
+        public long PlayTime => this.Characters.Sum(x => x.PlayTime);
 
         /// <summary>
         /// Gets or sets the user's characters list.
@@ -52,6 +65,7 @@ namespace Rhisis.Database.Entities
         /// </summary>
         public DbUser()
         {
+            this.CreatedAt = DateTime.UtcNow;
             this.Characters = new HashSet<DbCharacter>();
         }
     }

--- a/src/Rhisis.Database/Migrations/20190305201603_InitialMigration.Designer.cs
+++ b/src/Rhisis.Database/Migrations/20190305201603_InitialMigration.Designer.cs
@@ -9,7 +9,7 @@ using Rhisis.Database.Context;
 namespace Rhisis.Database.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    [Migration("20190223194344_InitialMigration")]
+    [Migration("20190305201603_InitialMigration")]
     partial class InitialMigration
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -50,6 +50,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<int>("Intelligence");
 
+                    b.Property<DateTime>("LastConnectionTime")
+                        .HasColumnType("DATETIME");
+
                     b.Property<int>("Level");
 
                     b.Property<int>("MapId");
@@ -60,6 +63,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired();
+
+                    b.Property<long>("PlayTime")
+                        .HasColumnType("BIGINT");
 
                     b.Property<float>("PosX");
 
@@ -199,6 +205,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<int>("Authority");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("DATETIME");
+
                     b.Property<string>("Email")
                         .IsRequired();
 
@@ -212,6 +221,9 @@ namespace Rhisis.Database.Migrations
                         .IsRequired();
 
                     b.HasKey("Id");
+
+                    b.HasIndex("Username", "Email")
+                        .IsUnique();
 
                     b.ToTable("users");
                 });

--- a/src/Rhisis.Database/Migrations/20190305201603_InitialMigration.cs
+++ b/src/Rhisis.Database/Migrations/20190305201603_InitialMigration.cs
@@ -17,6 +17,7 @@ namespace Rhisis.Database.Migrations
                     Username = table.Column<string>(nullable: false),
                     Password = table.Column<string>(nullable: false),
                     Email = table.Column<string>(nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "DATETIME", nullable: false),
                     LastConnectionTime = table.Column<DateTime>(type: "DATETIME", nullable: false),
                     Authority = table.Column<int>(nullable: false)
                 },
@@ -31,7 +32,6 @@ namespace Rhisis.Database.Migrations
                 {
                     Id = table.Column<int>(nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    UserId = table.Column<int>(nullable: false),
                     Name = table.Column<string>(nullable: false),
                     Gender = table.Column<byte>(nullable: false),
                     Level = table.Column<int>(nullable: false),
@@ -58,7 +58,10 @@ namespace Rhisis.Database.Migrations
                     Angle = table.Column<float>(nullable: false),
                     BankCode = table.Column<int>(nullable: false),
                     StatPoints = table.Column<int>(nullable: false),
-                    SkillPoints = table.Column<int>(nullable: false)
+                    SkillPoints = table.Column<int>(nullable: false),
+                    LastConnectionTime = table.Column<DateTime>(type: "DATETIME", nullable: false),
+                    PlayTime = table.Column<long>(type: "BIGINT", nullable: false),
+                    UserId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -78,13 +81,13 @@ namespace Rhisis.Database.Migrations
                     Id = table.Column<int>(nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
                     ItemId = table.Column<int>(nullable: false),
-                    CharacterId = table.Column<int>(nullable: false),
                     ItemCount = table.Column<int>(nullable: false),
                     ItemSlot = table.Column<int>(nullable: false),
                     CreatorId = table.Column<int>(nullable: false),
                     Refine = table.Column<byte>(nullable: false),
                     Element = table.Column<byte>(nullable: false),
-                    ElementRefine = table.Column<byte>(nullable: false)
+                    ElementRefine = table.Column<byte>(nullable: false),
+                    CharacterId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -103,7 +106,6 @@ namespace Rhisis.Database.Migrations
                 {
                     Id = table.Column<int>(nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
-                    CharacterId = table.Column<int>(nullable: false),
                     TargetTaskbar = table.Column<int>(nullable: false),
                     SlotLevelIndex = table.Column<int>(nullable: true),
                     SlotIndex = table.Column<int>(nullable: false),
@@ -113,7 +115,8 @@ namespace Rhisis.Database.Migrations
                     ObjectIndex = table.Column<uint>(nullable: false),
                     UserId = table.Column<uint>(nullable: false),
                     ObjectData = table.Column<uint>(nullable: false),
-                    Text = table.Column<string>(nullable: true)
+                    Text = table.Column<string>(nullable: true),
+                    CharacterId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -132,11 +135,11 @@ namespace Rhisis.Database.Migrations
                 {
                     Id = table.Column<int>(nullable: false)
                         .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    Title = table.Column<string>(nullable: false),
+                    Text = table.Column<string>(nullable: true),
                     Gold = table.Column<long>(type: "BIGINT", nullable: false),
                     ItemId = table.Column<int>(nullable: true),
                     ItemQuantity = table.Column<short>(nullable: false),
-                    Title = table.Column<string>(nullable: false),
-                    Text = table.Column<string>(nullable: true),
                     HasBeenRead = table.Column<bool>(nullable: false),
                     HasReceivedItem = table.Column<bool>(nullable: false),
                     HasReceivedGold = table.Column<bool>(nullable: false),
@@ -197,6 +200,12 @@ namespace Rhisis.Database.Migrations
                 name: "IX_shortcuts_CharacterId",
                 table: "shortcuts",
                 column: "CharacterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_users_Username_Email",
+                table: "users",
+                columns: new[] { "Username", "Email" },
+                unique: true);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/Rhisis.Database/Migrations/DatabaseContextModelSnapshot.cs
+++ b/src/Rhisis.Database/Migrations/DatabaseContextModelSnapshot.cs
@@ -48,6 +48,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<int>("Intelligence");
 
+                    b.Property<DateTime>("LastConnectionTime")
+                        .HasColumnType("DATETIME");
+
                     b.Property<int>("Level");
 
                     b.Property<int>("MapId");
@@ -58,6 +61,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<string>("Name")
                         .IsRequired();
+
+                    b.Property<long>("PlayTime")
+                        .HasColumnType("BIGINT");
 
                     b.Property<float>("PosX");
 
@@ -197,6 +203,9 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<int>("Authority");
 
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("DATETIME");
+
                     b.Property<string>("Email")
                         .IsRequired();
 
@@ -210,6 +219,9 @@ namespace Rhisis.Database.Migrations
                         .IsRequired();
 
                     b.HasKey("Id");
+
+                    b.HasIndex("Username", "Email")
+                        .IsUnique();
 
                     b.ToTable("users");
                 });

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -19,6 +19,7 @@ using Rhisis.World.Game.Maps;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Inventory;
 using Rhisis.World.Systems.Inventory.EventArgs;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -163,6 +164,7 @@ namespace Rhisis.World.Handlers
 
             // 4th: player is now spawned
             client.Player.Object.Spawned = true;
+            client.LoggedInAt = DateTime.UtcNow;
         }
     }
 }

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -46,6 +46,11 @@ namespace Rhisis.World
         public string RemoteEndPoint { get; private set; }
 
         /// <summary>
+        /// Gets or sets the time the player has logged in.
+        /// </summary>
+        public DateTime LoggedInAt { get; set; }
+
+        /// <summary>
         /// Creates a new <see cref="WorldClient"/> instance.
         /// </summary>
         public WorldClient()
@@ -124,6 +129,9 @@ namespace Rhisis.World
 
                 if (character != null)
                 {
+                    character.LastConnectionTime = this.LoggedInAt;
+                    character.PlayTime += (long)(DateTime.UtcNow - this.LoggedInAt).TotalSeconds;
+
                     character.PosX = this.Player.Object.Position.X;
                     character.PosY = this.Player.Object.Position.Y;
                     character.PosZ = this.Player.Object.Position.Z;


### PR DESCRIPTION
This PR updates the database schema and adds some new fields to `users` and `characters` table:

### User table

- `LastConnectionTime`: Represents the last time the user logged in with this account.
> ❓ Should we store the IP address from where the user has logged in ?

### Character table

- `LastConnectionTime`: Represents the last time the character has logged in to the game.
- `PlayTime`: Number of seconds the player has spent online.

This properties have been added so the server administrators can setup statistics.

Also, this PR includes a fixe to issue #56 by adding an unique key to the `Username` and `Email` field.