### PR TITLE
Death experience

### DIFF
--- a/bin/data/res/deathPenality.json
+++ b/bin/data/res/deathPenality.json
@@ -1,0 +1,23 @@
+{
+    "revivalPenality": [
+        { "level": 1, "value": 80 },
+        { "level": 2, "value": 60 },
+        { "level": 5, "value": 50 },
+        { "level": 10, "value": 40 },
+        { "level": 200, "value": 30 }
+    ],
+    "decExpPenality": [
+        { "level": 20, "value": 0 },
+        { "level": 29, "value": 6 },
+        { "level": 59, "value": 5 },
+        { "level": 89, "value": 4 },
+        { "level": 99, "value": 3 },
+        { "level": 109, "value": 2 },
+        { "level": 129, "value": 1.5 },
+        { "level": 200, "value": 1 }
+    ],
+    "levelDownPenality": [
+        { "level": 20, "value": 0 },
+        { "level": 200, "value": 1 }
+    ]
+}

--- a/src/Rhisis.CLI/Commands/Setup/SetupCommand.cs
+++ b/src/Rhisis.CLI/Commands/Setup/SetupCommand.cs
@@ -176,7 +176,6 @@ namespace Rhisis.CLI.Commands.Setup
                 "WI_WORLD_MADRIGAL"
             };
             worldConfiguration.Language = "en";
-            worldConfiguration.MailShippingCost = 500;
             worldConfiguration.Drops.OwnershipTime = 7;
             worldConfiguration.Drops.DespawnTime = 120;
 

--- a/src/Rhisis.Core/Helpers/ConfigurationHelper.cs
+++ b/src/Rhisis.Core/Helpers/ConfigurationHelper.cs
@@ -30,7 +30,8 @@ namespace Rhisis.Core.Helpers
             return JsonConvert.DeserializeObject<T>(fileContent, new JsonSerializerSettings
             {
                 MissingMemberHandling = MissingMemberHandling.Ignore,
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
             });
         }
 

--- a/src/Rhisis.Core/Resources/GameResources.cs
+++ b/src/Rhisis.Core/Resources/GameResources.cs
@@ -27,9 +27,11 @@ namespace Rhisis.Core.Resources
         public static readonly string JobPropPath = Path.Combine(DataSub1Path, "propJob.inc");
         public static readonly string TextClientPath = Path.Combine(DataSub1Path, "textClient.inc");
         public static readonly string ExpTablePath = Path.Combine(DataSub0Path, "expTable.inc");
+        public static readonly string DeathPenalityPath = Path.Combine(ResourcePath, "deathPenality.json");
 
         // Logs messages
         public const string UnableLoadMapMessage = "Unable to load map '{0}'. Reason: {1}.";
+        public const string UnableLoadMessage = "Unable to load {0}. Reason: {1}";
         public const string ObjectIgnoredMessage = "{0} id '{1}' was ignored. Reason: {2}.";
         public const string ObjectOverridedMessage = "{0} id '{1}' was overrided. Reason: {2}.";
         public const string ObjectErrorMessage = "{0} with id '{1}' has an error. Reason: {2}";
@@ -39,6 +41,7 @@ namespace Rhisis.Core.Resources
         private MoverLoader _movers;
         private ItemLoader _items;
         private ExpTableLoader _expTables;
+        private PenalityLoader _penalities;
 
         /// <summary>
         /// Gets the movers data.
@@ -54,6 +57,11 @@ namespace Rhisis.Core.Resources
         /// Gets the exp table data.
         /// </summary>
         public ExpTableLoader ExpTables => this._expTables ?? (this._expTables = DependencyContainer.Instance.Resolve<ExpTableLoader>());
+
+        /// <summary>
+        /// Gets the penality resources.
+        /// </summary>
+        public PenalityLoader Penalities => this._penalities ?? (this._penalities = DependencyContainer.Instance.Resolve<PenalityLoader>());
 
         /// <summary>
         /// Initialize the <see cref="GameResources"/> with loaders.

