### PR TITLE
#211 update dialog data structure. IntroText is now an array

### DIFF
--- a/bin/data/dialogs/en/MaFl_Amos.json
+++ b/bin/data/dialogs/en/MaFl_Amos.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Amos",
   "oralText": "Welcome, Flarinians! Sign up here for entry into the 1vs1 Guild Siege!",
-  "introText": "A guild is only as strong as it's weakest member, my friend, and this is where we separate the bark from the bite. Test your mettle in the 1vs1 Guild Siege if you think you're strong enough!",
+  "introText": [
+    "A guild is only as strong as it's weakest member, my friend, and this is where we separate the bark from the bite. Test your mettle in the 1vs1 Guild Siege if you think you're strong enough!"
+  ],
   "byeText": "For Glory!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Annie.json
+++ b/bin/data/dialogs/en/MaFl_Annie.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Annie",
   "oralText": "Please visit me if you have any questions about the 1vs1 Guild Siege.",
-  "introText": "Why hello there, young one. You certainly look strong! I bet you could even handle 1v2! Hahaha! Yes, I'm lying... you'll probably last about 2 seconds.",
+  "introText": [
+    "Why hello there, young one. You certainly look strong! I bet you could even handle 1v2! Hahaha! Yes, I'm lying... you'll probably last about 2 seconds."
+  ],
   "byeText": "Toodles!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Bobochan.json
+++ b/bin/data/dialogs/en/MaFl_Bobochan.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Bobochan",
   "oralText": "Step right up, adventurers! BoBoChan's Upgrade Shop is open for business!",
-  "introText": "Rhisis have mercy on this poor soul. You actually fight monsters with that?! Good grief! Please, allow me to help you upgrade it...",
+  "introText": [
+    "Rhisis have mercy on this poor soul. You actually fight monsters with that?! Good grief! Please, allow me to help you upgrade it..."
+  ],
   "byeText": "Goodbye, friend! Remember, for the best upgrades in Madrigal, visit BoBoChan!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Boboko.json
+++ b/bin/data/dialogs/en/MaFl_Boboko.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Boboko",
   "oralText": "The perfect shields of the Bobo family are only here, in the Shield Shop of Boboku!",
-  "introText": "You won't find a better armor selection in all of Flaris, I'll guarantee you that!",
+  "introText": [
+    "You won't find a better armor selection in all of Flaris, I'll guarantee you that!"
+  ],
   "byeText": "Tell your friends buy Bobo Family Equipment!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Boboku.json
+++ b/bin/data/dialogs/en/MaFl_Boboku.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Boboku",
   "oralText": "Your weapon is looking a little dull there, friend. Thank Rhisis for you, I buy and sell weapons!",
