### PR TITLE
Add IsDeleted flag to user, character and items.

### DIFF
--- a/src/Rhisis.Business/Services/AuthenticationService.cs
+++ b/src/Rhisis.Business/Services/AuthenticationService.cs
@@ -31,6 +31,11 @@ namespace Rhisis.Business.Services
                 return AuthenticationResult.BadUsername;
             }
 
+            if (_dbUser.IsDeleted)
+            {
+                return AuthenticationResult.AccountDeleted;
+            }
+
             if (!_dbUser.Password.Equals(password, StringComparison.OrdinalIgnoreCase))
             {
                 return AuthenticationResult.BadPassword;

--- a/src/Rhisis.Core/Common/AuthenticationResult.cs
+++ b/src/Rhisis.Core/Common/AuthenticationResult.cs
@@ -6,6 +6,7 @@
         BadUsername,
         BadPassword,
         AccountSuspended,
-        AccountTemporarySuspended
+        AccountTemporarySuspended,
+        AccountDeleted
     }
 }

--- a/src/Rhisis.Database/Entities/DbCharacter.cs
+++ b/src/Rhisis.Database/Entities/DbCharacter.cs
@@ -168,6 +168,12 @@ namespace Rhisis.Database.Entities
         public long PlayTime { get; set; }
 
         /// <summary>
+        /// Gets or sets a flag that indicates if the character is deleted.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IsDeleted { get; set; }
+
+        /// <summary>
         /// Gets the character associated user id.
         /// </summary>
         [Required]

--- a/src/Rhisis.Database/Entities/DbItem.cs
+++ b/src/Rhisis.Database/Entities/DbItem.cs
@@ -48,6 +48,12 @@ namespace Rhisis.Database.Entities
         public byte ElementRefine { get; set; }
 
         /// <summary>
+        /// Gets or sets a flag that indicates if the item is deleted.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IsDeleted { get; set; }
+
+        /// <summary>
         /// Gets or sets the character Id associated to this item.
         /// </summary>
         public int CharacterId { get; set; }

--- a/src/Rhisis.Database/Entities/DbUser.cs
+++ b/src/Rhisis.Database/Entities/DbUser.cs
@@ -1,6 +1,7 @@
 ﻿using Rhisis.Database.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