--- a/src/Rhisis.Core/Resources/Loaders/PenalityLoader.cs
+++ b/src/Rhisis.Core/Resources/Loaders/PenalityLoader.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.Helpers;
+using Rhisis.Core.Structures.Game;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Rhisis.Core.Resources.Loaders
+{
+    /// <summary>
+    /// Loads all server's penality data.
+    /// </summary>
+    public sealed class PenalityLoader : IGameResourceLoader
+    {
+        private readonly ILogger<PenalityLoader> _logger;
+        
+        /// <summary>
+        /// Gets the death penality data.
+        /// </summary>
+        public DeathPenalityData DeathPenality { get; private set; }
+
+        /// <summary>
+        /// Creates a new <see cref="PenalityLoader"/> instance.
+        /// </summary>
+        /// <param name="logger"></param>
+        public PenalityLoader(ILogger<PenalityLoader> logger)
+        {
+            this._logger = logger;
+        }
+
+        /// <inheritdoc />
+        public void Load()
+        {
+            if (!File.Exists(GameResources.DeathPenalityPath))
+            {
+                this._logger.LogWarning("Unable to load death penality. Reason: cannot find '{0}' file.", GameResources.DeathPenalityPath);
+                return;
+            }
+
+            this.DeathPenality = ConfigurationHelper.Load<DeathPenalityData>(GameResources.DeathPenalityPath);
+
+            if (this.DeathPenality == null)
+            {
+                this._logger.LogError(GameResources.UnableLoadMessage, "death penality", "Json loading error.");
+                return;
+            }
+
+            this.DeathPenality.RevivalPenality = this.DeathPenality.RevivalPenality.OrderBy(x => x.Level);
+            this.DeathPenality.DecExpPenality = this.DeathPenality.DecExpPenality.OrderBy(x => x.Level);
+            this.DeathPenality.LevelDownPenality = this.DeathPenality.LevelDownPenality.OrderBy(x => x.Level);
+
+            this._logger.LogInformation("-> Penalities loaded.");
+        }
+
+        /// <summary>
+        /// Gets a revival penality by a level.
+        /// </summary>
+        /// <param name="level">Level.</param>
+        /// <returns>Revival penality expressed as a percentage.</returns>
+        public decimal GetRevivalPenality(int level) => this.GetPenality(this.DeathPenality.RevivalPenality, level).Value;
+
+        /// <summary>
+        /// Gets the experience penality by a level.
+        /// </summary>
+        /// <param name="level">Level.</param>
+        /// <returns>Experience penality expressed as a percentage.</returns>
+        public decimal GetDecExpPenality(int level) => this.GetPenality(this.DeathPenality.DecExpPenality, level).Value;
+
+        /// <summary>
+        /// Gets the level down penality by a level.
+        /// </summary>
+        /// <param name="level">Level</param>
+        /// <returns>Boolean value that indicates if level should go down.</returns>
+        public bool GetLevelDownPenality(int level) 
+            => Convert.ToBoolean(this.GetPenality(this.DeathPenality.LevelDownPenality, level).Value);
+
+        /// <summary>
+        /// Gets a <see cref="PenalityData"/> from a collection of penalities and a level.
+        /// </summary>
+        /// <param name="penalityData">Penality data colletion.</param>
+        /// <param name="level">Level</param>
+        /// <returns></returns>
+        private PenalityData GetPenality(IEnumerable<PenalityData> penalityData, int level) 
+            => penalityData.FirstOrDefault(x => level <= x.Level) ?? penalityData.LastOrDefault();
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            this.DeathPenality = null;
+        }
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/DeathConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/DeathConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Structures.Configuration
+{
+    /// <summary>
+    /// Represents the death configuration section.
+    /// </summary>
+    [DataContract]
+    public sealed class DeathConfiguration
+    {
+        /// <summary>
+        /// Gets or sets a value that indicates if the death penality option is enabled.
+        /// </summary>
+        /// <remarks>
+        /// When the death penality systme is activated, experience is removed when a player dies.
+        /// </remarks>
+        [DataMember]
+        public bool DeathPenalityEnabled { get; set; } = true;
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/MailConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/MailConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Structures.Configuration
+{
+    /// <summary>
+    /// Represents the mail configuration section.
+    /// </summary>
+    public class MailConfiguration
+    {
+        public const int DefaultMailShippingCost = 500;
+
+        /// <summary>
+        /// Gets or sets mail shipping costs.
+        /// </summary>
+        [DataMember(Name = "mailShippingCost")]
+        public uint MailShippingCost { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="MailConfiguration"/> instance.
+        /// </summary>
+        public MailConfiguration()
+        {
+            this.MailShippingCost = DefaultMailShippingCost;
+        }
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/WorldConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/WorldConfiguration.cs
@@ -10,9 +10,7 @@ namespace Rhisis.Core.Structures.Configuration
     public class WorldConfiguration : BaseConfiguration
     {
         public const string DefaultLanguage = "en";
-        public const int DefaultMailShippingCost = 500;
         
-
         /// <summary>
         /// Gets or sets the world's id.
         /// </summary>
@@ -65,13 +63,13 @@ namespace Rhisis.Core.Structures.Configuration
         /// Gets or sets the IPC configuration.
         /// </summary>
         [DataMember(Name = "isc")]
-        public ISCConfiguration ISC { get; set; }
+        public ISCConfiguration ISC { get; set; } = new ISCConfiguration();
 
         /// <summary>
-        /// Gets or sets mail shipping costs.
+        /// Gets or sets the mails configuration.
         /// </summary>
-        [DataMember(Name = "mailShippingCost")]
-        public uint MailShippingCost { get; set; }
+        [DataMember(Name = "mails")]
+        public MailConfiguration Mails { get; set; } = new MailConfiguration();
 
         /// <summary>
         /// Gets or sets the Style Customization settings.
@@ -86,15 +84,18 @@ namespace Rhisis.Core.Structures.Configuration
         public PartyConfiguration PartyConfiguration { get; set; } = new PartyConfiguration();
 
         /// <summary>
+        /// Gets or sets the death configuration settings.
+        /// </summary>
+        [DataMember(Name = "death")]
+        public DeathConfiguration Death { get; set; } = new DeathConfiguration();
+
+        /// <summary>
         /// Creates a new <see cref="WorldConfiguration"/> instance.
         /// </summary>
         public WorldConfiguration()
         {
             this.Language = DefaultLanguage;
             this.Systems = new Dictionary<string, bool>();
-            this.ISC = new ISCConfiguration();
-            this.Rates = new WorldRates();
-            this.MailShippingCost = DefaultMailShippingCost;
         }
     }
 }

--- a/src/Rhisis.Core/Structures/Game/DeathPenalityData.cs
+++ b/src/Rhisis.Core/Structures/Game/DeathPenalityData.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Structures.Game
+{
+    [DataContract]
+    public class DeathPenalityData
+    {
+        [DataMember]
+        public IEnumerable<PenalityData> RevivalPenality { get; set; }
+
+        [DataMember]
+        public IEnumerable<PenalityData> DecExpPenality { get; set; }
+
+        [DataMember]
+        public IEnumerable<PenalityData> LevelDownPenality { get; set; }
+    }
+}

--- a/src/Rhisis.Core/Structures/Game/PenalityData.cs
+++ b/src/Rhisis.Core/Structures/Game/PenalityData.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.Serialization;
+
+namespace Rhisis.Core.Structures.Game
+{
+    [DataContract]
+    public class PenalityData
+    {
+        [DataMember]
+        public int Level { get; set; }
+
+        [DataMember]
+        public decimal Value { get; set; }
+    }
+}

--- a/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
+++ b/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
@@ -69,5 +69,10 @@ namespace Rhisis.World.Game.Components
         public int Version { get; set; } = StartVersion;
 
         public ModeType Mode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player level when it dies.
+        /// </summary>
+        public int DeathLevel { get; set; }
     }
 }

--- a/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/IMapRevivalRegion.cs
@@ -24,6 +24,11 @@ namespace Rhisis.World.Game.Maps.Regions
         bool IsChaoRegion { get; }
 
         /// <summary>
+        /// Gets a value that indicates if the current region has to target another revival key.
+        /// </summary>
+        bool TargetRevivalKey { get; }
+
+        /// <summary>
         /// Gets the revival position.
         /// </summary>
         Vector3 RevivalPosition { get; }

--- a/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
+++ b/src/Rhisis.World/Game/Maps/Regions/MapRevivalRegion.cs
@@ -15,6 +15,9 @@ namespace Rhisis.World.Game.Maps.Regions
         public bool IsChaoRegion { get; }
 
         /// <inheritdoc />
+        public bool TargetRevivalKey { get; }
+
+        /// <inheritdoc />
         public Vector3 RevivalPosition { get; }
 
         /// <summary>
@@ -28,13 +31,15 @@ namespace Rhisis.World.Game.Maps.Regions
         /// <param name="key">Revival map key.</param>
         /// <param name="position">Revival position.</param>
         /// <param name="isChao">Indicates that the region is a revival region for PK players.</param>
-        public MapRevivalRegion(int x, int z, int width, int length, int mapId, string key, Vector3 position, bool isChao)
+        /// <param name="targetRevivalKey">Indicates that the region has a revival target.</param>
+        public MapRevivalRegion(int x, int z, int width, int length, int mapId, string key, Vector3 position, bool isChao, bool targetRevivalKey)
             : base(x, z, width, length)
         {
             this.MapId = mapId;
             this.Key = key;
             this.RevivalPosition = position;
             this.IsChaoRegion = isChao;
+            this.TargetRevivalKey = targetRevivalKey;
         }
 
         /// <summary>
@@ -45,6 +50,6 @@ namespace Rhisis.World.Game.Maps.Regions
         /// <returns>New <see cref="MapRevivalRegion"/> instance.</returns>
         public static IMapRevivalRegion FromRgnElement(RgnRegion3 region, int revivalMapId)
             => new MapRevivalRegion(region.Left, region.Top, region.Right, region.Bottom,
-                                    revivalMapId, region.Key, region.Position.Clone(), region.ChaoKey);
+                                    revivalMapId, region.Key, region.Position.Clone(), region.ChaoKey, region.TargetKey);
     }
 }

