### PR TITLE
Death System and resurection

### DIFF
--- a/src/Rhisis.Core/Resources/Rgn/RegionInfo.cs
+++ b/src/Rhisis.Core/Resources/Rgn/RegionInfo.cs
@@ -1,0 +1,35 @@
+﻿namespace Rhisis.Core.Resources
+{
+    public sealed class RegionInfo
+    {
+        /// <summary>
+        /// Trigger region.
+        /// </summary>
+        public const int RI_TRIGGER = 10;
+
+        /// <summary>
+        /// Attribute region.
+        /// </summary>
+        public const int RI_ATTRIBUTE = 11;
+
+        /// <summary>
+        /// Begin region.
+        /// </summary>
+        public const int RI_BEGIN = 12;
+
+        /// <summary>
+        /// Revival region.
+        /// </summary>
+        public const int RI_REVIVAL = 13;
+
+        /// <summary>
+        /// Structure region.
+        /// </summary>
+        public const int RI_STRUCTURE = 14;
+
+        /// <summary>
+        /// Place region.
+        /// </summary>
+        public const int RI_PLACE = 15;
+    }
+}

--- a/src/Rhisis.Core/Resources/Wld/WldFile.cs
+++ b/src/Rhisis.Core/Resources/Wld/WldFile.cs
@@ -1,0 +1,82 @@
+﻿using Rhisis.Core.Structures;
+using System;
+using System.IO;
+
+namespace Rhisis.Core.Resources
+{
+    /// <summary>
+    /// FlyFF World File structure.
+    /// </summary>
+    public class WldFile : FileStream, IDisposable
+    {
+        public WldFileInformations WorldInformations { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="WldFile"/> instance.
+        /// </summary>
+        /// <param name="filePath">Wld file data</param>
+        public WldFile(string filePath)
+            : base(filePath, FileMode.Open, FileAccess.Read)
+        {
+            this.Read();
+        }
+
+        /// <summary>
+        /// Reads the content of the Wld file.
+        /// </summary>
+        private void Read()
+        {
+            var reader = new StreamReader(this);
+            Vector3 size = null;
+            bool isIndoor = false;
+            bool canFly = false;
+            int mpu = 0;
+            int revivalMapId = 0;
+            string revivalKey = string.Empty;
+
+            while (!reader.EndOfStream)
+            {
+                var line = reader.ReadLine().Trim().ToLower();
+
+                if (line.StartsWith("//") || string.IsNullOrEmpty(line))
+                    continue;
+
+                string[] lineArray = line.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+
+                switch (lineArray[0].ToLower())
+                {
+                    case "size":
+                        size = this.ReadSize(lineArray);
+                        break;
+                    case "indoor":
+                        isIndoor = lineArray[1] == "1" ? true : false;
+                        break;
+                    case "fly":
+                        canFly = lineArray[1] == "1" ? true : false;
+                        break;
+                    case "mpu":
+                        mpu = int.Parse(lineArray[1]);
+                        break;
+                    case "revival":
+                        revivalMapId = int.Parse(lineArray[1]);
+                        revivalKey = lineArray[2].Trim('"');
+                        break;
+                }
+            }
+
+            this.WorldInformations = new WldFileInformations((int)size.X, (int)size.Z, mpu, isIndoor, canFly, revivalMapId, revivalKey);
+        }
+
+        /// <summary>
+        /// Read the "size" field of the wld file.
+        /// </summary>
+        /// <param name="lineArray">Current line array</param>
+        private Vector3 ReadSize(string[] lineArray)
+        {
+            string width = lineArray[1].Replace(",", string.Empty);
+            string length = lineArray[2];
+
+            return new Vector3(int.Parse(width), 0, int.Parse(length));
+        }
+    }
+}

--- a/src/Rhisis.Core/Resources/Wld/WldFile.cs
+++ b/src/Rhisis.Core/Resources/Wld/WldFile.cs
@@ -9,6 +9,7 @@ namespace Rhisis.Core.Resources
     /// </summary>
     public class WldFile : FileStream, IDisposable
     {
+        private static readonly char[] SplitCharacters = new[] { ' ', '\t' };
         public WldFileInformations WorldInformations { get; private set; }
 
         /// <summary>
@@ -41,7 +42,7 @@ namespace Rhisis.Core.Resources
                 if (line.StartsWith("//") || string.IsNullOrEmpty(line))
                     continue;
 
-                string[] lineArray = line.Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] lineArray = line.Split(SplitCharacters, StringSplitOptions.RemoveEmptyEntries);
 
                 switch (lineArray[0].ToLower())
                 {
@@ -64,7 +65,7 @@ namespace Rhisis.Core.Resources
                 }
             }
 
