### PR TITLE
Add multiple dialog texts on DialogLinks. Allow next button on game

### DIFF
--- a/bin/data/dialogs/en/MaFl_Amos.json
+++ b/bin/data/dialogs/en/MaFl_Amos.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Amos",
-	"oralText": "Welcome, Flarinians! Sign up here for entry into the 1vs1 Guild Siege!",
-	"introText": "A guild is only as strong as it's weakest member, my friend, and this is where we separate the bark from the bite. Test your mettle in the 1vs1 Guild Siege if you think you're strong enough!",
-	"byeText": "For Glory!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Greetings, adventurer! If you;re interesting in providing your worth in the 1vs1 Guild Siege, then I am the guy to talk to. My name is Amos and i am the 1vs1 Guild Siege Manager for Flarine.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "For Glory!"
-		}
-	]
+  "name": "MaFl_Amos",
+  "oralText": "Welcome, Flarinians! Sign up here for entry into the 1vs1 Guild Siege!",
+  "introText": "A guild is only as strong as it's weakest member, my friend, and this is where we separate the bark from the bite. Test your mettle in the 1vs1 Guild Siege if you think you're strong enough!",
+  "byeText": "For Glory!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Greetings, adventurer! If you;re interesting in providing your worth in the 1vs1 Guild Siege, then I am the guy to talk to. My name is Amos and i am the 1vs1 Guild Siege Manager for Flarine."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "For Glory!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Annie.json
+++ b/bin/data/dialogs/en/MaFl_Annie.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Annie",
-	"oralText": "Please visit me if you have any questions about the 1vs1 Guild Siege.",
-	"introText": "Why hello there, young one. You certainly look strong! I bet you could even handle 1v2! Hahaha! Yes, I'm lying... you'll probably last about 2 seconds.",
-	"byeText": "Toodles!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Okay, on a serious note, my name is Anny and I am the Rewards Manager for the 1vs1 Guild Siege. Stop by anytime if you need to pick up your rewards, require some information, or would like to hear more or my witty sarcasm.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Toodles!"
-		}
-	]
+  "name": "MaFl_Annie",
+  "oralText": "Please visit me if you have any questions about the 1vs1 Guild Siege.",
+  "introText": "Why hello there, young one. You certainly look strong! I bet you could even handle 1v2! Hahaha! Yes, I'm lying... you'll probably last about 2 seconds.",
+  "byeText": "Toodles!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Okay, on a serious note, my name is Anny and I am the Rewards Manager for the 1vs1 Guild Siege. Stop by anytime if you need to pick up your rewards, require some information, or would like to hear more or my witty sarcasm."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Toodles!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Bobochan.json
+++ b/bin/data/dialogs/en/MaFl_Bobochan.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Bobochan",
-	"oralText": "Step right up, adventurers! BoBoChan's Upgrade Shop is open for business!",
-	"introText": "Rhisis have mercy on this poor soul. You actually fight monsters with that?! Good grief! Please, allow me to help you upgrade it...",
-	"byeText": "Goodbye, friend! Remember, for the best upgrades in Madrigal, visit BoBoChan!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "What, you haven't heard of me? I'm BoBoChan, the most well known upgrade specialist in all of Madrigal. I love what I do, and people come from all over the world for my services.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Goodbye, friend! Remember, for the best upgrades in Madrigal, visit BoBoChan!"
-		}
-	]
+  "name": "MaFl_Bobochan",
+  "oralText": "Step right up, adventurers! BoBoChan's Upgrade Shop is open for business!",
+  "introText": "Rhisis have mercy on this poor soul. You actually fight monsters with that?! Good grief! Please, allow me to help you upgrade it...",
+  "byeText": "Goodbye, friend! Remember, for the best upgrades in Madrigal, visit BoBoChan!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "What, you haven't heard of me? I'm BoBoChan, the most well known upgrade specialist in all of Madrigal. I love what I do, and people come from all over the world for my services."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Goodbye, friend! Remember, for the best upgrades in Madrigal, visit BoBoChan!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Boboko.json
+++ b/bin/data/dialogs/en/MaFl_Boboko.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Boboko",
-	"oralText": "The perfect shields of the Bobo family are only here, in the Shield Shop of Boboku!",
-	"introText": "You won't find a better armor selection in all of Flaris, I'll guarantee you that!",
-	"byeText": "Tell your friends buy Bobo Family Equipment!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Who am I? You must be joking. I'm only the most famous armorer in Flarine! I'm Boboko Bobo and I run the Bobo family Armor Shop for new Mercenaries, Acrobats and Assists.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Tell your friends buy Bobo Family Equipment!"
-		}
-	]
+  "name": "MaFl_Boboko",
+  "oralText": "The perfect shields of the Bobo family are only here, in the Shield Shop of Boboku!",
+  "introText": "You won't find a better armor selection in all of Flaris, I'll guarantee you that!",
+  "byeText": "Tell your friends buy Bobo Family Equipment!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Who am I? You must be joking. I'm only the most famous armorer in Flarine! I'm Boboko Bobo and I run the Bobo family Armor Shop for new Mercenaries, Acrobats and Assists."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Tell your friends buy Bobo Family Equipment!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Boboku.json
+++ b/bin/data/dialogs/en/MaFl_Boboku.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Boboku",
-	"oralText": "Your weapon is looking a little dull there, friend. Thank Rhisis for you, I buy and sell weapons!",
-	"introText": "*sigh* Oh, sorry! I was daydreaming about Julia over there. She's so amazing! Hey, do you think a girl like her and a guy like me could ever be? What? How could she resist me?!",
-	"byeText": "Thanks for stopping by! Tell Julia I said hello!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Greetings from the Bobo Family, stranger! I am Boboku Bobo. I run the Weapon Shop here in Flarine. Have a look around and don't forget to visit my brother's shops!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Thanks for stopping by! Tell Julia I said hello!"
-		}
-	]
+  "name": "MaFl_Boboku",
+  "oralText": "Your weapon is looking a little dull there, friend. Thank Rhisis for you, I buy and sell weapons!",
+  "introText": "*sigh* Oh, sorry! I was daydreaming about Julia over there. She's so amazing! Hey, do you think a girl like her and a guy like me could ever be? What? How could she resist me?!",
+  "byeText": "Thanks for stopping by! Tell Julia I said hello!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Greetings from the Bobo Family, stranger! I am Boboku Bobo. I run the Weapon Shop here in Flarine. Have a look around and don't forget to visit my brother's shops!"
+	  ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Thanks for stopping by! Tell Julia I said hello!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_CardMaster.json
+++ b/bin/data/dialogs/en/MaFl_CardMaster.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_CardMaster",
-	"oralText": "If you need any weapon or armor piercing cards converted, I'm your gal!",
-	"introText": "Welcome, adventurer! If you have 10 piercing cards, I will attempt to convert the 10 that you give me into 1 card of the next level. I can;t offer any guarantees, however, as sometimes you may only get back 1 of the  same type of card.",
-	"byeText": "Stop by anytime, my friend!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "I'm the Card Master. After hearing about all the wonderful card being thrown away, I decided to offer my services to the city of Flarine.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Stop by anytime, my friend!"
-		}
-	]
+  "name": "MaFl_CardMaster",
+  "oralText": "If you need any weapon or armor piercing cards converted, I'm your gal!",
+  "introText": "Welcome, adventurer! If you have 10 piercing cards, I will attempt to convert the 10 that you give me into 1 card of the next level. I can;t offer any guarantees, however, as sometimes you may only get back 1 of the  same type of card.",
+  "byeText": "Stop by anytime, my friend!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I'm the Card Master. After hearing about all the wonderful card being thrown away, I decided to offer my services to the city of Flarine."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Stop by anytime, my friend!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Charlie.json
+++ b/bin/data/dialogs/en/MaFl_Charlie.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "Mafl_Charlie",
-	"oralText": "If you need to access your house, or would like to buy some furniture, I'm your man!",
-	"introText": "Hello there! I sell furniture so you can decorate your house to fit your style. Amazing, right?! How about inviting your friends over to show it off? Your house can also be used as private meeting place for your guild.",
-	"byeText": "Remember, decorating your house is important if you want to entertain your guests!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Charlie and I make various types of furniture that you can use to decorate your house! My furniture is the best in Madrigal!!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Remember, decorating your house is important if you want to entertain your guests!"
-		}
-	]
+  "name": "Mafl_Charlie",
+  "oralText": "If you need to access your house, or would like to buy some furniture, I'm your man!",
+  "introText": "Hello there! I sell furniture so you can decorate your house to fit your style. Amazing, right?! How about inviting your friends over to show it off? Your house can also be used as private meeting place for your guild.",
+  "byeText": "Remember, decorating your house is important if you want to entertain your guests!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Charlie and I make various types of furniture that you can use to decorate your house! My furniture is the best in Madrigal!!"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Remember, decorating your house is important if you want to entertain your guests!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Donaris.json
+++ b/bin/data/dialogs/en/MaFl_Donaris.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Donaris",
-	"oralText": "Check in here to review the weekly results of the Guild Siege!",
-	"introText": "Only the most cunning of guilds can hope to achieve victory in the Guild Sieges. Are you ready for the challenge?",
-	"byeText": "Good luck to you! I hope I see you in ranking charts!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Hello, it's very nice to meet you! I am the Reward Manager for the Guild Siege Center. I can reward prize money, return application fees, or even show you this week's ranking for the Guild Siege.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Good luck to you! I hope I see you in ranking charts!"
-		}
-	]
+  "name": "MaFl_Donaris",
+  "oralText": "Check in here to review the weekly results of the Guild Siege!",
+  "introText": "Only the most cunning of guilds can hope to achieve victory in the Guild Sieges. Are you ready for the challenge?",
+  "byeText": "Good luck to you! I hope I see you in ranking charts!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Hello, it's very nice to meet you! I am the Reward Manager for the Guild Siege Center. I can reward prize money, return application fees, or even show you this week's ranking for the Guild Siege."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Good luck to you! I hope I see you in ranking charts!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_FlaMayor.json
+++ b/bin/data/dialogs/en/MaFl_FlaMayor.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_FlaMayor",
-	"oralText": "Welcome to Flarine! Please, enjoy your stay!",
-	"introText": "Flarine is the capital city of Madrigal. It may be a small city, but it's certainly the most beautiful. Feel free to come see me if you ever need anything.",
-	"byeText": "We have a Guild Siege every Saturday. Speak to the Guild Siege Managers for more information!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "I am the mayor of Flarine. The well-being of the citizens is my highest priority. Is there anything I can help you with?",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "We have a Guild Siege every Saturday. Speak to the Guild Siege Managers for more information!"
-		}
-	]
+  "name": "MaFl_FlaMayor",
+  "oralText": "Welcome to Flarine! Please, enjoy your stay!",
+  "introText": "Flarine is the capital city of Madrigal. It may be a small city, but it's certainly the most beautiful. Feel free to come see me if you ever need anything.",
+  "byeText": "We have a Guild Siege every Saturday. Speak to the Guild Siege Managers for more information!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am the mayor of Flarine. The well-being of the citizens is my highest priority. Is there anything I can help you with?"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "We have a Guild Siege every Saturday. Speak to the Guild Siege Managers for more information!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_GUILDHOUSESALE.json
+++ b/bin/data/dialogs/en/MaFl_GUILDHOUSESALE.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_GUILDHOUSESALE",
-	"oralText": "Talk to me if you would like to learn about Guild Houses.",
-	"introText": "Every guild deserves a home to call their own, don't you agree? Besides, I hear the buffs come in very handy!",
-	"byeText": "I know my service don't come cheap, but I think you will find they are definitely worth it. Think about it for a little while.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Hello! My name is Bertha. I am currently selling property to guilds that need a little extra space.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "I know my service don't come cheap, but I think you will find they are definitely worth it. Think about it for a little while."
-		}
-	]
+  "name": "MaFl_GUILDHOUSESALE",
+  "oralText": "Talk to me if you would like to learn about Guild Houses.",
+  "introText": "Every guild deserves a home to call their own, don't you agree? Besides, I hear the buffs come in very handy!",
+  "byeText": "I know my service don't come cheap, but I think you will find they are definitely worth it. Think about it for a little while.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Hello! My name is Bertha. I am currently selling property to guilds that need a little extra space."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "I know my service don't come cheap, but I think you will find they are definitely worth it. Think about it for a little while."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Gergantes.json
+++ b/bin/data/dialogs/en/MaFl_Gergantes.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Gergantes",
-	"oralText": "*scribbles* Ah, yes! This is good stuff... I'm such a great writer! Now I just need a good protagonist...",
-	"introText": "I am writing one of my best novels yet! It's action-packed, fast faced, dark, and even a little scary! It's about this hero who enters a dark cave and... well  wait, if I tell you, you might steal my idea! Who are you anyway!?",
-	"byeText": "My next novel will be a best seller, I'm sure! Keep an eye out for it!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Pleased to meet you! My name is Gergantes Hambert. I live here in Flarine and I love it. I am a famous novelist as well as a Chairman of the Publication Society. Do you like to read?",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "My next novel will be a best seller, I'm sure! Keep an eye out for it!"
-		}
-	]
+  "name": "MaFl_Gergantes",
+  "oralText": "*scribbles* Ah, yes! This is good stuff... I'm such a great writer! Now I just need a good protagonist...",
+  "introText": "I am writing one of my best novels yet! It's action-packed, fast faced, dark, and even a little scary! It's about this hero who enters a dark cave and... well  wait, if I tell you, you might steal my idea! Who are you anyway!?",
+  "byeText": "My next novel will be a best seller, I'm sure! Keep an eye out for it!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Pleased to meet you! My name is Gergantes Hambert. I live here in Flarine and I love it. I am a famous novelist as well as a Chairman of the Publication Society. Do you like to read?"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "My next novel will be a best seller, I'm sure! Keep an eye out for it!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_GuildWar.json
+++ b/bin/data/dialogs/en/MaFl_GuildWar.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_GuildWar",
-	"oralText": "Welcome, competitors! The Guild Siege Application Center is open for business!",
-	"introText": "If your guild has reached the point where you think you have the strength and numbers to compete against another guild, then you're in the right place. Prove to everyone that you;re able to become a legend like Badza!",
-	"byeText": "For Glory!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "It's pleasure to make your acquaintance. I am the Guild Siege Master of Flarine. Speak with me if you need general Guild Siege information, want to apply, form your party, or enter the arena.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "For Glory!"
-		}
-	]
+  "name": "MaFl_GuildWar",
+  "oralText": "Welcome, competitors! The Guild Siege Application Center is open for business!",
+  "introText": "If your guild has reached the point where you think you have the strength and numbers to compete against another guild, then you're in the right place. Prove to everyone that you;re able to become a legend like Badza!",
+  "byeText": "For Glory!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "It's pleasure to make your acquaintance. I am the Guild Siege Master of Flarine. Speak with me if you need general Guild Siege information, want to apply, form your party, or enter the arena."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "For Glory!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Helper_ver12.json
+++ b/bin/data/dialogs/en/MaFl_Helper_ver12.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Helper_ver12",
-	"oralText": "New to Madrigal? Visit your friendly neighborhood Buff Pang!",
-	"introText": "Hello there! I'm granting buffs to adventurers who haven't completed their second job change yet. Come see me anytime if you ever find yourself in need of a boost to your stats!",
-	"byeText": "Enjoy your stay in Madrigal!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "I am a Buff Pang. There a several of us throughout Madrigal and we are here to help adventurers by applying bonuses to their combat statistic. Are you in need of a buff, my friend?",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Enjoy your stay in Madrigal!"
-		}
-	]
+  "name": "MaFl_Helper_ver12",
+  "oralText": "New to Madrigal? Visit your friendly neighborhood Buff Pang!",
+  "introText": "Hello there! I'm granting buffs to adventurers who haven't completed their second job change yet. Come see me anytime if you ever find yourself in need of a boost to your stats!",
+  "byeText": "Enjoy your stay in Madrigal!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am a Buff Pang. There a several of us throughout Madrigal and we are here to help adventurers by applying bonuses to their combat statistic. Are you in need of a buff, my friend?"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Enjoy your stay in Madrigal!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Jeff.json
+++ b/bin/data/dialogs/en/MaFl_Jeff.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Jeff",
-	"oralText": "*sigh* I miss Kimberly so much. I can barely focus on my duties...",
-	"introText": "Ugh, I still get so many complaints about the machine I sold to Saint City and Darken City. I may have used substandard building materials from the Dekane Mines. Ah well...",
-	"byeText": "Say hello to my wife, kimberly, in Saint City if you happen to see her, will you?",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Jeff Prosis and I am the Machine Developer of Flarine. Kimberly, my wife, is a guide in Saint City.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Say hello to my wife, kimberly, in Saint City if you happen to see her, will you?"
-		}
-	]
+  "name": "MaFl_Jeff",
+  "oralText": "*sigh* I miss Kimberly so much. I can barely focus on my duties...",
+  "introText": "Ugh, I still get so many complaints about the machine I sold to Saint City and Darken City. I may have used substandard building materials from the Dekane Mines. Ah well...",
+  "byeText": "Say hello to my wife, kimberly, in Saint City if you happen to see her, will you?",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Jeff Prosis and I am the Machine Developer of Flarine. Kimberly, my wife, is a guide in Saint City."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Say hello to my wife, kimberly, in Saint City if you happen to see her, will you?"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Juria.json
+++ b/bin/data/dialogs/en/MaFl_Juria.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Juria",
-	"oralText": "Welcome to the Office. of Flarine. How can I be of service?",
-	"introText": "*Sigh* Boboku is so manly, strong and kind. But I could never date him because his belly is too big!",
-	"byeText": "Farewell!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Julia Trinity and I manage the Office of Flarine. How can I help you today?",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Farewell!"
-		}
-	]
+  "name": "MaFl_Juria",
+  "oralText": "Welcome to the Office. of Flarine. How can I be of service?",
+  "introText": "*Sigh* Boboku is so manly, strong and kind. But I could never date him because his belly is too big!",
+  "byeText": "Farewell!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Julia Trinity and I manage the Office of Flarine. How can I help you today?"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Farewell!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Luda.json
+++ b/bin/data/dialogs/en/MaFl_Luda.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Luda",
-	"oralText": "Are you Vagrant? Do you weapons or armor? I've got what you need!",
-	"introText": "Hello, potential customer! Thanks for stopping by! Please, feel free to look at my collection of Vagrant weapons and armor. Careful though, you touch it, you buy it!",
-	"byeText": "Be careful out there. I wouldn't want to lose a potential customer! *Chuckles*",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Luda and I run the Vagrant Store of Flarine. I opened this shop after Boboku and Boboko stopped selling Vagrant items. Now I corner the market, hahaha!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Be careful out there. I wouldn't want to lose a potential customer! *Chuckles*"
-		}
-	]
+  "name": "MaFl_Luda",
+  "oralText": "Are you Vagrant? Do you weapons or armor? I've got what you need!",
+  "introText": "Hello, potential customer! Thanks for stopping by! Please, feel free to look at my collection of Vagrant weapons and armor. Careful though, you touch it, you buy it!",
+  "byeText": "Be careful out there. I wouldn't want to lose a potential customer! *Chuckles*",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Luda and I run the Vagrant Store of Flarine. I opened this shop after Boboku and Boboko stopped selling Vagrant items. Now I corner the market, hahaha!"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there. I wouldn't want to lose a potential customer! *Chuckles*"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Lui.json
+++ b/bin/data/dialogs/en/MaFl_Lui.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Lui",
-	"oralText": "Come one, come all! Get your supplies here! You're gonna need it!",
-	"introText": "Going somewhere? You look a little unprepared, so I'd think twice about leaving Flarine without stocking up on supplies. Good thing for you, I'm here. So, whaddya need?",
-	"byeText": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Who am I? I'm Lui Keraldine, of course. My friends call me Handsome Lui. Since we're not friends, why don't you just call me Lui. If you buy something from my General Store here, I *might* let you call me Handsome.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!"
-		}
-	]
+  "name": "MaFl_Lui",
+  "oralText": "Come one, come all! Get your supplies here! You're gonna need it!",
+  "introText": "Going somewhere? You look a little unprepared, so I'd think twice about leaving Flarine without stocking up on supplies. Good thing for you, I'm here. So, whaddya need?",
+  "byeText": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Who am I? I'm Lui Keraldine, of course. My friends call me Handsome Lui. Since we're not friends, why don't you just call me Lui. If you buy something from my General Store here, I *might* let you call me Handsome."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Martinyc.json
+++ b/bin/data/dialogs/en/MaFl_Martinyc.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Martinyc",
-	"oralText": "The history of Madrigal... strange to say that least. I must discover the secrets!",
-	"introText": "Do you know anything about the history of Madrigal? No? Well I've been uncovering some fascinating information as of late. It seems that much of our history has been conveniently covered up. Interesting, huh?",
-	"byeText": "If you learn of any interesting facts about Madrigal's history, be sure to stop by again!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Nice to meet you My name is Martinyc Tictraibet. I know, it's a difficult name to pronounce , isn't it? Anyway, I'm a historian and I've made it my life's work to discover the secrets of Madrigal and document it's history.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "If you learn of any interesting facts about Madrigal's history, be sure to stop by again!"
-		}
-	]
+  "name": "MaFl_Martinyc",
+  "oralText": "The history of Madrigal... strange to say that least. I must discover the secrets!",
+  "introText": "Do you know anything about the history of Madrigal? No? Well I've been uncovering some fascinating information as of late. It seems that much of our history has been conveniently covered up. Interesting, huh?",
+  "byeText": "If you learn of any interesting facts about Madrigal's history, be sure to stop by again!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Nice to meet you My name is Martinyc Tictraibet. I know, it's a difficult name to pronounce , isn't it? Anyway, I'm a historian and I've made it my life's work to discover the secrets of Madrigal and document it's history."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "If you learn of any interesting facts about Madrigal's history, be sure to stop by again!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Mikyel.json
+++ b/bin/data/dialogs/en/MaFl_Mikyel.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Mikyel",
-	"oralText": "Welcome to the Flarine Quest Office! Looking for work? I may have a job for you...",
-	"introText": "My apologies, there are no quests available for an adventurer of your talent and skill at this time.",
-	"byeText": "Farewell!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Mikyel and I am the manager of Flarine Quest Office. When our citizens post a hunting order or another task, it is my job to find the right candidate for the job. Check back in from time to time to see if I have anything available!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Farewell!"
-		}
-	]
+  "name": "MaFl_Mikyel",
+  "oralText": "Welcome to the Flarine Quest Office! Looking for work? I may have a job for you...",
+  "introText": "My apologies, there are no quests available for an adventurer of your talent and skill at this time.",
+  "byeText": "Farewell!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Mikyel and I am the manager of Flarine Quest Office. When our citizens post a hunting order or another task, it is my job to find the right candidate for the job. Check back in from time to time to see if I have anything available!"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Farewell!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Official.json
+++ b/bin/data/dialogs/en/MaFl_Official.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Official",
-	"oralText": "Welcome to Flarine!",
-	"introText": "The library is located to my right and the reception desk is to my left. You can speak with Julia for access your bank, view ranking information, or browse your Guild Warehouse.",
-	"byeText": "Thank you for visiting the Public Office. For Flarine!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "We Public Officials work directly with the mayor to better Flarine. We are here to serve you. If you have any questions, just ask!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Thank you for visiting the Public Office. For Flarine!"
-		}
-	]
+  "name": "MaFl_Official",
+  "oralText": "Welcome to Flarine!",
+  "introText": "The library is located to my right and the reception desk is to my left. You can speak with Julia for access your bank, view ranking information, or browse your Guild Warehouse.",
+  "byeText": "Thank you for visiting the Public Office. For Flarine!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "We Public Officials work directly with the mayor to better Flarine. We are here to serve you. If you have any questions, just ask!"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Thank you for visiting the Public Office. For Flarine!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Peach.json
+++ b/bin/data/dialogs/en/MaFl_Peach.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Peach",
-	"oralText": "Would anyone like a jewel crafted or perhaps a jewelry setting created ?",
-	"introText": "Hi there! I offer jewelry services to the citizens of Flarine and create and set jewels for those wishing to modify their Ultimate Weapons. I also remove blessings and level reductions from items, among other things!",
-	"byeText": "Take care. Remember, for anything to do with jewels. I'm your girl!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Peach! I'm here to assist Bobochan and help supplement his upgrading business. I also sell Scrolls  of Pet Awakening (Raised Pets) and Scrolls of Awakening. Stop by anytime!",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Take care. Remember, for anything to do with jewels. I'm your girl!"
-		}
-	]
+  "name": "MaFl_Peach",
+  "oralText": "Would anyone like a jewel crafted or perhaps a jewelry setting created ?",
+  "introText": "Hi there! I offer jewelry services to the citizens of Flarine and create and set jewels for those wishing to modify their Ultimate Weapons. I also remove blessings and level reductions from items, among other things!",
+  "byeText": "Take care. Remember, for anything to do with jewels. I'm your girl!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Peach! I'm here to assist Bobochan and help supplement his upgrading business. I also sell Scrolls  of Pet Awakening (Raised Pets) and Scrolls of Awakening. Stop by anytime!"
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Take care. Remember, for anything to do with jewels. I'm your girl!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_PetTamer.json
+++ b/bin/data/dialogs/en/MaFl_PetTamer.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_PetTamer",
-	"oralText": "Raising your own pet takes patience and dedication. Are you ready?",
-	"introText": "Rawr! Tee hee! ^^ Sorry, I was just practicing my tiger call. Do you have a pet? I love pets, it's what I live for!",
-	"byeText": "Don't forget to feed your pet!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "I come from a long line of Pet Tamers. My family has been taming pets for generations and I am the best Pet tamer among them. Feel free to visit me if you hever need help with your pet.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Don't forget to feed your pet!"
-		}
-	]
+  "name": "MaFl_PetTamer",
+  "oralText": "Raising your own pet takes patience and dedication. Are you ready?",
+  "introText": "Rawr! Tee hee! ^^ Sorry, I was just practicing my tiger call. Do you have a pet? I love pets, it's what I live for!",
+  "byeText": "Don't forget to feed your pet!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I come from a long line of Pet Tamers. My family has been taming pets for generations and I am the best Pet tamer among them. Feel free to visit me if you hever need help with your pet."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Don't forget to feed your pet!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Ray.json
+++ b/bin/data/dialogs/en/MaFl_Ray.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Ray",
-	"oralText": "Hey, you two! Stop that bickering, it's pointless! Take it to the arena!",
-	"introText": "In the PvP arena, you can fight other adventurers such as yourself. If you meet unfortunate circumstances, and are slain on the arena floor, you will not incur any death penalties.",
-	"byeText": "Another one bites the dust!",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "My name is Lay and I am in charge of the PvP arena. I'll only let you in if you've chosen your first job.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "Another one bites the dust!"
-		}
-	]
+  "name": "MaFl_Ray",
+  "oralText": "Hey, you two! Stop that bickering, it's pointless! Take it to the arena!",
+  "introText": "In the PvP arena, you can fight other adventurers such as yourself. If you meet unfortunate circumstances, and are slain on the arena floor, you will not incur any death penalties.",
+  "byeText": "Another one bites the dust!",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Lay and I am in charge of the PvP arena. I'll only let you in if you've chosen your first job."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Another one bites the dust!"
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_SecretRoom_EAST.json
+++ b/bin/data/dialogs/en/MaFl_SecretRoom_EAST.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_SecretRoom_EAST",
-	"oralText": "Only the strongest of guilds can achieve victory in the Secret Room!",
-	"introText": "If your guild is the first to sucessfully complete the Secret Room, the tax rate can be set and collected by your guild for all Eastern Region territories. These terretories include Flaris, Saint Morning, Rhisis Garden, and the Forsaken Tower.",
-	"byeText": "May Rhisis guide you, and be with you, young one.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "Hello, adventurer! I'm in charge of the Secret Room for the Eastern Regions and I keep track of the tax rate for those territories. If you have any questions about this heroic challenge, please don't hesitate to ask.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "May Rhisis guide you, and be with you, young one."
-		}
-	]
+  "name": "MaFl_SecretRoom_EAST",
+  "oralText": "Only the strongest of guilds can achieve victory in the Secret Room!",
+  "introText": "If your guild is the first to sucessfully complete the Secret Room, the tax rate can be set and collected by your guild for all Eastern Region territories. These terretories include Flaris, Saint Morning, Rhisis Garden, and the Forsaken Tower.",
+  "byeText": "May Rhisis guide you, and be with you, young one.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "Hello, adventurer! I'm in charge of the Secret Room for the Eastern Regions and I keep track of the tax rate for those territories. If you have any questions about this heroic challenge, please don't hesitate to ask."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "May Rhisis guide you, and be with you, young one."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Waforu.json
+++ b/bin/data/dialogs/en/MaFl_Waforu.json
@@ -3,20 +3,24 @@
 //
 
 {
-	"name": "MaFl_Waforu",
-	"oralText": "Step right up, champions! Welcome to the Red Chip Emporium!",
-	"introText": "Heya stranger! If your guild wins the Guild Siege, you will be awarded Red Chips for your victory. The armor sets I sell here in my shop are absolutely the best you can find! So how many Red Chips do you have, hmmmm?",
-	"byeText": "So long, contender. May Rhisis be with you.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"text": "I am Wafor, the Battle Merchant. I've had my share of victories in the sieges, but I'm getting to old for that sort of thing. I still love the competition, however, so i decided  to stay in the business and offer my services as a Red Chip Vendor.",
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"text": "So long, contender. May Rhisis be with you."
-		}
-	]
+  "name": "MaFl_Waforu",
+  "oralText": "Step right up, champions! Welcome to the Red Chip Emporium!",
+  "introText": "Heya stranger! If your guild wins the Guild Siege, you will be awarded Red Chips for your victory. The armor sets I sell here in my shop are absolutely the best you can find! So how many Red Chips do you have, hmmmm?",
+  "byeText": "So long, contender. May Rhisis be with you.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am Wafor, the Battle Merchant. I've had my share of victories in the sieges, but I'm getting to old for that sort of thing. I still love the competition, however, so i decided  to stay in the business and offer my services as a Red Chip Vendor."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "So long, contender. May Rhisis be with you."
+      ]
+    }
+  ]
 }

