### PR TITLE
Decoupled Rhisis.CLI from Rhisis.Core.DependencyInjection

### DIFF
--- a/src/Rhisis.CLI/Application.cs
+++ b/src/Rhisis.CLI/Application.cs
@@ -5,15 +5,17 @@ using Rhisis.CLI.Commands.User;
 
 namespace Rhisis.CLI
 {
-    [Command(ThrowOnUnexpectedArgument = false, Description = Program.Description)]
+    [Command(ThrowOnUnexpectedArgument = false, Description = Description)]
     [Subcommand(typeof(DatabaseCommand))]
     [Subcommand(typeof(SetupCommand))]
     [Subcommand(typeof(UserCommand))]
     public class Application
     {
         public const string DefaultDatabaseConfigurationFile = "config/database.json";
-
-        public void OnExecute(CommandLineApplication app, IConsole console)
+        public const string Description = "This tool is a command line interface allowing " +
+                                          "administrators to manage their own servers easily.";
+        
+        public void OnExecute(CommandLineApplication app)
         {
             app.ShowHelp();
         }

--- a/src/Rhisis.CLI/Commands/Database/DatabaseCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseCommand.cs
@@ -8,6 +8,6 @@ namespace Rhisis.CLI.Commands.Database
     [Subcommand(typeof(DatabaseInitializationCommand))]
     public class DatabaseCommand
     {
-        public void OnExecute(CommandLineApplication app, IConsole console) => app.ShowHelp();
+        public void OnExecute(CommandLineApplication app) => app.ShowHelp();
     }
 }

--- a/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
@@ -1,50 +1,57 @@
-﻿using McMaster.Extensions.CommandLineUtils;
+﻿using System;
+using McMaster.Extensions.CommandLineUtils;
 using Microsoft.EntityFrameworkCore.DataEncryption.Providers;
-using Rhisis.CLI.Helpers;
+using Rhisis.CLI.Services;
 using Rhisis.Core.Helpers;
 using Rhisis.Database;
-using System;
 
 namespace Rhisis.CLI.Commands.Database
 {
     [Command("configure", Description = "Configures the database access")]
     public class DatabaseConfigureCommand
-    {
+    {       
         [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "configuration", Description = "Specify the database configuration file path.")]
         public string DatabaseConfigurationFile { get; set; }
+        
+        private readonly ConsoleHelper _consoleHelper;
 
-        public void OnExecute(CommandLineApplication app, IConsole console)
+        public DatabaseConfigureCommand(ConsoleHelper consoleHelper)
+        {
+            _consoleHelper = consoleHelper;
+        }
+
+        public void OnExecute()
         {
             if (string.IsNullOrEmpty(DatabaseConfigurationFile))
                 DatabaseConfigurationFile = Application.DefaultDatabaseConfigurationFile;
-
+            
             var dbConfiguration = new DatabaseConfiguration()
             {
                 EncryptionKey = Convert.ToBase64String(AesProvider.GenerateKey(AesKeySize.AES256Bits).Key)
             };
 
             Console.WriteLine("Select one of the available providers:");
-            ConsoleHelper.DisplayEnum<DatabaseProvider>();
+            _consoleHelper.DisplayEnum<DatabaseProvider>();
             Console.Write("Database provider: ");
-            dbConfiguration.Provider = ConsoleHelper.ReadEnum<DatabaseProvider>();
+            dbConfiguration.Provider = _consoleHelper.ReadEnum<DatabaseProvider>();
 
             if (dbConfiguration.Provider == DatabaseProvider.MySql)
             {
                 Console.Write("Port (3306): ");
-                dbConfiguration.Port = ConsoleHelper.ReadIntegerOrDefault(3306);
+                dbConfiguration.Port = _consoleHelper.ReadIntegerOrDefault(3306);
             }
 
             Console.Write("Host (localhost): ");
-            dbConfiguration.Host = ConsoleHelper.ReadStringOrDefault("localhost");
+            dbConfiguration.Host = _consoleHelper.ReadStringOrDefault("localhost");
 
             Console.Write("Username (root): ");
-            dbConfiguration.Username = ConsoleHelper.ReadStringOrDefault("root");
+            dbConfiguration.Username = _consoleHelper.ReadStringOrDefault("root");
 
             Console.Write("Password: ");
-            dbConfiguration.Password = ConsoleHelper.ReadPassword();
+            dbConfiguration.Password = _consoleHelper.ReadPassword();
 
             Console.Write("Database name (rhisis): ");
-            dbConfiguration.Database = ConsoleHelper.ReadStringOrDefault("rhisis");
+            dbConfiguration.Database = _consoleHelper.ReadStringOrDefault("rhisis");
 
             Console.WriteLine("--------------------------------");
             Console.WriteLine("Configuration:");
@@ -58,7 +65,7 @@ namespace Rhisis.CLI.Commands.Database
 
             Console.WriteLine("--------------------------------");
             
-            bool response = ConsoleHelper.AskConfirmation("Save this configuration?");
+            bool response = _consoleHelper.AskConfirmation("Save this configuration?");
 
             if (response)
             {

--- a/src/Rhisis.CLI/Commands/Database/DatabaseInitializationCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseInitializationCommand.cs
@@ -1,4 +1,6 @@
 ﻿using McMaster.Extensions.CommandLineUtils;
+using Rhisis.CLI.Services;
+using Rhisis.Database;
 
 namespace Rhisis.CLI.Commands.Database
 {
@@ -11,22 +13,22 @@ namespace Rhisis.CLI.Commands.Database
         [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "configuration", Description = "Specify the database configuration file path.")]
         public string DatabaseConfigurationFile { get; set; }
 
-        public DatabaseInitializationCommand()
+        public DatabaseInitializationCommand(DatabaseFactory databaseFactory, ConsoleHelper consoleHelper)
         {
-            this._configurationCommand = new DatabaseConfigureCommand
+            this._configurationCommand = new DatabaseConfigureCommand(consoleHelper)
             {
                 DatabaseConfigurationFile = this.DatabaseConfigurationFile
             };
-            this._updateCommand = new DatabaseUpdateCommand
+            this._updateCommand = new DatabaseUpdateCommand(databaseFactory)
             {
                 DatabaseConfigurationFile = this.DatabaseConfigurationFile
             };
         }
 
-        public void OnExecute(CommandLineApplication app, IConsole console)
+        public void OnExecute()
         {
-            this._configurationCommand.OnExecute(app, console);
-            this._updateCommand.OnExecute(app, console);
+            this._configurationCommand.OnExecute();
+            this._updateCommand.OnExecute();
         }
     }
 }

--- a/src/Rhisis.CLI/Commands/Database/DatabaseUpdateCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseUpdateCommand.cs
@@ -1,31 +1,42 @@
 ﻿using System;
 using McMaster.Extensions.CommandLineUtils;
-using Rhisis.Core.DependencyInjection;
-using Rhisis.Database.Context;
+using Rhisis.Core.Helpers;
+using Rhisis.Database;
 
 namespace Rhisis.CLI.Commands.Database
 {
     [Command("update", Description = "Updates the database structure")]
     public class DatabaseUpdateCommand
     {
-        [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "configuration", Description = "Specify the database configuration file path.")]
+        private readonly IDatabase _database;
+
+        [Option(CommandOptionType.SingleValue, ShortName = "c", LongName = "configuration",
+            Description = "Specify the database configuration file path.")]
         public string DatabaseConfigurationFile { get; set; }
 
-        public void OnExecute(CommandLineApplication app, IConsole console)
+        public DatabaseUpdateCommand(DatabaseFactory databaseFactory)
         {
             if (string.IsNullOrEmpty(DatabaseConfigurationFile))
                 DatabaseConfigurationFile = Application.DefaultDatabaseConfigurationFile;
 
+            var dbConfig = ConfigurationHelper.Load<DatabaseConfiguration>(DatabaseConfigurationFile);
+            _database = databaseFactory.GetDatabase(dbConfig);
+        }
+
+        public void OnExecute()
+        {
             try
             {
                 Console.WriteLine("Starting database structure update...");
-                using (var rhisisDbContext = DependencyContainer.Instance.Resolve<DatabaseContext>())
+                var rhisisDbContext = _database.DatabaseContext;
+                if (rhisisDbContext.DatabaseExists())
                 {
-                    if (rhisisDbContext.DatabaseExists())
-                    {
-                        rhisisDbContext.Migrate();
-                        Console.WriteLine("Database updated.");
-                    }
+                    rhisisDbContext.Migrate();
+                    Console.WriteLine("Database updated.");
+                }
+                else
+                {
+                    Console.WriteLine("Database does not exist yet!");
                 }
             }
             catch (Exception e)

--- a/src/Rhisis.CLI/Commands/User/UserCommand.cs
+++ b/src/Rhisis.CLI/Commands/User/UserCommand.cs
@@ -7,6 +7,6 @@ namespace Rhisis.CLI.Commands.User
     [Subcommand(typeof(UserShowCommand))]
     public sealed class UserCommand
     {
-        public void OnExecute(CommandLineApplication app, IConsole console) => app.ShowHelp();
+        public void OnExecute(CommandLineApplication app) => app.ShowHelp();
     }
 }

--- a/src/Rhisis.CLI/Services/ConsoleHelper.cs
+++ b/src/Rhisis.CLI/Services/ConsoleHelper.cs
@@ -1,19 +1,19 @@
 ﻿using System;
 using System.Text;
 
-namespace Rhisis.CLI.Helpers
+namespace Rhisis.CLI.Services
 {
     /// <summary>
     /// Extends the basic console with helper methods.
     /// </summary>
-    public static class ConsoleHelper
+    public class ConsoleHelper
     {
         /// <summary>
         /// Reads a string value from the console.
         /// </summary>
         /// <param name="defaultValue">Default value return if input is empty</param>
         /// <returns></returns>
-        public static string ReadStringOrDefault(string defaultValue = null)
+        public string ReadStringOrDefault(string defaultValue = null)
         {
             string value = Console.ReadLine();
 
@@ -25,7 +25,7 @@ namespace Rhisis.CLI.Helpers
         /// </summary>
         /// <param name="defaultValue">Default value</param>
         /// <returns></returns>
-        public static int ReadIntegerOrDefault(int defaultValue = 0)
+        public int ReadIntegerOrDefault(int defaultValue = 0)
         {
             string value = Console.ReadLine();
 
@@ -41,7 +41,7 @@ namespace Rhisis.CLI.Helpers
         /// Displays an enum as a numbered list.
         /// </summary>
         /// <typeparam name="TEnum"></typeparam>
-        public static void DisplayEnum<TEnum>() where TEnum : struct
+        public void DisplayEnum<TEnum>() where TEnum : struct
         {
             string[] providerNames = Enum.GetNames(typeof(TEnum));
 
@@ -54,7 +54,7 @@ namespace Rhisis.CLI.Helpers
         /// </summary>
         /// <typeparam name="TEnum"></typeparam>
         /// <returns></returns>
-        public static TEnum ReadEnum<TEnum>() where TEnum : struct
+        public TEnum ReadEnum<TEnum>() where TEnum : struct
         {
             var value = default(TEnum);
             string[] providerNames = Enum.GetNames(typeof(TEnum));
@@ -77,7 +77,7 @@ namespace Rhisis.CLI.Helpers
         /// </summary>
         /// <param name="passwordCharacter">Password character used to hide input characters</param>
         /// <returns></returns>
-        public static string ReadPassword(string passwordCharacter = "*")
+        public string ReadPassword(string passwordCharacter = "*")
         {
             var password = new StringBuilder();
 
@@ -113,7 +113,7 @@ namespace Rhisis.CLI.Helpers
         /// </summary>
         /// <param name="confirmationMessage">Confirmation message</param>
         /// <returns></returns>
-        public static bool AskConfirmation(string confirmationMessage)
+        public bool AskConfirmation(string confirmationMessage)
         {
             Console.Write($"{confirmationMessage} (y/n): ");
             string response = Console.ReadLine();

--- a/src/Rhisis.Database/ConfigureDatabase.cs
+++ b/src/Rhisis.Database/ConfigureDatabase.cs
@@ -7,13 +7,14 @@ namespace Rhisis.Database
 {
     public static class ConfigureDatabase
     {
-        private const string MySqlConnectionString = "server={0};userid={1};pwd={2};port={4};database={3};sslmode=none;";
+        private const string MySqlConnectionString =
+            "server={0};userid={1};pwd={2};port={4};database={3};sslmode=none;";
+
         private const string MsSqlConnectionString = "Server={0};Database={1};User Id={2};Password={3};";
 
-        public static DbContextOptionsBuilder ConfigureCorrectDatabase(this DbContextOptionsBuilder optionsBuilder, 
+        public static DbContextOptionsBuilder ConfigureCorrectDatabase(this DbContextOptionsBuilder optionsBuilder,
             DatabaseConfiguration configuration)
         {
-            
             switch (configuration.Provider)
             {
                 case DatabaseProvider.MySql:
@@ -41,7 +42,12 @@ namespace Rhisis.Database
             return optionsBuilder;
         }
 
-        public static IServiceCollection RegisterDatabaseServices(this IServiceCollection serviceCollection, 
+        public static IServiceCollection RegisterDatabaseFactory(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.AddTransient<DatabaseFactory>();
+        }
+
+        public static IServiceCollection RegisterDatabaseServices(this IServiceCollection serviceCollection,
             DatabaseConfiguration configuration)
         {
             return serviceCollection

--- a/src/Rhisis.Database/Database.cs
+++ b/src/Rhisis.Database/Database.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Threading.Tasks;
 using Rhisis.Database.Context;
 using Rhisis.Database.Repositories;
 using Rhisis.Database.Repositories.Implementation;
-using System.Threading.Tasks;
 
 namespace Rhisis.Database
 {
@@ -23,6 +22,8 @@ namespace Rhisis.Database
 
         /// <inheritdoc />
         public IShortcutRepository TaskbarShortcuts { get; private set; }
+
+        public DatabaseContext DatabaseContext => _databaseContext;
 
         /// <summary>
         /// Creates a new <see cref="Database"/> object instance.

--- a/src/Rhisis.Database/DatabaseFactory.cs
+++ b/src/Rhisis.Database/DatabaseFactory.cs
@@ -2,12 +2,11 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Rhisis.Core.Helpers;
-using Rhisis.Database;
 using Rhisis.Database.Context;
 
-namespace Rhisis.Migrations
+namespace Rhisis.Database
 {
-    public class DbContextFactory : IDesignTimeDbContextFactory<DatabaseContext>
+    public class DatabaseFactory : IDesignTimeDbContextFactory<DatabaseContext>
     {
         private const string MigrationConfigurationEnv = "DB_CONFIG";
         
@@ -23,6 +22,20 @@ namespace Rhisis.Migrations
             DbContextOptionsBuilder optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.ConfigureCorrectDatabase(configuration);
             return new DatabaseContext(optionsBuilder.Options, configuration);
+        }
+        
+        /// <summary>
+        /// Creates a database on the given database configuration.
+        /// Lifetime should be managed by IOC framework if using any!
+        /// </summary>
+        /// <param name="configuration">The database configuration to use</param>
+        /// <returns>A new instance of an IDatabase implementation</returns>
+        public IDatabase GetDatabase(DatabaseConfiguration configuration)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+            optionsBuilder.ConfigureCorrectDatabase(configuration);
+            var databaseContext = new DatabaseContext(optionsBuilder.Options, configuration);
+            return new Database(databaseContext);
         }
     }
 }

--- a/src/Rhisis.Database/IDatabase.cs
+++ b/src/Rhisis.Database/IDatabase.cs
@@ -1,11 +1,16 @@
-﻿using Rhisis.Database.Repositories;
-using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Rhisis.Database.Context;
+using Rhisis.Database.Repositories;
 
 namespace Rhisis.Database
 {
     public interface IDatabase
     {
+        /// <summary>
+        /// Gets the database context used.
+        /// </summary>
+        DatabaseContext DatabaseContext { get; }
+
         /// <summary>
         /// Gets the users.
         /// </summary>


### PR DESCRIPTION
* Refactored Rhisis.CLI to solely use the .net core Microsoft.Extensions.DependencyInjection assembly, decoupling it from Rhisis.Core.DependencyInjection.
* Made ConsoleHelper a service that is injected into commands.

* Moved DbDesignTimeContextFactory to Rhisis.Database assembly.
* Renamed DbDesignTimeContextFactory to DatabaseFactory and added factory method for IDatabase.

ConsoleHelper isnt a static class anymore, but a service added to the .net core IOC/DI container.
McMasters.extensions.commandlineutils is now using the .net core dependency injection interfaces to handle it's inversion of control.

These changes should make CLI more sane to follow and extend. Adding services instead of static 'helpers' will make it more clear on how the program flow is. theres one way to get dependencies and this is through constructor based injection with the .net core dependancy interfaces (not entirely true because mcmaster allows for injection into the OnExecute method).

I removed the 'dependency' upon Rhisis.Core.DependencyInjection as I deem that class obsolete, it is basically doing what Microsoft.Extensions.DependencyInjection is already doing, so it is just a wrapper that adds an extra layer of 'complexity'(literally and figuratively).

Rhisis.CLI basically serves as an example project on how it can be done.

(Database, IDatabase are basically wrappers too for DBContext, but serve a slightly more usefull purpose)