### PR TITLE
Experience and Level up

### DIFF
--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Rhisis.Core/Resources/GameResources.cs
+++ b/src/Rhisis.Core/Resources/GameResources.cs
@@ -38,6 +38,7 @@ namespace Rhisis.Core.Resources
         private IEnumerable<Type> _loaders;
         private MoverLoader _movers;
         private ItemLoader _items;
+        private ExpTableLoader _expTables;
 
         /// <summary>
         /// Gets the movers data.
@@ -48,6 +49,11 @@ namespace Rhisis.Core.Resources
         /// Gets the items data.
         /// </summary>
         public ItemLoader Items => this._items ?? (this._items = DependencyContainer.Instance.Resolve<ItemLoader>());
+
+        /// <summary>
+        /// Gets the exp table data.
+        /// </summary>
+        public ExpTableLoader ExpTables => this._expTables ?? (this._expTables = DependencyContainer.Instance.Resolve<ExpTableLoader>());
 
         /// <summary>
         /// Initialize the <see cref="GameResources"/> with loaders.

--- a/src/Rhisis.Core/Rhisis.Core.csproj
+++ b/src/Rhisis.Core/Rhisis.Core.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/src/Rhisis.Core/Structures/Game/CharacterExpTableData.cs
+++ b/src/Rhisis.Core/Structures/Game/CharacterExpTableData.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace Rhisis.Core.Structures.Game
+{
+    public readonly struct CharacterExpTableData : IEquatable<CharacterExpTableData>
+    {
+        /// <summary>
+        /// Gets the level.
+        /// </summary>
+        public int Level { get; }
+
+        /// <summary>
+        /// Gets the experience required for the current level.
+        /// </summary>
+        public long Exp { get; }
+
+        /// <summary>
+        /// Gets another kind of experience.
+        /// </summary>
+        /// <remarks>
+        /// This seems not to be used in official files.
+        /// </remarks>
+        public long Pxp { get; }
+
+        /// <summary>
+        /// Gets the number of statistics points given for the current level.
+        /// </summary>
+        public long Gp { get; }
+
+        /// <summary>
+        /// Gets the experience limit of the current level.
+        /// </summary>
+        public long LimExp { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="CharacterExpTableData"/> instance.
+        /// </summary>
+        /// <param name="level"></param>
+        /// <param name="experience"></param>
+        /// <param name="pxp"></param>
+        /// <param name="gp"></param>
+        /// <param name="limitExperience"></param>
+        public CharacterExpTableData(int level, long experience, long pxp, long gp, long limitExperience)
+        {
+            this.Level = level;
+            this.Exp = experience;
+            this.Pxp = pxp;
+            this.Gp = gp;
+            this.LimExp = limitExperience;
+        }
+
+        /// <summary>
+        /// Compares two instances of <see cref="CharacterExpTableData"/>.
+        /// </summary>
+        /// <param name="other">Other <see cref="CharacterExpTableData"/>.</param>
+        /// <returns>True if the same; false otherwise.</returns>
+        public bool Equals(CharacterExpTableData other) 
+            => (this.Level, this.Exp, this.Pxp, this.Gp, this.LimExp) == (other.Level, other.Exp, other.Pxp, other.Gp, other.LimExp);
+    }
+}

--- a/src/Rhisis.Core/Structures/Game/MoverData.cs
+++ b/src/Rhisis.Core/Structures/Game/MoverData.cs
@@ -1,5 +1,4 @@
 ﻿using Rhisis.Core.Data;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
 
@@ -11,96 +10,187 @@ namespace Rhisis.Core.Structures.Game
     [DataContract]
     public class MoverData
     {
+        /// <summary>
+        /// Gets the mover id.
+        /// </summary>
         [DataMember(Name = "dwID")]
         public int Id { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the mover name.
+        /// </summary>
         [DataMember(Name = "szName")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover AI id.
+        /// </summary>
         [DataMember(Name = "dwAI")]
         public int AI { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover belligerence.
+        /// </summary>
         [DataMember(Name = "dwBelligerence")]
         public int Belligerence { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover speed.
+        /// </summary>
         [DataMember(Name = "fSpeed")]
         public float Speed { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover Hit Points (HP).
+        /// </summary>
         [DataMember(Name = "dwAddHp")]
         public int AddHp { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover Magic Points (MP).
+        /// </summary>
         [DataMember(Name = "dwAddMp")]
         public int AddMp { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover level.
+        /// </summary>
         [DataMember(Name = "dwLevel")]
         public int Level { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover flight level.
+        /// </summary>
         [DataMember(Name = "dwFilghtLevel")]
         public int FlightLevel { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover attack min.
+        /// </summary>
         [DataMember(Name = "dwAtkMin")]
         public int AttackMin { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover attack max.
+        /// </summary>
         [DataMember(Name = "dwAtkMax")]
         public int AttackMax { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover strength.
+        /// </summary>
         [DataMember(Name = "dwStr")]
         public int Strength { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover stamina.
+        /// </summary>
         [DataMember(Name = "dwSta")]
         public int Stamina { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover dexterity.
+        /// </summary>
         [DataMember(Name = "dwDex")]
         public int Dexterity { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover intelligence.
+        /// </summary>
         [DataMember(Name = "dwInt")]
         public int Intelligence { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover hit rate.
+        /// </summary>
         [DataMember(Name = "dwHR")]
         public int HitRating { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover escape rate.
+        /// </summary>
         [DataMember(Name = "dwER")]
         public int EscapeRating { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover class.
+        /// </summary>
         [DataMember(Name = "dwClass")]
         public MoverClassType Class { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover natural armor.
+        /// </summary>
         [DataMember(Name = "dwNaturealArmor")]
         public int NaturalArmor { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover magic resistance.
+        /// </summary>
         [DataMember(Name = "dwResisMagic")]
         public int MagicResitance { get; set; }
 
+        /// <summary>
+        /// Gets or sets the mover attack delay.
+        /// </summary>
         [DataMember(Name = "dwReAttackDelay")]
         public int ReAttackDelay { get; set; }
-
+        
+        /// <summary>
+        /// Gets or sets the mover attack speed.
+        /// </summary>
         [DataMember(Name = "dwAttackSpeed")]
         public int AttackSpeed { get; set; }
 
         [DataMember(Name = "dwCorrectionValue")]
         public int CorrectionValue { get; set; }
 
+        /// <summary>
+        /// Gets or sets the amount of experience given when the mover dies.
+        /// </summary>
+        [DataMember(Name = "dwExpValue")]
+        public long Experience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimal amount of gold dropped when the mover dies.
+        /// </summary>
         [IgnoreDataMember]
         public int DropGoldMin { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximal amount of gold dropped when the mover dies.
+        /// </summary>
         [IgnoreDataMember]
         public int DropGoldMax { get; set; }
 
+        /// <summary>
+        /// Gets or sets the maximal amount of items dropped when the mover dies.
+        /// </summary>
         [IgnoreDataMember]
         public int MaxDropItem { get; set; }
 
+        /// <summary>
+        /// Gets or sets the collection of items the mover can drop.
+        /// </summary>
         [IgnoreDataMember]
         public ICollection<DropItemData> DropItems { get; }
 
+        /// <summary>
+        /// Gets or sets the collection of item kinds the mover can drop.
+        /// </summary>
         [IgnoreDataMember]
         public ICollection<DropItemKindData> DropItemsKind { get; }
-
+        
+        /// <summary>
+        /// Creates a new <see cref="MoverData"/> instance.
+        /// </summary>
         public MoverData()
         {
             this.DropItems = new List<DropItemData>();
             this.DropItemsKind = new List<DropItemKindData>();
         }
 
+        /// <inheritdoc />
         public override string ToString() => this.Name;
     }
 }

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Rhisis.World/Game/Components/StatisticsComponent.cs
+++ b/src/Rhisis.World/Game/Components/StatisticsComponent.cs
@@ -14,6 +14,12 @@ namespace Rhisis.World.Game.Components
 
         public ushort StatPoints { get; set; }
 
+        public ushort SkillPoints { get; set; }
+
+        public StatisticsComponent()
+        {
+        }
+
         public StatisticsComponent(DbCharacter character)
         {
             this.Strength = (ushort)character.Strength;
@@ -21,10 +27,7 @@ namespace Rhisis.World.Game.Components
             this.Dexterity = (ushort)character.Dexterity;
             this.Intelligence = (ushort)character.Intelligence;
             this.StatPoints = (ushort)character.StatPoints;
-        }
-
-        public StatisticsComponent()
-        {
+            this.SkillPoints = (ushort)character.SkillPoints;
         }
     }
 }

--- a/src/Rhisis.World/Packets/PlayerPackets.cs
+++ b/src/Rhisis.World/Packets/PlayerPackets.cs
@@ -34,5 +34,41 @@ namespace Rhisis.World.Packets
                 player.Connection.Send(packet);
             }
         }
+
+        /// <summary>
+        /// Send player update level.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="level"></param>
+        public static void SendPlayerSetLevel(IPlayerEntity player, int level)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SETLEVEL);
+                packet.Write((short)level);
+
+                SendToVisible(packet, player);
+            }
+        }
+
+        /// <summary>
+        /// Send Player experience.
+        /// </summary>
+        /// <param name="player"></param>
+        public static void SendPlayerExperience(IPlayerEntity player)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SETEXPERIENCE);
+                packet.Write(player.PlayerData.Experience);
+                packet.Write((short)player.Object.Level);
+                packet.Write(0);
+                packet.Write((int)player.Statistics.SkillPoints);
+                packet.Write(long.MaxValue); // death exp
+                packet.Write(short.MaxValue); // death level
+
+                player.Connection.Send(packet);
+            }
+        }
     }
 }

--- a/src/Rhisis.World/Packets/SpawnPackets.cs
+++ b/src/Rhisis.World/Packets/SpawnPackets.cs
@@ -109,7 +109,7 @@ namespace Rhisis.World.Packets
                 packet.Write(player.PlayerData.Gold); // Gold
                 packet.Write(player.PlayerData.Experience); // exp
                 packet.Write(0); // skill level
-                packet.Write(0); // skill points
+                packet.Write((int)player.Statistics.SkillPoints); // skill points
                 packet.Write<long>(0); // death exp
                 packet.Write(0); // death level
 

--- a/src/Rhisis.World/Packets/StatisticsPackets.cs
+++ b/src/Rhisis.World/Packets/StatisticsPackets.cs
@@ -22,5 +22,17 @@ namespace Rhisis.World.Packets
                 player.Connection.Send(packet);
             }
         }
+
+        public static void SendPlayerStatsPoints(IPlayerEntity player)
+        {
+            using (var packet = new FFPacket())
+            {
+                packet.StartNewMergedPacket(player.Id, SnapshotType.SET_GROWTH_LEARNING_POINT);
+                packet.Write((long)player.Statistics.StatPoints);
+                packet.Write<long>(0);
+
+                player.Connection.Send(packet);
+            }
+        }
     }
 }

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -14,6 +14,8 @@ using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Drop;
 using Rhisis.World.Systems.Drop.EventArgs;
+using Rhisis.World.Systems.Leveling;
+using Rhisis.World.Systems.Leveling.EventArgs;
 using System.Linq;
 
 namespace Rhisis.World.Systems.Battle
@@ -90,9 +92,9 @@ namespace Rhisis.World.Systems.Battle
                 this.ClearBattleTargets(attacker);
                 WorldPacketFactory.SendUpdateAttributes(defender, DefineAttributes.HP, defender.Health.Hp);
 
-                if (defender is IMonsterEntity deadMonster)
+                if (defender is IMonsterEntity deadMonster && attacker is IPlayerEntity player)
                 {
-                    WorldPacketFactory.SendDie(attacker as IPlayerEntity, defender, attacker, e.AttackType);
+                    WorldPacketFactory.SendDie(player, defender, attacker, e.AttackType);
                     var worldServerConfiguration = DependencyContainer.Instance.Resolve<WorldConfiguration>();
                     var itemsData = DependencyContainer.Instance.Resolve<ItemLoader>();
                     var expTable = DependencyContainer.Instance.Resolve<ExpTableLoader>();
@@ -148,7 +150,9 @@ namespace Rhisis.World.Systems.Battle
                     int goldDropped = RandomHelper.Random(deadMonster.Data.DropGoldMin, deadMonster.Data.DropGoldMax);
                     deadMonster.NotifySystem<DropSystem>(new DropGoldEventArgs(goldDropped, attacker));
 
-                    // TODO: give exp
+                    // Give experience
+                    long experience = deadMonster.Data.Experience * worldServerConfiguration.Rates.Experience;
+                    player.NotifySystem<LevelSystem>(new ExperienceEventArgs(experience)); 
                 }
                 else if (defender is IPlayerEntity deadPlayer)
                 {

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -97,7 +97,7 @@ namespace Rhisis.World.Systems.Battle
                     var itemsData = DependencyContainer.Instance.Resolve<ItemLoader>();
                     var expTable = DependencyContainer.Instance.Resolve<ExpTableLoader>();
 
-                    deadMonster.Timers.DespawnTime = Time.TimeInSeconds() + 5;
+                    deadMonster.Timers.DespawnTime = Time.TimeInSeconds() + 5; // Configure this timer on world configuration
 
                     // Drop items
                     int itemCount = 0;

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -20,8 +20,10 @@ namespace Rhisis.World.Systems.Death
         private readonly ILogger<DeathSystem> _logger = DependencyContainer.Instance.Resolve<ILogger<DeathSystem>>();
         private readonly MapLoader _mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
 
+        /// <inheritdoc />
         public WorldEntityType Type => WorldEntityType.Player;
 
+        /// <inheritdoc />
         public void Execute(IEntity entity, SystemEventArgs args)
         {
             if (!(entity is IPlayerEntity player))
@@ -44,10 +46,6 @@ namespace Rhisis.World.Systems.Death
             player.Health.Hp = (int)(HealthFormulas.GetMaxOriginHp(player.Object.Level, playerStats.Stamina, jobData.MaxHpFactor) * RecoveryRate);
             player.Health.Mp = (int)(HealthFormulas.GetMaxOriginMp(player.Object.Level, playerStats.Intelligence, jobData.MaxMpFactor, true) * RecoveryRate);
             player.Health.Fp = (int)(HealthFormulas.GetMaxOriginFp(player.Object.Level, playerStats.Stamina, playerStats.Dexterity, playerStats.Strength, jobData.MaxFpFactor, true) * RecoveryRate);
-
-            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.HP, player.Health.Hp);
-            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.MP, player.Health.Mp);
-            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.FP, player.Health.Fp);
 
             bool shouldReplace = false;
             if (revivalRegion.MapId != player.Object.MapId)
@@ -84,6 +82,9 @@ namespace Rhisis.World.Systems.Death
             WorldPacketFactory.SendMotion(player, ObjectMessageType.OBJMSG_ACC_STOP | ObjectMessageType.OBJMSG_STOP_TURN | ObjectMessageType.OBJMSG_STAND);
             WorldPacketFactory.SendPlayerRevival(player);
             WorldPacketFactory.SendMoverPosition(player);
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.HP, player.Health.Hp);
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.MP, player.Health.Mp);
+            WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.FP, player.Health.Fp);
         }
     }
 }