--- a/src/Rhisis.World/Packets/PlayerPackets.cs
+++ b/src/Rhisis.World/Packets/PlayerPackets.cs
@@ -65,7 +65,7 @@ namespace Rhisis.World.Packets
                 packet.Write(0);
                 packet.Write((int)player.Statistics.SkillPoints);
                 packet.Write(long.MaxValue); // death exp
-                packet.Write(short.MaxValue); // death level
+                packet.Write((short)player.PlayerData.DeathLevel);
 
                 player.Connection.Send(packet);
             }

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -2,7 +2,9 @@
 using Rhisis.Core.Common.Formulas;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Resources;
 using Rhisis.Core.Structures.Configuration;
+using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
@@ -16,8 +18,6 @@ namespace Rhisis.World.Systems.Death
     [System(SystemType.Notifiable)]
     public sealed class DeathSystem : ISystem
     {
-        private const float RecoveryRate = 0.2f;
-
         private readonly ILogger<DeathSystem> _logger = DependencyContainer.Instance.Resolve<ILogger<DeathSystem>>();
         private readonly MapLoader _mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
         private readonly WorldConfiguration _worldConfiguration = DependencyContainer.Instance.Resolve<WorldConfiguration>();
@@ -42,12 +42,13 @@ namespace Rhisis.World.Systems.Death
                 return;
             }
 