--- a/src/Rhisis.Core/Structures/Game/Dialogs/DialogLink.cs
+++ b/src/Rhisis.Core/Structures/Game/Dialogs/DialogLink.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
 
 namespace Rhisis.Core.Structures.Game.Dialogs
 {
@@ -18,19 +19,19 @@ namespace Rhisis.Core.Structures.Game.Dialogs
         public string Title { get; set; }
 
         /// <summary>
-        /// Gets or sets the dialog link text.
+        /// Gets or sets the dialog link texts.
         /// </summary>
         /// <remarks>
         /// This text will appear once the client has clicked on the link title.
         /// </remarks>
-        [DataMember(Name = "text")]
-        public string Text { get; set; }
+        [DataMember(Name = "texts")]
+        public IList<string> Texts { get; set; }
 
         /// <summary>
         /// Create an empty <see cref="DialogLink"/> instance.
         /// </summary>
         public DialogLink()
-            : this(string.Empty, string.Empty, string.Empty)
+            : this(string.Empty, string.Empty)
         {
         }
 
@@ -40,11 +41,11 @@ namespace Rhisis.Core.Structures.Game.Dialogs
         /// <param name="id">Dialog link id</param>
         /// <param name="title">Dialog link title</param>
         /// <param name="text">Dialog link text</param>
-        public DialogLink(string id, string title, string text)
+        public DialogLink(string id, string title)
         {
             this.Id = id;
             this.Title = title;
-            this.Text = text;
+            this.Texts = new List<string>();
         }
     }
 }