@@ -48,6 +49,12 @@ namespace Rhisis.Database.Entities
         /// </summary>
         [Required]
         public int Authority { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag that indicates if the user is deleted.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IsDeleted { get; set; }
 
         /// <summary>
         /// Gets the total play time of this user in seconds.

--- a/src/Rhisis.Database/Migrations/20190308184619_InitialMigration.Designer.cs
+++ b/src/Rhisis.Database/Migrations/20190308184619_InitialMigration.Designer.cs
@@ -9,7 +9,7 @@ using Rhisis.Database.Context;
 namespace Rhisis.Database.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    [Migration("20190305201603_InitialMigration")]
+    [Migration("20190308184619_InitialMigration")]
     partial class InitialMigration
     {
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -49,6 +49,8 @@ namespace Rhisis.Database.Migrations
                     b.Property<int>("Hp");
 
                     b.Property<int>("Intelligence");
+
+                    b.Property<bool>("IsDeleted");
 
                     b.Property<DateTime>("LastConnectionTime")
                         .HasColumnType("DATETIME");
@@ -106,6 +108,8 @@ namespace Rhisis.Database.Migrations
                     b.Property<byte>("Element");
 
                     b.Property<byte>("ElementRefine");
+
+                    b.Property<bool>("IsDeleted");
 
                     b.Property<int>("ItemCount");
 
@@ -210,6 +214,8 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<string>("Email")
                         .IsRequired();
+
+                    b.Property<bool>("IsDeleted");
 
                     b.Property<DateTime>("LastConnectionTime")
                         .HasColumnType("DATETIME");

--- a/src/Rhisis.Database/Migrations/20190308184619_InitialMigration.cs
+++ b/src/Rhisis.Database/Migrations/20190308184619_InitialMigration.cs
@@ -19,7 +19,8 @@ namespace Rhisis.Database.Migrations
                     Email = table.Column<string>(nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "DATETIME", nullable: false),
                     LastConnectionTime = table.Column<DateTime>(type: "DATETIME", nullable: false),
-                    Authority = table.Column<int>(nullable: false)
+                    Authority = table.Column<int>(nullable: false),
+                    IsDeleted = table.Column<bool>(nullable: false)
                 },
                 constraints: table =>
                 {
@@ -61,6 +62,7 @@ namespace Rhisis.Database.Migrations
                     SkillPoints = table.Column<int>(nullable: false),
                     LastConnectionTime = table.Column<DateTime>(type: "DATETIME", nullable: false),
                     PlayTime = table.Column<long>(type: "BIGINT", nullable: false),
+                    IsDeleted = table.Column<bool>(nullable: false),
                     UserId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>
@@ -87,6 +89,7 @@ namespace Rhisis.Database.Migrations
                     Refine = table.Column<byte>(nullable: false),
                     Element = table.Column<byte>(nullable: false),
                     ElementRefine = table.Column<byte>(nullable: false),
+                    IsDeleted = table.Column<bool>(nullable: false),
                     CharacterId = table.Column<int>(nullable: false)
                 },
                 constraints: table =>

--- a/src/Rhisis.Database/Migrations/DatabaseContextModelSnapshot.cs
+++ b/src/Rhisis.Database/Migrations/DatabaseContextModelSnapshot.cs
@@ -48,6 +48,8 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<int>("Intelligence");
 
+                    b.Property<bool>("IsDeleted");
+
                     b.Property<DateTime>("LastConnectionTime")
                         .HasColumnType("DATETIME");
 
@@ -104,6 +106,8 @@ namespace Rhisis.Database.Migrations
                     b.Property<byte>("Element");
 
                     b.Property<byte>("ElementRefine");
+
+                    b.Property<bool>("IsDeleted");
 
                     b.Property<int>("ItemCount");
 
@@ -208,6 +212,8 @@ namespace Rhisis.Database.Migrations
 
                     b.Property<string>("Email")
                         .IsRequired();
+
+                    b.Property<bool>("IsDeleted");
 
                     b.Property<DateTime>("LastConnectionTime")
                         .HasColumnType("DATETIME");

--- a/src/Rhisis.Login/LoginHandler.cs
+++ b/src/Rhisis.Login/LoginHandler.cs
@@ -69,6 +69,9 @@ namespace Rhisis.Login
                 case AuthenticationResult.AccountTemporarySuspended:
                     // TODO
                     break;
+                case AuthenticationResult.AccountDeleted:
+                    AuthenticationFailed(client, ErrorType.ILLEGAL_ACCESS, "logged in with deleted account");
+                    break;
                 case AuthenticationResult.Success:
                     if (loginServer.IsClientConnected(certifyPacket.Username))
                     {

--- a/src/Rhisis.World/Handlers/JoinGameHandler.cs
+++ b/src/Rhisis.World/Handlers/JoinGameHandler.cs
@@ -44,6 +44,12 @@ namespace Rhisis.World.Handlers
                 return;
             }
 
+            if (character.IsDeleted)
+            {
+                Logger.Warn($"Cannot connect with character '{character.Name}' for user '{character.User.Username}'. Reason: character is deleted.");
+                return;
+            }
+
             if (character.User.Authority <= 0)
             {
                 Logger.Info($"User {character.User.Username} is banned.");

--- a/test/Rhisis.Business.Tests/AuthenticationServiceTest.cs
+++ b/test/Rhisis.Business.Tests/AuthenticationServiceTest.cs
@@ -35,6 +35,9 @@ namespace Rhisis.Business.Tests
         [InlineData("mayer", "c31f44c8-fc9c-4cea-872c-66f91be16589", AuthenticationResult.Success)]
         [InlineData("Eastrall", "a833300qsdnisqd45646djfdec6db", AuthenticationResult.BadUsername)]
         [InlineData("Nita", "a833300c-be76367-46bd77bec6db", AuthenticationResult.BadPassword)]
+        [InlineData("Armstrong", "daf059bc-e76c-4b8f-b431-e049617ebb31", AuthenticationResult.AccountDeleted)]
+        [InlineData("Stacey", "c96f0d63-f16c-48b2-a1c9-0b7b2af3dee5", AuthenticationResult.AccountDeleted)]
+        [InlineData("Weber", "8a946c3f-7261-4871-8ab9-a7cf02a18149", AuthenticationResult.AccountDeleted)]
         public void AuthenticationTest(string username, string password, AuthenticationResult expectedResult)
         {
             AuthenticationResult result = this._service.Authenticate(username, password);

--- a/test/Rhisis.Business.Tests/Resources/Users/UsersDatabase.json
+++ b/test/Rhisis.Business.Tests/Resources/Users/UsersDatabase.json
@@ -14,51 +14,61 @@
   {
     "id": 0,
     "username": "Michael",
-    "password": "a833300c-be76-4b52-9367-46bd77bec6db"
+    "password": "a833300c-be76-4b52-9367-46bd77bec6db",
+    "isDeleted": false
   },
   {
     "id": 1,
     "username": "Gaines",
-    "password": "d05581d6-197e-48fa-92f6-0f9147642e3f"
+    "password": "d05581d6-197e-48fa-92f6-0f9147642e3f",
+    "isDeleted": false
   },
   {
     "id": 2,
     "username": "Nita",
-    "password": "60fc6908-c3a3-4c55-80f7-9043cc009d73"
+    "password": "60fc6908-c3a3-4c55-80f7-9043cc009d73",
+    "isDeleted": false
   },
   {
     "id": 3,
     "username": "Armstrong",
-    "password": "daf059bc-e76c-4b8f-b431-e049617ebb31"
+    "password": "daf059bc-e76c-4b8f-b431-e049617ebb31",
+    "isDeleted": true
   },
   {
     "id": 4,
     "username": "Helene",
-    "password": "deaf2be8-0499-44d1-90cb-83a473eeb60d"
+    "password": "deaf2be8-0499-44d1-90cb-83a473eeb60d",
+    "isDeleted": false
   },
   {
     "id": 5,
     "username": "Mayer",
-    "password": "c31f44c8-fc9c-4cea-872c-66f91be16589"
+    "password": "c31f44c8-fc9c-4cea-872c-66f91be16589",
+    "isDeleted": false
   },
   {
     "id": 6,
     "username": "Twila",
-    "password": "b945521c-f0b6-4588-b647-89697624cfab"
+    "password": "b945521c-f0b6-4588-b647-89697624cfab",
+    "isDeleted": false
   },
   {
     "id": 7,
     "username": "Stacey",
-    "password": "c96f0d63-f16c-48b2-a1c9-0b7b2af3dee5"
+    "password": "c96f0d63-f16c-48b2-a1c9-0b7b2af3dee5",
+    "isDeleted": true
   },
   {
     "id": 8,
     "username": "Reeves",
-    "password": "4a071cda-ac1a-4619-b1b7-a0a0dd2964dc"
+    "password": "4a071cda-ac1a-4619-b1b7-a0a0dd2964dc",
+    "isDeleted": false
   },
   {
     "id": 9,
     "username": "Weber",
-    "password": "8a946c3f-7261-4871-8ab9-a7cf02a18149"
+    "password": "8a946c3f-7261-4871-8ab9-a7cf02a18149",
+    "isDeleted": true
   }
 ]


### PR DESCRIPTION
This PR adds a `IsDeleted` flag to the `DbUser`, `DbCharacter` and `DbItem` entities to prevent losing data. A purge option will be made on the CLI tool to hard remove the data from the database.

Also, some checks have been made to Login process, character selection and join world process, to prevent logging in with a deleted character.