-  "introText": "*sigh* Oh, sorry! I was daydreaming about Julia over there. She's so amazing! Hey, do you think a girl like her and a guy like me could ever be? What? How could she resist me?!",
+  "introText": [
+    "*sigh* Oh, sorry! I was daydreaming about Julia over there. She's so amazing! Hey, do you think a girl like her and a guy like me could ever be? What? How could she resist me?!"
+  ],
   "byeText": "Thanks for stopping by! Tell Julia I said hello!",
   "links": [
     {
@@ -13,7 +15,7 @@
       "title": "Who are you?",
       "texts": [
         "Greetings from the Bobo Family, stranger! I am Boboku Bobo. I run the Weapon Shop here in Flarine. Have a look around and don't forget to visit my brother's shops!"
-	  ]
+      ]
     },
     {
       "id": "BYE",

--- a/bin/data/dialogs/en/MaFl_CardMaster.json
+++ b/bin/data/dialogs/en/MaFl_CardMaster.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_CardMaster",
   "oralText": "If you need any weapon or armor piercing cards converted, I'm your gal!",
-  "introText": "Welcome, adventurer! If you have 10 piercing cards, I will attempt to convert the 10 that you give me into 1 card of the next level. I can;t offer any guarantees, however, as sometimes you may only get back 1 of the  same type of card.",
+  "introText": [
+    "Welcome, adventurer! If you have 10 piercing cards, I will attempt to convert the 10 that you give me into 1 card of the next level. I can;t offer any guarantees, however, as sometimes you may only get back 1 of the  same type of card."
+  ],
   "byeText": "Stop by anytime, my friend!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Charlie.json
+++ b/bin/data/dialogs/en/MaFl_Charlie.json
@@ -5,7 +5,9 @@
 {
   "name": "Mafl_Charlie",
   "oralText": "If you need to access your house, or would like to buy some furniture, I'm your man!",
-  "introText": "Hello there! I sell furniture so you can decorate your house to fit your style. Amazing, right?! How about inviting your friends over to show it off? Your house can also be used as private meeting place for your guild.",
+  "introText": [
+    "Hello there! I sell furniture so you can decorate your house to fit your style. Amazing, right?! How about inviting your friends over to show it off? Your house can also be used as private meeting place for your guild."
+  ],
   "byeText": "Remember, decorating your house is important if you want to entertain your guests!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Donaris.json
+++ b/bin/data/dialogs/en/MaFl_Donaris.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Donaris",
   "oralText": "Check in here to review the weekly results of the Guild Siege!",
-  "introText": "Only the most cunning of guilds can hope to achieve victory in the Guild Sieges. Are you ready for the challenge?",
+  "introText": [
+    "Only the most cunning of guilds can hope to achieve victory in the Guild Sieges. Are you ready for the challenge?"
+  ],
   "byeText": "Good luck to you! I hope I see you in ranking charts!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_FlaMayor.json
+++ b/bin/data/dialogs/en/MaFl_FlaMayor.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_FlaMayor",
   "oralText": "Welcome to Flarine! Please, enjoy your stay!",
-  "introText": "Flarine is the capital city of Madrigal. It may be a small city, but it's certainly the most beautiful. Feel free to come see me if you ever need anything.",
+  "introText": [
+    "Flarine is the capital city of Madrigal. It may be a small city, but it's certainly the most beautiful. Feel free to come see me if you ever need anything."
+  ],
   "byeText": "We have a Guild Siege every Saturday. Speak to the Guild Siege Managers for more information!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_GUILDHOUSESALE.json
+++ b/bin/data/dialogs/en/MaFl_GUILDHOUSESALE.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_GUILDHOUSESALE",
   "oralText": "Talk to me if you would like to learn about Guild Houses.",
-  "introText": "Every guild deserves a home to call their own, don't you agree? Besides, I hear the buffs come in very handy!",
+  "introText": [
+    "Every guild deserves a home to call their own, don't you agree? Besides, I hear the buffs come in very handy!"
+  ],
   "byeText": "I know my service don't come cheap, but I think you will find they are definitely worth it. Think about it for a little while.",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Gergantes.json
+++ b/bin/data/dialogs/en/MaFl_Gergantes.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Gergantes",
   "oralText": "*scribbles* Ah, yes! This is good stuff... I'm such a great writer! Now I just need a good protagonist...",
-  "introText": "I am writing one of my best novels yet! It's action-packed, fast faced, dark, and even a little scary! It's about this hero who enters a dark cave and... well  wait, if I tell you, you might steal my idea! Who are you anyway!?",
+  "introText": [
+    "I am writing one of my best novels yet! It's action-packed, fast faced, dark, and even a little scary! It's about this hero who enters a dark cave and... well  wait, if I tell you, you might steal my idea! Who are you anyway!?"
+  ],
   "byeText": "My next novel will be a best seller, I'm sure! Keep an eye out for it!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_GuildWar.json
+++ b/bin/data/dialogs/en/MaFl_GuildWar.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_GuildWar",
   "oralText": "Welcome, competitors! The Guild Siege Application Center is open for business!",
-  "introText": "If your guild has reached the point where you think you have the strength and numbers to compete against another guild, then you're in the right place. Prove to everyone that you;re able to become a legend like Badza!",
+  "introText": [
+    "If your guild has reached the point where you think you have the strength and numbers to compete against another guild, then you're in the right place. Prove to everyone that you;re able to become a legend like Badza!"
+  ],
   "byeText": "For Glory!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Helper_ver12.json
+++ b/bin/data/dialogs/en/MaFl_Helper_ver12.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Helper_ver12",
   "oralText": "New to Madrigal? Visit your friendly neighborhood Buff Pang!",
-  "introText": "Hello there! I'm granting buffs to adventurers who haven't completed their second job change yet. Come see me anytime if you ever find yourself in need of a boost to your stats!",
+  "introText": [
+    "Hello there! I'm granting buffs to adventurers who haven't completed their second job change yet. Come see me anytime if you ever find yourself in need of a boost to your stats!"
+  ],
   "byeText": "Enjoy your stay in Madrigal!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Is.json
+++ b/bin/data/dialogs/en/MaFl_Is.json
@@ -3,52 +3,54 @@
 //
 
 {
-	"name": "MaFl_Is",
-	"oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
-	"introText": "Welcome to Madrigal. You look lost! Is there anything I can help you with?",
-	"byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"texts": [
-				"I am Is, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
-				"There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
-				"Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
-			 ]
-		},
-		{
-			"id": "LOCATION",
-			"title": "Where am I?",
-			"texts": [
-				"Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
-				"If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
-			 ]
-		},
-		{
-			"id": "SHOPS",
-			"title": "Shops?",
-			"texts": [
-				"There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
-				"You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
-				"People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
-			 ]
-		},
-		{
-			"id": "DEATHS",
-			"title": "Death?",
-			"texts": [
-				"If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
-				"If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
-				"In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
-			 ]
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"texts": [
-				"Be careful out there, young one. I sense great potential in you."
-			 ]
-		},
-	]
+  "name": "MaFl_Is",
+  "oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
+  "introText": [
+    "Welcome to Madrigal. You look lost! Is there anything I can help you with?"
+  ],
+  "byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am Is, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
+        "There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
+        "Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
+      ]
+    },
+    {
+      "id": "LOCATION",
+      "title": "Where am I?",
+      "texts": [
+        "Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
+        "If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
+      ]
+    },
+    {
+      "id": "SHOPS",
+      "title": "Shops?",
+      "texts": [
+        "There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
+        "You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
+        "People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
+      ]
+    },
+    {
+      "id": "DEATHS",
+      "title": "Death?",
+      "texts": [
+        "If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
+        "If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
+        "In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there, young one. I sense great potential in you."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Ismeralda.json
+++ b/bin/data/dialogs/en/MaFl_Ismeralda.json
@@ -3,52 +3,54 @@
 //
 
 {
-	"name": "MaFl_Ismeralda",
-	"oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
-	"introText": "Welcome to Madrigal. You look lost! Is there anything I can help you with?",
-	"byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"texts": [
-				"My name is Ismerelda Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
-				"There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
-				"Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
-			 ]
-		},
-		{
-			"id": "LOCATION",
-			"title": "Where am I?",
-			"texts": [
-				"Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
-				"If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
-			 ]
-		},
-		{
-			"id": "SHOPS",
-			"title": "Shops?",
-			"texts": [
-				"There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
-				"You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
-				"People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
-			 ]
-		},
-		{
-			"id": "DEATHS",
-			"title": "Death?",
-			"texts": [
-				"If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
-				"If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
-				"In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
-			 ]
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"texts": [
-				"Be careful out there, young one. I sense great potential in you."
-			 ]
-		},
-	]
+  "name": "MaFl_Ismeralda",
+  "oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
+  "introText": [
+    "Welcome to Madrigal. You look lost! Is there anything I can help you with?"
+  ],
+  "byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "My name is Ismerelda Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
+        "There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
+        "Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
+      ]
+    },
+    {
+      "id": "LOCATION",
+      "title": "Where am I?",
+      "texts": [
+        "Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
+        "If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
+      ]
+    },
+    {
+      "id": "SHOPS",
+      "title": "Shops?",
+      "texts": [
+        "There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
+        "You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
+        "People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
+      ]
+    },
+    {
+      "id": "DEATHS",
+      "title": "Death?",
+      "texts": [
+        "If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
+        "If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
+        "In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there, young one. I sense great potential in you."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Ispim.json
+++ b/bin/data/dialogs/en/MaFl_Ispim.json
@@ -3,52 +3,54 @@
 //
 
 {
-	"name": "MaFl_Ispim",
-	"oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
-	"introText": "Welcome to Madrigal. You look lost! Is there anything I can help you with?",
-	"byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"texts": [
-				"I am Ispim Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
-				"There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
-				"Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
-			 ]
-		},
-		{
-			"id": "LOCATION",
-			"title": "Where am I?",
-			"texts": [
-				"Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
-				"If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
-			 ]
-		},
-		{
-			"id": "SHOPS",
-			"title": "Shops?",
-			"texts": [
-				"There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
-				"You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
-				"People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
-			 ]
-		},
-		{
-			"id": "DEATHS",
-			"title": "Death?",
-			"texts": [
-				"If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
-				"If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
-				"In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
-			 ]
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"texts": [
-				"Be careful out there, young one. I sense great potential in you."
-			 ]
-		},
-	]
+  "name": "MaFl_Ispim",
+  "oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
+  "introText": [
+    "Welcome to Madrigal. You look lost! Is there anything I can help you with?"
+  ],
+  "byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am Ispim Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
+        "There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
+        "Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
+      ]
+    },
+    {
+      "id": "LOCATION",
+      "title": "Where am I?",
+      "texts": [
+        "Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
+        "If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
+      ]
+    },
+    {
+      "id": "SHOPS",
+      "title": "Shops?",
+      "texts": [
+        "There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
+        "You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
+        "People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
+      ]
+    },
+    {
+      "id": "DEATHS",
+      "title": "Death?",
+      "texts": [
+        "If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
+        "If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
+        "In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there, young one. I sense great potential in you."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Isruel.json
+++ b/bin/data/dialogs/en/MaFl_Isruel.json
@@ -3,52 +3,54 @@
 //
 
 {
-	"name": "MaFl_Isruel",
-	"oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
-	"introText": " ",
-	"byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"texts": [
-				"I am Isruel Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
-				"There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
-				"Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
-			 ]
-		},
-		{
-			"id": "LOCATION",
-			"title": "Where am I?",
-			"texts": [
-				"Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
-				"If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
-			 ]
-		},
-		{
-			"id": "SHOPS",
-			"title": "Shops?",
-			"texts": [
-				"There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
-				"You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
-				"People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
-			 ]
-		},
-		{
-			"id": "DEATHS",
-			"title": "Death?",
-			"texts": [
-				"If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
-				"If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
-				"In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
-			 ]
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			"texts": [
-				"Be careful out there, young one. I sense great potential in you."
-			 ]
-		},
-	]
+  "name": "MaFl_Isruel",
+  "oralText": "Welcome! If you need any help or information, please don't hesitate to ask.",
+  "introText": [
+    " "
+  ],
+  "byeText": "Goodbye, adventurer. Enjoy your stay in Flarine.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "I am Isruel Trinity, and I am one of the guides in Flarine City. If you need any help or information, just ask me or my twin sisters!",
+        "There are severals of us throughout Flarine and we all look alike so try not to be get confused, tee hee! We confuse ourselves sometimes so it's alright if you do.",
+        "Anyway, stop by and see me anytime if you need any help or information. That's what we're all here for!"
+      ]
+    },
+    {
+      "id": "LOCATION",
+      "title": "Where am I?",
+      "texts": [
+        "Flarine is the most beautiful city in Madrigal, in my humble opinion. It's always spring here and I love it. Just be careful of all the Masquerpets outside the city.",
+        "If you're going to explore the wilds of Flaris, make sure you stock up on supplies from one of our many vendors here before you leave."
+      ]
+    },
+    {
+      "id": "SHOPS",
+      "title": "Shops?",
+      "texts": [
+        "There are many shops in the city that sell everything from food  and drink, to weapons and armor. Have a look around to see what we have available!",
+        "You can also purchase exotic items from the many private shops in the area. These shops are usually run by other adventurers, such as yourself.",
+        "People from all over Madrigal visit this city everyday to shop and enjoy the sights. It is so beautiful here. Is there anything else I can assist you with?"
+      ]
+    },
+    {
+      "id": "DEATHS",
+      "title": "Death?",
+      "texts": [
+        "If your Health Points (HP) reach zero, you will die. Not to worry, through, you have several options when this happens.",
+        "If you select Lodestar, you will be summoned back to town and resurrected. Alternatively, players who've chosen the Assist Job can often resurrect you where you died.",
+        "In addition to this, you can also purchase a Scroll of Resurrection by selecting the Premium Item Shop icon on your task bar. This allows to resurrect in place."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there, young one. I sense great potential in you."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Jeff.json
+++ b/bin/data/dialogs/en/MaFl_Jeff.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Jeff",
   "oralText": "*sigh* I miss Kimberly so much. I can barely focus on my duties...",
-  "introText": "Ugh, I still get so many complaints about the machine I sold to Saint City and Darken City. I may have used substandard building materials from the Dekane Mines. Ah well...",
+  "introText": [
+    "Ugh, I still get so many complaints about the machine I sold to Saint City and Darken City. I may have used substandard building materials from the Dekane Mines. Ah well..."
+  ],
   "byeText": "Say hello to my wife, kimberly, in Saint City if you happen to see her, will you?",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Juria.json
+++ b/bin/data/dialogs/en/MaFl_Juria.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Juria",
   "oralText": "Welcome to the Office. of Flarine. How can I be of service?",
-  "introText": "*Sigh* Boboku is so manly, strong and kind. But I could never date him because his belly is too big!",
+  "introText": [
+    "*Sigh* Boboku is so manly, strong and kind. But I could never date him because his belly is too big!"
+  ],
   "byeText": "Farewell!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Kidmen.json
+++ b/bin/data/dialogs/en/MaFl_Kidmen.json
@@ -3,24 +3,26 @@
 //
 
 {
-	"name": "MaFl_Kidmen",
-	"oralText": "Spread the blessings of Rhisis throughout Madrigal! Sprinkle the tears of Rhisis upon the ground. Welcome to the club. Assist!",
-	"introText": "An Assist naturally have a giving heart. It's one of the fundamental teaching of Eiene, the Ringmaster Hero.",
-	"byeText": "Be careful out there, young one. I sense great potential in you.",
-	"links": [
-		{
-			"id": "PRESENTATION",
-			"title": "Who are you?",
-			"texts": [
-				"They call me Kidmen Nicore. I'm a Sergeant at the Madrigal Job Training Center and I hope to guide brave souls as they follow the path to becoming an Assist."
-			 ]
-		},
-		{
-			"id": "BYE",
-			"title": "Goodbye!",
-			 "texts": [
-				"Be careful out there, young one. I sense great potential in you."
-			 ]
-		}
-	]
+  "name": "MaFl_Kidmen",
+  "oralText": "Spread the blessings of Rhisis throughout Madrigal! Sprinkle the tears of Rhisis upon the ground. Welcome to the club. Assist!",
+  "introText": [
+    "An Assist naturally have a giving heart. It's one of the fundamental teaching of Eiene, the Ringmaster Hero."
+  ],
+  "byeText": "Be careful out there, young one. I sense great potential in you.",
+  "links": [
+    {
+      "id": "PRESENTATION",
+      "title": "Who are you?",
+      "texts": [
+        "They call me Kidmen Nicore. I'm a Sergeant at the Madrigal Job Training Center and I hope to guide brave souls as they follow the path to becoming an Assist."
+      ]
+    },
+    {
+      "id": "BYE",
+      "title": "Goodbye!",
+      "texts": [
+        "Be careful out there, young one. I sense great potential in you."
+      ]
+    }
+  ]
 }

--- a/bin/data/dialogs/en/MaFl_Luda.json
+++ b/bin/data/dialogs/en/MaFl_Luda.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Luda",
   "oralText": "Are you Vagrant? Do you weapons or armor? I've got what you need!",
-  "introText": "Hello, potential customer! Thanks for stopping by! Please, feel free to look at my collection of Vagrant weapons and armor. Careful though, you touch it, you buy it!",
+  "introText": [
+    "Hello, potential customer! Thanks for stopping by! Please, feel free to look at my collection of Vagrant weapons and armor. Careful though, you touch it, you buy it!"
+  ],
   "byeText": "Be careful out there. I wouldn't want to lose a potential customer! *Chuckles*",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Lui.json
+++ b/bin/data/dialogs/en/MaFl_Lui.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Lui",
   "oralText": "Come one, come all! Get your supplies here! You're gonna need it!",
-  "introText": "Going somewhere? You look a little unprepared, so I'd think twice about leaving Flarine without stocking up on supplies. Good thing for you, I'm here. So, whaddya need?",
+  "introText": [
+    "Going somewhere? You look a little unprepared, so I'd think twice about leaving Flarine without stocking up on supplies. Good thing for you, I'm here. So, whaddya need?"
+  ],
   "byeText": "Don't forget to shop at Handsome Lui's General Shop for your adventuring needs!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Martinyc.json
+++ b/bin/data/dialogs/en/MaFl_Martinyc.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Martinyc",
   "oralText": "The history of Madrigal... strange to say that least. I must discover the secrets!",
-  "introText": "Do you know anything about the history of Madrigal? No? Well I've been uncovering some fascinating information as of late. It seems that much of our history has been conveniently covered up. Interesting, huh?",
+  "introText": [
+    "Do you know anything about the history of Madrigal? No? Well I've been uncovering some fascinating information as of late. It seems that much of our history has been conveniently covered up. Interesting, huh?"
+  ],
   "byeText": "If you learn of any interesting facts about Madrigal's history, be sure to stop by again!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Mikyel.json
+++ b/bin/data/dialogs/en/MaFl_Mikyel.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Mikyel",
   "oralText": "Welcome to the Flarine Quest Office! Looking for work? I may have a job for you...",
-  "introText": "My apologies, there are no quests available for an adventurer of your talent and skill at this time.",
+  "introText": [
+    "My apologies, there are no quests available for an adventurer of your talent and skill at this time."
+  ],
   "byeText": "Farewell!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Official.json
+++ b/bin/data/dialogs/en/MaFl_Official.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Official",
   "oralText": "Welcome to Flarine!",
-  "introText": "The library is located to my right and the reception desk is to my left. You can speak with Julia for access your bank, view ranking information, or browse your Guild Warehouse.",
+  "introText": [
+    "The library is located to my right and the reception desk is to my left. You can speak with Julia for access your bank, view ranking information, or browse your Guild Warehouse."
+  ],
   "byeText": "Thank you for visiting the Public Office. For Flarine!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Peach.json
+++ b/bin/data/dialogs/en/MaFl_Peach.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Peach",
   "oralText": "Would anyone like a jewel crafted or perhaps a jewelry setting created ?",
-  "introText": "Hi there! I offer jewelry services to the citizens of Flarine and create and set jewels for those wishing to modify their Ultimate Weapons. I also remove blessings and level reductions from items, among other things!",
+  "introText": [
+    "Hi there! I offer jewelry services to the citizens of Flarine and create and set jewels for those wishing to modify their Ultimate Weapons. I also remove blessings and level reductions from items, among other things!"
+  ],
   "byeText": "Take care. Remember, for anything to do with jewels. I'm your girl!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_PetTamer.json
+++ b/bin/data/dialogs/en/MaFl_PetTamer.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_PetTamer",
   "oralText": "Raising your own pet takes patience and dedication. Are you ready?",
-  "introText": "Rawr! Tee hee! ^^ Sorry, I was just practicing my tiger call. Do you have a pet? I love pets, it's what I live for!",
+  "introText": [
+    "Rawr! Tee hee! ^^ Sorry, I was just practicing my tiger call. Do you have a pet? I love pets, it's what I live for!"
+  ],
   "byeText": "Don't forget to feed your pet!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Ray.json
+++ b/bin/data/dialogs/en/MaFl_Ray.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Ray",
   "oralText": "Hey, you two! Stop that bickering, it's pointless! Take it to the arena!",
-  "introText": "In the PvP arena, you can fight other adventurers such as yourself. If you meet unfortunate circumstances, and are slain on the arena floor, you will not incur any death penalties.",
+  "introText": [
+    "In the PvP arena, you can fight other adventurers such as yourself. If you meet unfortunate circumstances, and are slain on the arena floor, you will not incur any death penalties."
+  ],
   "byeText": "Another one bites the dust!",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_SecretRoom_EAST.json
+++ b/bin/data/dialogs/en/MaFl_SecretRoom_EAST.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_SecretRoom_EAST",
   "oralText": "Only the strongest of guilds can achieve victory in the Secret Room!",
-  "introText": "If your guild is the first to sucessfully complete the Secret Room, the tax rate can be set and collected by your guild for all Eastern Region territories. These terretories include Flaris, Saint Morning, Rhisis Garden, and the Forsaken Tower.",
+  "introText": [
+    "If your guild is the first to sucessfully complete the Secret Room, the tax rate can be set and collected by your guild for all Eastern Region territories. These terretories include Flaris, Saint Morning, Rhisis Garden, and the Forsaken Tower."
+  ],
   "byeText": "May Rhisis guide you, and be with you, young one.",
   "links": [
     {

--- a/bin/data/dialogs/en/MaFl_Waforu.json
+++ b/bin/data/dialogs/en/MaFl_Waforu.json
@@ -5,7 +5,9 @@
 {
   "name": "MaFl_Waforu",
   "oralText": "Step right up, champions! Welcome to the Red Chip Emporium!",
-  "introText": "Heya stranger! If your guild wins the Guild Siege, you will be awarded Red Chips for your victory. The armor sets I sell here in my shop are absolutely the best you can find! So how many Red Chips do you have, hmmmm?",
+  "introText": [
+    "Heya stranger! If your guild wins the Guild Siege, you will be awarded Red Chips for your victory. The armor sets I sell here in my shop are absolutely the best you can find! So how many Red Chips do you have, hmmmm?"
+  ],
   "byeText": "So long, contender. May Rhisis be with you.",
   "links": [
     {

--- a/src/Rhisis.Core/Structures/Game/Dialogs/DialogData.cs
+++ b/src/Rhisis.Core/Structures/Game/Dialogs/DialogData.cs
@@ -22,7 +22,7 @@ namespace Rhisis.Core.Structures.Game.Dialogs
         /// Gets or sets the dialog's introduction text.
         /// </summary>
         [DataMember(Name = "introText")]
-        public string IntroText { get; set; }
+        public IEnumerable<string> IntroText { get; set; }
 
         /// <summary>
         /// Gets or sets the dialog's goodbye text.
@@ -55,7 +55,7 @@ namespace Rhisis.Core.Structures.Game.Dialogs
         {
             this.Name = name;
             this.OralText = oralText;
-            this.IntroText = introText;
+            this.IntroText = new[] { introText };
             this.ByeText = byeText;
             this.Links = new List<DialogLink>();
         }

--- a/src/Rhisis.World/Systems/NpcDialog/NpcDialogSystem.cs
+++ b/src/Rhisis.World/Systems/NpcDialog/NpcDialogSystem.cs
@@ -57,7 +57,7 @@ namespace Rhisis.World.Systems.NpcDialog
                 return;
             }
 
-            IEnumerable<string> dialogTexts = new[] { npcEntity.Data.Dialog.IntroText };
+            IEnumerable<string> dialogTexts = npcEntity.Data.Dialog.IntroText;
 
             if (!string.IsNullOrEmpty(e.DialogKey))
             {


### PR DESCRIPTION
This PR covers issue #211 and updates the dialog data structure.

Before that, the NPC dialog `introText` was a single string. In order to enable multiple dialogs on introduction, `introText` is now an array.
To add multiple dialogs on the `introText`, you need to respect the following structure:

```json
{
    "name": "MaFl_NAME",
    "introText": [
        "First dialog",
        "Second dialog"
    ],
    ...
}
```

This will display the "First dialog" text in the NPC box and print a "next" button. When clicking on the next button, the "Second dialog" text will be shown.