+            decimal recoveryRate = GameResources.Instance.Penalities.GetRevivalPenality(player.Object.Level) / 100;
             var jobData = player.PlayerData.JobData;
             var playerStats = player.Statistics;
 
-            player.Health.Hp = (int)(HealthFormulas.GetMaxOriginHp(player.Object.Level, playerStats.Stamina, jobData.MaxHpFactor) * RecoveryRate);
-            player.Health.Mp = (int)(HealthFormulas.GetMaxOriginMp(player.Object.Level, playerStats.Intelligence, jobData.MaxMpFactor, true) * RecoveryRate);
-            player.Health.Fp = (int)(HealthFormulas.GetMaxOriginFp(player.Object.Level, playerStats.Stamina, playerStats.Dexterity, playerStats.Strength, jobData.MaxFpFactor, true) * RecoveryRate);
+            player.Health.Hp = (int)(HealthFormulas.GetMaxOriginHp(player.Object.Level, playerStats.Stamina, jobData.MaxHpFactor) * recoveryRate);
+            player.Health.Mp = (int)(HealthFormulas.GetMaxOriginMp(player.Object.Level, playerStats.Intelligence, jobData.MaxMpFactor, true) * recoveryRate);
+            player.Health.Fp = (int)(HealthFormulas.GetMaxOriginFp(player.Object.Level, playerStats.Stamina, playerStats.Dexterity, playerStats.Strength, jobData.MaxFpFactor, true) * recoveryRate);
 
             bool shouldReplace = false;
             if (revivalRegion.MapId != player.Object.MapId)