--- a/src/Rhisis.World/Packets/NpcDialogPackets.cs
+++ b/src/Rhisis.World/Packets/NpcDialogPackets.cs
@@ -15,17 +15,20 @@ namespace Rhisis.World.Packets
         /// <param name="player">Player</param>
         /// <param name="text">Npc dialog text</param>
         /// <param name="dialogLinks">Npc dialog links</param>
-        public static void SendDialog(IPlayerEntity player, string text, IEnumerable<DialogLink> dialogLinks)
+        public static void SendDialog(IPlayerEntity player, IEnumerable<string> dialogTexts, IEnumerable<DialogLink> dialogLinks)
         {
             using (var packet = new FFPacket())
             {
                 packet.StartNewMergedPacket(player.Id, SnapshotType.RUNSCRIPTFUNC);
                 packet.Write((short)DialogOptions.FUNCTYPE_REMOVEALLKEY);
 
-                packet.StartNewMergedPacket(player.Id, SnapshotType.RUNSCRIPTFUNC);
-                packet.Write((short)DialogOptions.FUNCTYPE_SAY);
-                packet.Write(text);
-                packet.Write(0); // quest id
+                foreach (string text in dialogTexts)
+                {
+                    packet.StartNewMergedPacket(player.Id, SnapshotType.RUNSCRIPTFUNC);
+                    packet.Write((short)DialogOptions.FUNCTYPE_SAY);
+                    packet.Write(text);
+                    packet.Write(0); // quest id
+                }
 
                 foreach (DialogLink link in dialogLinks)
                 {

--- a/src/Rhisis.World/Systems/NpcDialog/NpcDialogSystem.cs
+++ b/src/Rhisis.World/Systems/NpcDialog/NpcDialogSystem.cs
@@ -5,6 +5,7 @@ using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Packets;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Rhisis.World.Systems.NpcDialog
@@ -42,7 +43,7 @@ namespace Rhisis.World.Systems.NpcDialog
         /// <param name="e"></param>
         private void OpenDialog(IPlayerEntity player, NpcDialogOpenEventArgs e)
         {
-            var npcEntity = player.Context.FindEntity<INpcEntity>(e.NpcObjectId);
+            var npcEntity = player.Object.CurrentMap?.FindEntity<INpcEntity>(e.NpcObjectId);
 
             if (npcEntity == null)
             {
@@ -56,7 +57,7 @@ namespace Rhisis.World.Systems.NpcDialog
                 return;
             }
 
-            string dialogText = npcEntity.Data.Dialog.IntroText;
+            IEnumerable<string> dialogTexts = new[] { npcEntity.Data.Dialog.IntroText };
 
             if (!string.IsNullOrEmpty(e.DialogKey))
             {
@@ -76,11 +77,11 @@ namespace Rhisis.World.Systems.NpcDialog
                         return;
                     }
 
-                    dialogText = dialogLink.Text;
+                    dialogTexts = dialogLink.Texts;
                 }
             }
 
-            WorldPacketFactory.SendDialog(player, dialogText, npcEntity.Data.Dialog.Links);
+            WorldPacketFactory.SendDialog(player, dialogTexts, npcEntity.Data.Dialog.Links);
         }
     }
 }


### PR DESCRIPTION
This PR covers issue #205 and bring changes to the `DialogLink` definition.

Instead of passing a single text, you can now pass multiple texts such as:

```json
{
  "name": "MaFl_NAME",
  "oralText": "Oral",
  "introText": "Intro",
  "byeText": "Bye text",
  "links": [
    {
      "id": "PRESENTATION",
      "title": "Who are you?",
      "texts": [
        "FirstText", 
        "Second Text"
      ]
    },
    {
      "id": "BYE",
      "title": "Goodbye!",
      "texts": [
        "Bye Text"
      ]
    }
  ]
}
```

In game, the dialog box will display a "Next" button and then display the second text, and so on.