-            this.WorldInformations = new WldFileInformations((int)size.X, (int)size.Z, mpu, isIndoor, canFly, revivalMapId, revivalKey);
+            this.WorldInformations = new WldFileInformations((int)size?.X, (int)size?.Z, mpu, isIndoor, canFly, revivalMapId, revivalKey);
         }
 
         /// <summary>

--- a/src/Rhisis.Core/Resources/Wld/WldFileInformations.cs
+++ b/src/Rhisis.Core/Resources/Wld/WldFileInformations.cs
@@ -1,0 +1,75 @@
+﻿using System;
+
+namespace Rhisis.Core.Resources
+{
+    /// <summary>
+    /// Defines a <see cref="WldFile"/> informations data structure.
+    /// </summary>
+    public readonly struct WldFileInformations : IEquatable<WldFileInformations>
+    {
+        /// <summary>
+        /// Gets the world file width value.
+        /// </summary>
+        public int Width { get; }
+
+        /// <summary>
+        /// Gets the world file length value.
+        /// </summary>
+        public int Length { get; }
+
+        /// <summary>
+        /// Gets the MPU (meters per unit) value.
+        /// </summary>
+        public int MPU { get; }
+
+        /// <summary>
+        /// Gets a value that indicates if the world is indoor or not.
+        /// </summary>
+        public bool Indoor { get; }
+
+        /// <summary>
+        /// Gets a value that indicates if we can fly in the world.
+        /// </summary>
+        public bool Fly { get;}
+
+        /// <summary>
+        /// Gets the revival map id.
+        /// </summary>
+        public int RevivalMapId { get; }
+
+        /// <summary>
+        /// Gets the revival key.
+        /// </summary>
+        public string RevivalKey { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="WldFileInformations"/> structure.
+        /// </summary>
+        /// <param name="width">World width.</param>
+        /// <param name="length">World length.</param>
+        /// <param name="mpu">World metters per unit.</param>
+        /// <param name="isIndoor">Flag that indicates if the world is indoor. (eg. dungeon)</param>
+        /// <param name="canFly">Flag that indicates if the world authorizes flying objects.</param>
+        /// <param name="revivalMapId">World revival map id.</param>
+        /// <param name="revivalKey">World revival key.</param>
+        public WldFileInformations(int width, int length, int mpu, bool isIndoor, bool canFly, int revivalMapId, string revivalKey)
+        {
+            this.Width = width;
+            this.Length = length;
+            this.MPU = mpu;
+            this.Indoor = isIndoor;
+            this.Fly = canFly;
+            this.RevivalMapId = revivalMapId;
+            this.RevivalKey = revivalKey;
+        }
+
+        /// <summary>
+        /// Compares the current instance with another <see cref="WldFileInformations"/>.
+        /// </summary>
+        /// <param name="other">Other <see cref="WldFileInformations"/>.</param>
+        /// <returns>True if the same; false otherwise.</returns>
+        public bool Equals(WldFileInformations other) 
+            => (this.Width, this.Length, this.MPU, this.Indoor, this.Fly, this.RevivalMapId, this.RevivalKey) ==
+               (other.Width, other.Length, other.MPU, other.Indoor, other.Fly, other.RevivalMapId, other.RevivalKey);
+    }
+}

--- a/src/Rhisis.World/Game/Core/Context.cs
+++ b/src/Rhisis.World/Game/Core/Context.cs
@@ -33,13 +33,19 @@ namespace Rhisis.World.Game.Core
             if (entity == null)
                 throw new RhisisException($"An error occured while creating an entity of type {typeof(TEntity)}");
 
+            this.AddEntity(entity);
+
+            return (TEntity)entity;
+        }
+
+        /// <inheritdoc />
+        public void AddEntity(IEntity entity)
+        {
             lock (SyncRoot)
             {
                 if (!this._entities.TryAdd(entity.Id, entity))
                     throw new RhisisException($"An error occured while adding the entity to the context list.");
             }
-
-            return (TEntity)entity;
         }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/Game/Core/Entity.cs