--- a/src/Rhisis.World/Systems/Leveling/EventArgs/ExperienceEventArgs.cs
+++ b/src/Rhisis.World/Systems/Leveling/EventArgs/ExperienceEventArgs.cs
@@ -1,0 +1,30 @@
+﻿using Rhisis.World.Game.Core.Systems;
+
+namespace Rhisis.World.Systems.Leveling.EventArgs
+{
+    /// <summary>
+    /// Experience event containing the amount of experience to give to an entity.
+    /// </summary>
+    public class ExperienceEventArgs : SystemEventArgs
+    {
+        /// <summary>
+        /// Gets the amount of experience to give.
+        /// </summary>
+        public long Experience { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="ExperienceEventArgs"/> instance.
+        /// </summary>
+        /// <param name="experience">Amount of experience to give.</param>
+        public ExperienceEventArgs(long experience)
+        {
+            this.Experience = experience;
+        }
+
+        /// <inheritdoc />
+        public override bool CheckArguments()
+        {
+            return this.Experience > 0;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Leveling/LevelSystem.cs
+++ b/src/Rhisis.World/Systems/Leveling/LevelSystem.cs
@@ -1,12 +1,19 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Resources;
+using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Packets;
+using Rhisis.World.Systems.Leveling.EventArgs;
 using System;
 
 namespace Rhisis.World.Systems.Leveling
 {
+    /// <summary>
+    /// Leveling system.
+    /// </summary>
     [System(SystemType.Notifiable)]
     public sealed class LevelSystem : ISystem
     {
@@ -30,7 +37,61 @@ namespace Rhisis.World.Systems.Leveling
                 return;
             }
 
-            throw new NotImplementedException();
+            switch (args)
+            {
+                case ExperienceEventArgs e:
+                    this.GiveExperience(player, e);
+                    break;
+                default:
+                    this._logger.LogWarning("Unknown level system action type: {0} for player {1}", args.GetType(), entity.Object.Name);
+                    break;
+            }
+        }
+
+        private void GiveExperience(IPlayerEntity player, ExperienceEventArgs e)
+        {
+            long experience = this.CalculateExtraExperience(player, e.Experience);
+
+            // TODO: experience to party
+
+            if (this.GiveExperienceToPlayer(player, experience))
+            {
+                WorldPacketFactory.SendPlayerSetLevel(player, player.Object.Level);
+                WorldPacketFactory.SendPlayerStatsPoints(player);
+            }
+
+            WorldPacketFactory.SendPlayerExperience(player);
+        }
+
+        private bool GiveExperienceToPlayer(IPlayerEntity player, long experience)
+        {
+            int nextLevel = player.Object.Level + 1;
+            CharacterExpTableData nextLevelExpTable = GameResources.Instance.ExpTables.GetCharacterExp(nextLevel);
+            player.PlayerData.Experience += experience;
+
+            if (player.PlayerData.Experience >= nextLevelExpTable.Exp) // Level up
+            {
+                long remainingExp = player.PlayerData.Experience - nextLevelExpTable.Exp;
+
+                player.Object.Level += 1;
+                player.Statistics.SkillPoints += (ushort)(((player.Object.Level - 1) / 20) + 2);
+                player.Statistics.StatPoints += (ushort)nextLevelExpTable.Gp;
+                player.PlayerData.Experience = 0;
+
+                if (remainingExp > 0)
+                    this.GiveExperienceToPlayer(player, remainingExp); // Multiple level up
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private long CalculateExtraExperience(IPlayerEntity player, long experience)
+        {
+            // TODO: add exp scrolls logic here
+
+            return experience;
         }
     }
 }

--- a/src/Rhisis.World/Systems/Leveling/LevelSystem.cs
+++ b/src/Rhisis.World/Systems/Leveling/LevelSystem.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
+using System;
+
+namespace Rhisis.World.Systems.Leveling
+{
+    [System(SystemType.Notifiable)]
+    public sealed class LevelSystem : ISystem
+    {
+        private readonly ILogger<LevelSystem> _logger = DependencyContainer.Instance.Resolve<ILogger<LevelSystem>>();
+
+        /// <inheritdoc />
+        public WorldEntityType Type => WorldEntityType.Player;
+
+        /// <inheritdoc />
+        public void Execute(IEntity entity, SystemEventArgs args)
+        {
+            if (!(entity is IPlayerEntity player))
+            {
+                this._logger.LogError($"Cannot execute Level System. {entity.Object.Name} is not a player.");
+                return;
+            }
+
+            if (!args.CheckArguments())
+            {
+                this._logger.LogError($"Cannot execute Level System action: {args.GetType()} due to invalid arguments.");
+                return;
+            }
+
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Rhisis.World/WorldClient.cs
+++ b/src/Rhisis.World/WorldClient.cs
@@ -129,12 +129,14 @@ namespace Rhisis.World
                     character.Level = this.Player.Object.Level;
 
                     character.Gold = this.Player.PlayerData.Gold;
+                    character.Experience = this.Player.PlayerData.Experience;
 
                     character.Strength = this.Player.Statistics.Strength;
                     character.Stamina = this.Player.Statistics.Stamina;
                     character.Dexterity = this.Player.Statistics.Dexterity;
                     character.Intelligence = this.Player.Statistics.Intelligence;
                     character.StatPoints = this.Player.Statistics.StatPoints;
+                    character.SkillPoints = this.Player.Statistics.SkillPoints;
 
                     // Delete items
                     var itemsToDelete = new List<DbItem>(character.Items.Count);


### PR DESCRIPTION
This PR covers issue #29 and adds the possibility to give experience to a player using the `LevelSystem` and the `ExperienceEventArgs`.

Experience tables are loaded during startup and experience is given when a player kills a monster. Also, when the player has enough experience to level up, statistics points and skills are given to the player.