### PR TITLE
#212 Prevent dialogs from having duplicate links id.

### DIFF
--- a/src/Rhisis.Core/Extensions/LinqExtensions.cs
+++ b/src/Rhisis.Core/Extensions/LinqExtensions.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Rhisis.Core.Extensions
 {
@@ -17,6 +19,11 @@ namespace Rhisis.Core.Extensions
             return source.Zip(Enumerable.Range(0, source.Count()), (s, r) => new { Group = r / itemsPerGroup, Item = s })
                         .GroupBy(i => i.Group, g => g.Item)
                         .ToList();
+        }
+
+        public static bool HasDuplicates<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> expression)
+        {
+            return source.GroupBy(expression).Any(x => x.Count() > 1);
         }
     }
 }

--- a/src/Rhisis.Core/Resources/GameResources.cs
+++ b/src/Rhisis.Core/Resources/GameResources.cs
@@ -32,6 +32,7 @@ namespace Rhisis.Core.Resources
         public const string UnableLoadMapMessage = "Unable to load map '{0}'. Reason: {1}.";
         public const string ObjectIgnoredMessage = "{0} id '{1}' was ignored. Reason: {2}.";
         public const string ObjectOverridedMessage = "{0} id '{1}' was overrided. Reason: {2}.";
+        public const string ObjectErrorMessage = "{0} with id '{1}' has an error. Reason: {2}";
 
         private ILogger<GameResources> _logger;
         private IEnumerable<Type> _loaders;

--- a/src/Rhisis.Core/Resources/Loaders/DialogLoader.cs
+++ b/src/Rhisis.Core/Resources/Loaders/DialogLoader.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
 using Newtonsoft.Json.Linq;
+using Rhisis.Core.Extensions;
 using Rhisis.Core.Structures.Game.Dialogs;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Rhisis.Core.Resources.Loaders
 {
@@ -93,9 +95,18 @@ namespace Rhisis.Core.Resources.Loaders
         private void AddDialog(DialogSet dialogSet, DialogData dialog)
         {
             if (dialogSet.ContainsKey(dialog.Name))
+            {
                 this._logger.LogDebug(GameResources.ObjectIgnoredMessage, "Dialog", dialog.Name, "already declared");
-            else
-                dialogSet.Add(dialog.Name, dialog);
+                return;
+            }
+
+            if (dialog.Links.HasDuplicates(x => x.Id))
+            {
+                this._logger.LogError(GameResources.ObjectErrorMessage, "Dialog", dialog.Name, "duplicate dialog link keys.");
+                return;
+            }
+
+            dialogSet.Add(dialog.Name, dialog);
         }
     }
 }

--- a/test/Rhisis.Core.Test/Extensions/LinqExtensions.cs
+++ b/test/Rhisis.Core.Test/Extensions/LinqExtensions.cs
@@ -10,6 +10,14 @@ namespace Rhisis.Core.Test.Extensions
     {
         private readonly IEnumerable<int> array = Enumerable.Repeat(new Random().Next(), 64);
 
+        public static readonly IEnumerable<object[]> DuplicateTestData = new List<object[]>
+        {
+            new object[] { SomeData.Generate(10), false },
+            new object[] { SomeData.Generate(10), false },
+            new object[] { SomeData.Generate(40, true), true },
+            new object[] { SomeData.Generate(20, true), true },
+        };
+
         [Theory]
         [InlineData(2)]
         [InlineData(10)]
@@ -26,6 +34,37 @@ namespace Rhisis.Core.Test.Extensions
 
             Assert.Equal(numberOfGroups, groups.Count());
             Assert.Equal(array.Count(), groups.Sum(x => x.Count()));
+        }
+
+        [Theory]
+        [MemberData(nameof(DuplicateTestData))]
+        public void HasDuplicatesTest(IEnumerable<SomeData> data, bool hasDuplicate)
+        {
+            bool containsDuplicate = data.HasDuplicates(x => x.Id);
+
+            Assert.Equal(hasDuplicate, containsDuplicate);
+        }
+    }
+
+    public class SomeData
+    {
+        public int Id { get; set; }
+
+        public string Value => $"Value {this.Id}";
+
+        public SomeData(int id)
+        {
+            this.Id = id;
+        }
+
+        public static IEnumerable<SomeData> Generate(int count, bool hasDuplicates = false)
+        {
+            var data = Enumerable.Range(0, count).Select(x => new SomeData(x)).ToList();
+
+            if (hasDuplicates)
+                data.Add(data.ElementAt(0));
+
+            return data;
         }
     }
 }


### PR DESCRIPTION
This PR covers issue #212 and adds an extra check on dialog loader to prevent dialogs from having duplicate dialog link ids.