+++ b/src/Rhisis.World/Game/Core/Entity.cs
@@ -18,7 +18,7 @@ namespace Rhisis.World.Game.Core
         public uint Id { get; }
 
         /// <inheritdoc />
-        public IContext Context { get; }
+        public IContext Context { get; private set; }
 
         /// <inheritdoc />
         public abstract WorldEntityType Type { get; }
@@ -47,6 +47,14 @@ namespace Rhisis.World.Game.Core
 
         /// <inheritdoc />
         public void Delete() => this.Context.DeleteEntity(this);
+
+        /// <inheritdoc />
+        public void SwitchContext(IContext newContext)
+        {
+            this.Delete();
+            this.Context = newContext;
+            this.Context.AddEntity(this);
+        }
 
         /// <inheritdoc />
         public bool Equals(IEntity x, IEntity y) => x.Equals(y);

--- a/src/Rhisis.World/Game/Core/IContext.cs
+++ b/src/Rhisis.World/Game/Core/IContext.cs
@@ -21,6 +21,12 @@ namespace Rhisis.World.Game.Core
         TEntity CreateEntity<TEntity>() where TEntity : IEntity;
 
         /// <summary>
+        /// Adds an existing entity to the current context.
+        /// </summary>
+        /// <param name="entity">Entity to add.</param>
+        void AddEntity(IEntity entity);
+
+        /// <summary>
         /// Find an entity in this context.
         /// </summary>
         /// <typeparam name="TEntity">Entity type</typeparam>

--- a/src/Rhisis.World/Game/Core/IEntity.cs
+++ b/src/Rhisis.World/Game/Core/IEntity.cs
@@ -49,5 +49,11 @@ namespace Rhisis.World.Game.Core
         /// Deletes this entity from the current context.
         /// </summary>
         void Delete();
+
+        /// <summary>
+        /// Switch to another context.
+        /// </summary>
+        /// <param name="newContext">New context</param>
+        void SwitchContext(IContext newContext);
     }
 }

--- a/src/Rhisis.World/Game/Loaders/MapLoader.cs
+++ b/src/Rhisis.World/Game/Loaders/MapLoader.cs
@@ -3,8 +3,10 @@ using Rhisis.Core.Resources;
 using Rhisis.Core.Resources.Loaders;
 using Rhisis.Core.Structures.Configuration;
 using Rhisis.World.Game.Maps;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Rhisis.World.Game.Loaders
 {
@@ -86,5 +88,12 @@ namespace Rhisis.World.Game.Loaders
         /// <param name="id">Map id</param>
         /// <returns>Map if exists, null otherwise</returns>
         public IMapInstance GetMapById(int id) => this._maps.TryGetValue(id, out IMapInstance value) ? value : null;
+
+        /// <summary>
+        /// Gets a map matching the given predicate.
+        /// </summary>
+        /// <param name="predicate">Predicate.</param>
+        /// <returns>Map that matches the given predicat.</returns>
+        public IMapInstance GetMap(Func<IMapInstance, bool> predicate) => this._maps.Values.FirstOrDefault(predicate);
     }
 }