@@ -99,7 +100,30 @@ namespace Rhisis.World.Systems.Death
         {
             if (this._worldConfiguration.Death.DeathPenalityEnabled)
             {
-                // TODO: process death penality
+                decimal expLossPercent = GameResources.Instance.Penalities.GetDecExpPenality(player.Object.Level);
+
+                if (expLossPercent <= 0)
+                    return;
+
+                player.PlayerData.Experience -= player.PlayerData.Experience * (long)(expLossPercent / 100m);
+                player.PlayerData.DeathLevel = player.Object.Level;
+
+                if (player.PlayerData.Experience < 0)
+                {
+                    if (GameResources.Instance.Penalities.GetLevelDownPenality(player.Object.Level))
+                    {
+                        CharacterExpTableData previousLevelExp = GameResources.Instance.ExpTables.GetCharacterExp(player.Object.Level - 1);
+
+                        player.Object.Level--;
+                        player.PlayerData.Experience = previousLevelExp.Exp + player.PlayerData.Experience;
+                    }
+                    else
+                    {
+                        player.PlayerData.Experience = 0;
+                    }
+                }
+
+                // TODO: send exp loss packet
             }
         }
     }

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -123,7 +123,7 @@ namespace Rhisis.World.Systems.Death
                     }
                 }
 
-                // TODO: send exp loss packet
+                WorldPacketFactory.SendPlayerExperience(player);
             }
         }
     }

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -2,6 +2,7 @@
 using Rhisis.Core.Common.Formulas;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Structures.Configuration;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
@@ -19,6 +20,7 @@ namespace Rhisis.World.Systems.Death
 
         private readonly ILogger<DeathSystem> _logger = DependencyContainer.Instance.Resolve<ILogger<DeathSystem>>();
         private readonly MapLoader _mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
+        private readonly WorldConfiguration _worldConfiguration = DependencyContainer.Instance.Resolve<WorldConfiguration>();
 
         /// <inheritdoc />
         public WorldEntityType Type => WorldEntityType.Player;
@@ -85,6 +87,20 @@ namespace Rhisis.World.Systems.Death
             WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.HP, player.Health.Hp);
             WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.MP, player.Health.Mp);
             WorldPacketFactory.SendUpdateAttributes(player, DefineAttributes.FP, player.Health.Fp);
+
+            this.ProcessDeathPenality(player);
+        }
+
+        /// <summary>
+        /// Applies death penality if enabled.
+        /// </summary>
+        /// <param name="player">Death player entity.</param>
+        private void ProcessDeathPenality(IPlayerEntity player)
+        {
+            if (this._worldConfiguration.Death.DeathPenalityEnabled)
+            {
+                // TODO: process death penality
+            }
         }
     }
 }

--- a/src/Rhisis.World/Systems/Mailbox/MailboxSystem.cs
+++ b/src/Rhisis.World/Systems/Mailbox/MailboxSystem.cs
@@ -80,7 +80,7 @@ namespace Rhisis.World.Systems.Mailbox
 
             var textClient = DependencyContainer.Instance.Resolve<TextClientLoader>();
             var worldConfiguration = DependencyContainer.Instance.Resolve<WorldConfiguration>();
-            var neededGold = worldConfiguration.MailShippingCost;
+            var neededGold = worldConfiguration.Mails.MailShippingCost;
             
             using (var database = DependencyContainer.Instance.Resolve<IDatabase>())
             {

--- a/src/Rhisis.World/WorldServerStartup.cs
+++ b/src/Rhisis.World/WorldServerStartup.cs
@@ -37,6 +37,7 @@ namespace Rhisis.World
             typeof(JobLoader),
             typeof(TextClientLoader),
             typeof(ExpTableLoader),
+            typeof(PenalityLoader),
 
             // World server specific loaders
             typeof(NpcLoader),


### PR DESCRIPTION
This PR covers issue #30 and adds the experience loss when a player resurects. It has the following features:

- Add and load `deathPenality.json` file based on `DeathPenality.inc` from official files
- Add a `DeathConfiguration` section on `world.json` configuration allowing server administrators to enable or disable death penality.
- Use recovery rates from `deathPenality.json` when resurecting
- Remove exeperience based on player's level
- Remove level if experience goes under 0 if level is superior at the level defined in `deathPenality.json`
- Fix revival positions