--- a/src/Rhisis.World/Game/Maps/IMapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/IMapInstance.cs
@@ -30,16 +30,6 @@ namespace Rhisis.World.Game.Maps
         IReadOnlyList<IMapRegion> Regions { get; }
 
         /// <summary>
-        /// Load NPC from the DYO file.
-        /// </summary>
-        void LoadDyo();
-
-        /// <summary>
-        /// Load regions from the RGN file.
-        /// </summary>
-        void LoadRgn();
-
-        /// <summary>
         /// Creates a new map layer and gives it a random id.
         /// </summary>
         /// <returns></returns>

--- a/src/Rhisis.World/Game/Maps/IMapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/IMapInstance.cs
@@ -1,4 +1,5 @@
-﻿using Rhisis.World.Game.Core;
+﻿using Rhisis.Core.Structures;
+using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Maps.Regions;
 using System.Collections.Generic;
 
@@ -18,6 +19,11 @@ namespace Rhisis.World.Game.Maps
         /// Gets the map name.
         /// </summary>
         string Name { get; }
+
+        /// <summary>
+        /// Gets the map default revival region.
+        /// </summary>
+        IMapRevivalRegion DefaultRevivalRegion { get; }
 
         /// <summary>
         /// Gets the map layers.
@@ -70,5 +76,35 @@ namespace Rhisis.World.Game.Maps
         /// Stops the context and the task.
         /// </summary>
         void StopUpdateTask();
+
+        /// <summary>
+        /// Gets the nearest revival region from a given position.
+        /// </summary>
+        /// <param name="position">Position.</param>
+        /// <returns>The nearest revival region.</returns>
+        IMapRevivalRegion GetNearRevivalRegion(Vector3 position);
+
+        /// <summary>
+        /// Gets the nearest revival region from a given position and if the region should be for chao mode (PK mode).
+        /// </summary>
+        /// <param name="position">Position.</param>
+        /// <param name="isChaoMode">Region is chao mode (PK mode).</param>
+        /// <returns>The nearest revival region.</returns>
+        IMapRevivalRegion GetNearRevivalRegion(Vector3 position, bool isChaoMode);
+
+        /// <summary>
+        /// Gets a revival region by his key.
+        /// </summary>
+        /// <param name="revivalKey">Revival region key.</param>
+        /// <returns>Revival region matching the key.</returns>
+        IMapRevivalRegion GetRevivalRegion(string revivalKey);
+
+        /// <summary>
+        /// Gets a revival region by his key and if the region should be for chao mode (PK mode).
+        /// </summary>
+        /// <param name="revivalKey">Revival region key.</param>
+        /// <param name="isChaoMode">Region is chao mode (PK mode).</param>
+        /// <returns>Revival region matching the key and the chao mode.</returns>
+        IMapRevivalRegion GetRevivalRegion(string revivalKey, bool isChaoMode);
     }
 }

--- a/src/Rhisis.World/Game/Maps/MapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/MapInstance.cs
@@ -133,8 +133,7 @@ namespace Rhisis.World.Game.Maps
                     {
                         case RegionInfo.RI_REVIVAL:
                             int revivalMapId = this._worldInformations.RevivalMapId == 0 ? this.Id : this._worldInformations.RevivalMapId;
-                            var newRevivalRegion = new MapRevivalRegion(region.Left, region.Top, region.Right, region.Bottom,
-                                revivalMapId, region.Key, region.Position.Clone());
+                            var newRevivalRegion = MapRevivalRegion.FromRgnElement(region, revivalMapId);
                             this._regions.Add(newRevivalRegion);
 
                             if (this._worldInformations.RevivalMapId != 0) // Set global revival region

--- a/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
@@ -1,0 +1,25 @@
+﻿using Rhisis.Core.Structures;
+
+namespace Rhisis.World.Game.Maps.Regions
+{
+    /// <summary>
+    /// Defines the behavior of a revival region.
+    /// </summary>
+    public interface IMapRevivalRegion : IMapRegion
+    {
+        /// <summary>
+        /// Gets the revival region's map id.
+        /// </summary>
+        int MapId { get; }
+
+        /// <summary>
+        /// Gets the revival region's map key.
+        /// </summary>
+        string Key { get; }
+
+        /// <summary>
+        /// Gets the revival position.
+        /// </summary>
+        Vector3 RevivalPosition { get; }
+    }
+}

--- a/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
@@ -18,6 +18,12 @@ namespace Rhisis.World.Game.Maps.Regions
         string Key { get; }
 
         /// <summary>
+        /// Gets a value that indicates if the region is a revival region for player that has killed other players.
+        /// Related to the PK Mode. (Chao mode)
+        /// </summary>
+        bool IsChaoRegion { get; }
+
+        /// <summary>
         /// Gets the revival position.
         /// </summary>
         Vector3 RevivalPosition { get; }

--- a/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
@@ -1,4 +1,5 @@
-﻿using Rhisis.Core.Structures;
+﻿using Rhisis.Core.Resources;
+using Rhisis.Core.Structures;
 
 namespace Rhisis.World.Game.Maps.Regions
 {
@@ -9,6 +10,9 @@ namespace Rhisis.World.Game.Maps.Regions
 
         /// <inheritdoc />
         public string Key { get; }
+
+        /// <inheritdoc />
+        public bool IsChaoRegion { get; }
 
         /// <inheritdoc />
         public Vector3 RevivalPosition { get; }
@@ -23,12 +27,24 @@ namespace Rhisis.World.Game.Maps.Regions
         /// <param name="mapId">Revival map id.</param>
         /// <param name="key">Revival map key.</param>
         /// <param name="position">Revival position.</param>
-        public MapRevivalRegion(int x, int z, int width, int length, int mapId, string key, Vector3 position)
+        /// <param name="isChao">Indicates that the region is a revival region for PK players.</param>
+        public MapRevivalRegion(int x, int z, int width, int length, int mapId, string key, Vector3 position, bool isChao)
             : base(x, z, width, length)
         {
             this.MapId = mapId;
             this.Key = key;
             this.RevivalPosition = position;
+            this.IsChaoRegion = isChao;
         }
+
+        /// <summary>
+        /// Creates a new <see cref="MapRevivalRegion"/> instance from an <see cref="RgnRegion3"/> element.
+        /// </summary>
+        /// <param name="region"><see cref="RgnRegion3"/> instance.</param>
+        /// <param name="revivalMapId">Revival map id.</param>
+        /// <returns>New <see cref="MapRevivalRegion"/> instance.</returns>
+        public static IMapRevivalRegion FromRgnElement(RgnRegion3 region, int revivalMapId)
+            => new MapRevivalRegion(region.Left, region.Top, region.Right, region.Bottom,
+                                    revivalMapId, region.Key, region.Position.Clone(), region.ChaoKey);
     }
 }

--- a/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
@@ -1,0 +1,34 @@
+﻿using Rhisis.Core.Structures;
+
+namespace Rhisis.World.Game.Maps.Regions
+{
+    public class MapRevivalRegion : MapRegion, IMapRevivalRegion
+    {
+        /// <inheritdoc />
+        public int MapId { get; }
+
+        /// <inheritdoc />
+        public string Key { get; }
+
+        /// <inheritdoc />
+        public Vector3 RevivalPosition { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="MapRevivalRegion"/> instance.
+        /// </summary>
+        /// <param name="x">Region X position on the world.</param>
+        /// <param name="z">Region Z position on the world.</param>
+        /// <param name="width">Region width.</param>
+        /// <param name="length">Region length.</param>
+        /// <param name="mapId">Revival map id.</param>
+        /// <param name="key">Revival map key.</param>
+        /// <param name="position">Revival position.</param>
+        public MapRevivalRegion(int x, int z, int width, int length, int mapId, string key, Vector3 position)
+            : base(x, z, width, length)
+        {
+            this.MapId = mapId;
+            this.Key = key;
+            this.RevivalPosition = position;
+        }
+    }
+}

--- a/src/Rhisis.World/Handlers/PlayerHandler.cs
+++ b/src/Rhisis.World/Handlers/PlayerHandler.cs
@@ -6,7 +6,9 @@ using Rhisis.Core.Structures;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World;
+using Rhisis.World.Game.Maps.Regions;
 using Rhisis.World.Packets;
+using Rhisis.World.Systems.Death;
 using Rhisis.World.Systems.Follow;
 using Rhisis.World.Systems.PlayerData;
 using Rhisis.World.Systems.PlayerData.EventArgs;
@@ -111,6 +113,18 @@ namespace Rhisis.World.Handlers
                 playerBehaviorPacket.Loop,
                 playerBehaviorPacket.MotionOption,
                 playerBehaviorPacket.TickCount);
+        }
+
+        [PacketHandler(PacketType.REVIVAL_TO_LODESTAR)]
+        public static void OnRevivalToLodestar(WorldClient client, INetPacketStream _)
+        {
+            if (!client.Player.Health.IsDead)
+            {
+                Logger.LogWarning($"Player '{client.Player.Object.Name}' tried to revival to lodestar without being dead.");
+                return;
+            }
+
+            client.Player.NotifySystem<DeathSystem>();
         }
     }
 }

--- a/src/Rhisis.World/Packets/MoverPackets.cs
+++ b/src/Rhisis.World/Packets/MoverPackets.cs
@@ -3,6 +3,7 @@ using Rhisis.Core.Structures;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Entities;
 
 namespace Rhisis.World.Packets
 {
@@ -79,6 +80,45 @@ namespace Rhisis.World.Packets
                 packet.Write(tickCount);
 
                 SendToVisible(packet, entity, sendToPlayer: false);
+            }
+        }
+
+        public static void SendDestinationPosition(IMovableEntity movableEntity)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(movableEntity.Id, SnapshotType.DESTPOS);
+                packet.Write(movableEntity.MovableComponent.DestinationPosition.X);
+                packet.Write(movableEntity.MovableComponent.DestinationPosition.Y);
+                packet.Write(movableEntity.MovableComponent.DestinationPosition.Z);
+                packet.Write<byte>(1);
+
+                SendToVisible(packet, movableEntity);
+            }
+        }
+
+        public static void SendMoverPosition(IEntity entity)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(entity.Id, SnapshotType.SETPOS);
+                packet.Write(entity.Object.Position.X);
+                packet.Write(entity.Object.Position.Y);
+                packet.Write(entity.Object.Position.Z);
+
+                SendToVisible(packet, entity, sendToPlayer: true);
+            }
+        }
+
+        public static void SendDestinationAngle(IEntity entity, bool left)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(entity.Id, SnapshotType.DESTANGLE);
+                packet.Write(entity.Object.Angle);
+                packet.Write(left);
+
+                SendToVisible(packet, entity);
             }
         }
     }

--- a/src/Rhisis.World/Packets/PlayerPackets.cs
+++ b/src/Rhisis.World/Packets/PlayerPackets.cs
@@ -1,0 +1,38 @@
+﻿using Rhisis.Network;
+using Rhisis.Network.Packets;
+using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World.Packets
+{
+    public static partial class WorldPacketFactory
+    {
+        /// <summary>
+        /// Sends player revival packet.
+        /// </summary>
+        /// <param name="entity"></param>
+        public static void SendPlayerRevival(IEntity entity)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(entity.Id, SnapshotType.REVIVAL_TO_LODESTAR);
+
+                SendToVisible(packet, entity, sendToPlayer: true);
+            }
+        }
+
+        public static void SendReplaceObject(IPlayerEntity player)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.REPLACE);
+                packet.Write(player.Object.MapId);
+                packet.Write(player.Object.Position.X);
+                packet.Write(player.Object.Position.Y);
+                packet.Write(player.Object.Position.Z);
+
+                player.Connection.Send(packet);
+            }
+        }
+    }
+}

--- a/src/Rhisis.World/Packets/WorldPacketFactory.cs
+++ b/src/Rhisis.World/Packets/WorldPacketFactory.cs
@@ -24,32 +24,6 @@ namespace Rhisis.World.Packets
                 player.Connection.Send(packet);
         }
 
-        public static void SendDestinationPosition(IMovableEntity movableEntity)
-        {
-            using (var packet = new FFPacket())
-            {
-                packet.StartNewMergedPacket(movableEntity.Id, SnapshotType.DESTPOS);
-                packet.Write(movableEntity.MovableComponent.DestinationPosition.X);
-                packet.Write(movableEntity.MovableComponent.DestinationPosition.Y);
-                packet.Write(movableEntity.MovableComponent.DestinationPosition.Z);
-                packet.Write<byte>(1);
-
-                SendToVisible(packet, movableEntity);
-            }
-        }
-
-        public static void SendDestinationAngle(IEntity entity, bool left)
-        {
-            using (var packet = new FFPacket())
-            {
-                packet.StartNewMergedPacket(entity.Id, SnapshotType.DESTANGLE);
-                packet.Write(entity.Object.Angle);
-                packet.Write(left);
-
-                SendToVisible(packet, entity);
-            }
-        }
-
         public static void SendFollowTarget(IEntity entity, IEntity targetEntity, float distance)
         {
             using (var packet = new FFPacket())

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Helpers;
 using Rhisis.Core.IO;
@@ -79,6 +80,7 @@ namespace Rhisis.World.Systems.Battle
             WorldPacketFactory.SendMeleeAttack(attacker, e.AttackType, defender.Id, e.UnknownParameter, meleeAttackResult.Flags);
 
             defender.Health.Hp -= meleeAttackResult.Damages;
+            WorldPacketFactory.SendUpdateAttributes(defender, DefineAttributes.HP, defender.Health.Hp);
 
             if (defender.Health.IsDead)
             {
@@ -86,10 +88,11 @@ namespace Rhisis.World.Systems.Battle
                 defender.Health.Hp = 0;
                 this.ClearBattleTargets(defender);
                 this.ClearBattleTargets(attacker);
-                WorldPacketFactory.SendDie(attacker as IPlayerEntity, defender, attacker, e.AttackType);
+                WorldPacketFactory.SendUpdateAttributes(defender, DefineAttributes.HP, defender.Health.Hp);
 
                 if (defender is IMonsterEntity deadMonster)
                 {
+                    WorldPacketFactory.SendDie(attacker as IPlayerEntity, defender, attacker, e.AttackType);
                     var worldServerConfiguration = DependencyContainer.Instance.Resolve<WorldConfiguration>();
                     var itemsData = DependencyContainer.Instance.Resolve<ItemLoader>();
                     var expTable = DependencyContainer.Instance.Resolve<ExpTableLoader>();
@@ -146,6 +149,10 @@ namespace Rhisis.World.Systems.Battle
                     deadMonster.NotifySystem<DropSystem>(new DropGoldEventArgs(goldDropped, attacker));
 
                     // TODO: give exp
+                }
+                else if (defender is IPlayerEntity deadPlayer)
+                {
+                    WorldPacketFactory.SendDie(deadPlayer, defender, attacker, e.AttackType);
                 }
             }
         }

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -1,0 +1,89 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.Common.Formulas;
+using Rhisis.Core.Data;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Loaders;
+using Rhisis.World.Game.Maps;
+using Rhisis.World.Game.Maps.Regions;
+using Rhisis.World.Packets;
+
+namespace Rhisis.World.Systems.Death
+{
+    [System(SystemType.Notifiable)]
+    public sealed class DeathSystem : ISystem
+    {
+        private const float RecoveryRate = 0.2f;
+
+        private readonly ILogger<DeathSystem> _logger = DependencyContainer.Instance.Resolve<ILogger<DeathSystem>>();
+        private readonly MapLoader _mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
+
+        public WorldEntityType Type => WorldEntityType.Player;
+
+        public void Execute(IEntity entity, SystemEventArgs args)
+        {
+            if (!(entity is IPlayerEntity player))
+            {
+                this._logger.LogError($"Cannot execute DeathSystem. {entity.Object.Name} is not a player.");
+                return;
+            }
+
+            IMapRevivalRegion revivalRegion = player.Object.CurrentMap.GetNearRevivalRegion(player.Object.Position);
+
+            if (revivalRegion == null)
+            {
+                this._logger.LogError($"Cannot find any revival region for map '{player.Object.CurrentMap.Name}'.");
+                return;
+            }
+
+            var jobData = player.PlayerData.JobData;
+            var playerStats = player.Statistics;
+
+            player.Health.Hp = (int)(HealthFormulas.GetMaxOriginHp(player.Object.Level, playerStats.Stamina, jobData.MaxHpFactor) * RecoveryRate);
+            player.Health.Mp = (int)(HealthFormulas.GetMaxOriginMp(player.Object.Level, playerStats.Intelligence, jobData.MaxMpFactor, true) * RecoveryRate);
+            player.Health.Fp = (int)(HealthFormulas.GetMaxOriginFp(player.Object.Level, playerStats.Stamina, playerStats.Dexterity, playerStats.Strength, jobData.MaxFpFactor, true) * RecoveryRate);
+
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.HP, player.Health.Hp);
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.MP, player.Health.Mp);
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.FP, player.Health.Fp);
+
+            bool shouldReplace = false;
+            if (revivalRegion.MapId != player.Object.MapId)
+            {
+                IMapInstance revivalMap = this._mapLoader.GetMapById(revivalRegion.MapId);
+
+                if (revivalMap == null)
+                {
+                    this._logger.LogError($"Cannot find revival map with id '{revivalRegion.MapId}'.");
+                    player.Connection.Server.DisconnectClient(player.Connection.Id);
+                    return;
+                }
+
+                IMapLayer revivalMapLayer = revivalMap.GetDefaultMapLayer();
+                player.SwitchContext(revivalMapLayer);
+                player.Object.Spawned = false;
+                player.Object.MapId = revivalMap.Id;
+                player.Object.LayerId = revivalMapLayer.Id;
+
+                shouldReplace = true;
+                revivalRegion = revivalMap.GetRevivalRegion(revivalRegion.Key);
+            }
+
+            player.Object.Position = revivalRegion.RevivalPosition.Clone();
+            player.MovableComponent.DestinationPosition = revivalRegion.RevivalPosition.Clone();
+
+            if (shouldReplace)
+            {
+                WorldPacketFactory.SendReplaceObject(player);
+                WorldPacketFactory.SendPlayerSpawn(player);
+                player.Object.Spawned = true;
+            }
+
+            WorldPacketFactory.SendMotion(player, ObjectMessageType.OBJMSG_ACC_STOP | ObjectMessageType.OBJMSG_STOP_TURN | ObjectMessageType.OBJMSG_STAND);
+            WorldPacketFactory.SendPlayerRevival(player);
+            WorldPacketFactory.SendMoverPosition(player);
+        }
+    }
+}


### PR DESCRIPTION
This PR covers issue #30 about the Death System. It includes the following changes and features:
- Loads the maps `.wld` files to get revival information
- Loads revival regions from maps `.rgn` files tagged as `region3` with index `RI_REVIVAL (13)` 
- Gets the nearest revival position when on the same map. (PK mode included)
- When map doesn't have any revival regions, checks the `.wld` revival information and proceed revival on the specified map id and revival key.
