### PR TITLE
Fix NPC loading and update timestep

### DIFF
--- a/src/Rhisis.Core/Resources/Dyo/CommonControlDyoElement.cs
+++ b/src/Rhisis.Core/Resources/Dyo/CommonControlDyoElement.cs
@@ -1,0 +1,198 @@
+﻿using Rhisis.Core.Data;
+using System.IO;
+using System.Text;
+
+namespace Rhisis.Core.Resources.Dyo
+{
+    public sealed class CommonControlDyoElement : DyoElement
+    {
+        private const uint CommonControlVersion1 = 0x80000000;
+        private const uint CommonControlVersion2 = 0x90000000;
+        private const int MaxControlDropItem = 4;
+        private const int MaxControlDropMonster = 3;
+        private const int MaxTrap = 3;
+        private const int MaxKey = 64;
+
+        /// <summary>
+        /// Defines the size of the data structure.
+        /// </summary>
+        private const int Size = 432;
+
+        public uint Version { get; private set; }
+
+        public uint Set { get; private set; }
+
+        public uint SetItem { get; private set; }
+
+        public uint SetLevel { get; private set; }
+
+        public uint SetQuestNum { get; private set; }
+
+        public uint SetFlagNum { get; private set; }
+
+        public uint SetGender { get; private set; }
+
+        public bool[] SetJob { get; private set; } = new bool[(int)DefineJob.MAX_JOB];
+
+        public uint SetEndu { get; private set; }
+
+        public uint MinItemNum { get; private set; }
+
+        public uint MaxItemNum { get; private set; }
+
+        public uint[] InsideItemKind { get; private set; } = new uint[MaxControlDropItem];
+
+        public uint[] InsideItemPer { get; private set; } = new uint[MaxControlDropItem];
+
+        public uint[] MonsterResistanceKind { get; private set; } = new uint[MaxControlDropMonster];
+
+        public uint[] MonsterResistanceNum { get; private set; } = new uint[MaxControlDropMonster];
+
+        public uint[] MonsterActionAttack { get; private set; } = new uint[MaxControlDropMonster];
+
+        public uint TrapOperTime { get; private set; }
+
+        public uint TrapRandomPer { get; private set; }
+
+        public uint TrapDelay { get; private set; }
+
+        public uint[] TrapKind { get; private set; } = new uint[MaxTrap];
+
+        public uint[] TrapLevel { get; private set; } = new uint[MaxTrap];
+
+        public string LinkControlKey { get; private set; }
+
+        public string ControlKey { get; private set; }
+
+        public uint SetQuestNum1 { get; private set; }
+
+        public uint SetFlagNum1 { get; private set; }
+
+        public uint SetQuestNum2 { get; private set; }
+
+        public uint SetFlagNum2 { get; private set; }
+
+        public uint SetItemCount { get; private set; }
+
+        public uint TeleportWorldId { get; private set; }
+
+        public uint TeleportX { get; private set; }
+
+        public uint TeleportY { get; private set; }
+
+        public uint TeleportZ { get; private set; }
+
+        public override void Read(BinaryReader reader)
+        {
+            base.Read(reader);
+
+            this.Version = reader.ReadUInt32();
+
+            if (this.Version == CommonControlVersion1)
+            {
+                this.Set = reader.ReadUInt32();
+                this.SetItem = reader.ReadUInt32();
+                this.SetLevel = reader.ReadUInt32();
+                this.SetQuestNum = reader.ReadUInt32();
+                this.SetFlagNum = reader.ReadUInt32();
+                this.SetGender = reader.ReadUInt32();
+
+                for (int i = 0; i < this.SetJob.Length; i++)
+                    this.SetJob[i] = reader.ReadInt32() == 1;
+
+                this.SetEndu = reader.ReadUInt32();
+
+                this.MinItemNum = reader.ReadUInt32();
+                this.MaxItemNum = reader.ReadUInt32();
+
+                for (int i = 0; i < MaxControlDropItem; i++)
+                {
+                    this.InsideItemKind[i] = reader.ReadUInt32();
+                    this.InsideItemPer[i] = reader.ReadUInt32();
+                }
+
+                for (int i = 0; i < MaxControlDropMonster; i++)
+                {
+                    this.MonsterResistanceKind[i] = reader.ReadUInt32();
+                    this.MonsterResistanceNum[i] = reader.ReadUInt32();
+                    this.MonsterActionAttack[i] = reader.ReadUInt32();
+                }
+
+                this.TrapOperTime = reader.ReadUInt32();
+                this.TrapRandomPer = reader.ReadUInt32();
+                this.TrapDelay = reader.ReadUInt32();
+
+                for (int i = 0; i < MaxTrap; i++)
+                {
+                    this.TrapKind[i] = reader.ReadUInt32();
+                    this.TrapLevel[i] = reader.ReadUInt32();
+                }
+
+                this.LinkControlKey = Encoding.Default.GetString(reader.ReadBytes(MaxKey));
+                this.ControlKey = Encoding.Default.GetString(reader.ReadBytes(MaxKey));
+
+                this.SetQuestNum1 = reader.ReadUInt32();
+                this.SetFlagNum1 = reader.ReadUInt32();
+                this.SetQuestNum2 = reader.ReadUInt32();
+                this.SetFlagNum2 = reader.ReadUInt32();
+                this.SetItemCount = reader.ReadUInt32();
+                this.TeleportWorldId = reader.ReadUInt32();
+                this.TeleportX = reader.ReadUInt32();
+                this.TeleportY = reader.ReadUInt32();
+                this.TeleportZ = reader.ReadUInt32();
+            }
+            else if (this.Version == CommonControlVersion2)
+            {
+                this.Set = reader.ReadUInt32();
+                this.SetItem = reader.ReadUInt32();
+                this.SetLevel = reader.ReadUInt32();
+                this.SetQuestNum = reader.ReadUInt32();
+                this.SetFlagNum = reader.ReadUInt32();
+                this.SetGender = reader.ReadUInt32();
+
+                for (int i = 0; i < this.SetJob.Length; i++)
+                    this.SetJob[i] = reader.ReadInt32() == 1;
+
+                this.SetEndu = reader.ReadUInt32();
+
+                this.MinItemNum = reader.ReadUInt32();
+                this.MaxItemNum = reader.ReadUInt32();
+
+                for (int i = 0; i < MaxControlDropItem; i++)
+                {
+                    this.InsideItemKind[i] = reader.ReadUInt32();
+                }
+                this.InsideItemPer[0] = reader.ReadUInt32();
+
+                this.TrapOperTime = reader.ReadUInt32();
+                this.TrapRandomPer = reader.ReadUInt32();
+                this.TrapDelay = reader.ReadUInt32();
+
+                for (int i = 0; i < MaxTrap; i++)
+                {
+                    this.TrapKind[i] = reader.ReadUInt32();
+                    this.TrapLevel[i] = reader.ReadUInt32();
+                }
+
+                this.LinkControlKey = Encoding.Default.GetString(reader.ReadBytes(MaxKey));
+                this.ControlKey = Encoding.Default.GetString(reader.ReadBytes(MaxKey));
+
+                this.SetQuestNum1 = reader.ReadUInt32();
+                this.SetFlagNum1 = reader.ReadUInt32();
+                this.SetQuestNum2 = reader.ReadUInt32();
+                this.SetFlagNum2 = reader.ReadUInt32();
+                this.SetItemCount = reader.ReadUInt32();
+                this.TeleportWorldId = reader.ReadUInt32();
+                this.TeleportX = reader.ReadUInt32();
+                this.TeleportY = reader.ReadUInt32();
+                this.TeleportZ = reader.ReadUInt32();
+            }
+            else
+            {
+                this.Set = this.Version;
+                reader.BaseStream.Position += Size - (sizeof(uint) * 10);
+                this.SetItem = reader.ReadUInt32();
+            }
+        }
+    }
+}

--- a/src/Rhisis.Core/Resources/Dyo/DyoElement.cs
+++ b/src/Rhisis.Core/Resources/Dyo/DyoElement.cs
@@ -5,6 +5,8 @@ namespace Rhisis.Core.Resources.Dyo
 {
     public class DyoElement
     {
+        public int ElementType { get; internal set; }
+
         public float Angle { get; private set; }
 
         public Vector3 Axis { get; private set; }

--- a/src/Rhisis.Core/Resources/Dyo/DyoFile.cs
+++ b/src/Rhisis.Core/Resources/Dyo/DyoFile.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rhisis.Core.Common;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -24,22 +25,32 @@ namespace Rhisis.Core.Resources.Dyo
             this._elements = new List<DyoElement>();
             var memoryReader = new BinaryReader(this);
 
-            while (true)
+            while (memoryReader.BaseStream.Position < memoryReader.BaseStream.Length)
             {
                 DyoElement rgnElement = null;
-                int type = memoryReader.ReadInt32();
+                uint type = memoryReader.ReadUInt32();
 
-                if (type == -1)
-                    break;
-
-                if (type == 5)
+                switch (type)
                 {
-                    rgnElement = new NpcDyoElement();
-                    rgnElement.Read(memoryReader);
+                    case (int)WorldObjectType.Control:
+                        rgnElement = new CommonControlDyoElement();
+                        break;
+                    case (int)WorldObjectType.Mover:
+                        rgnElement = new NpcDyoElement();
+                        break;
+                    case (int)WorldObjectType.Object:
+                    case (int)WorldObjectType.Item:
+                    case (int)WorldObjectType.Ship:
+                        rgnElement = new DyoElement();
+                        break;
                 }
 
-                if (rgnElement != null)
-                    this._elements.Add(rgnElement);
+                if (rgnElement == null)
+                    break;
+
+                rgnElement.ElementType = (int)type;
+                rgnElement.Read(memoryReader);
+                this._elements.Add(rgnElement);
             }
         }
         

--- a/src/Rhisis.Core/Resources/Dyo/NpcDyoElement.cs
+++ b/src/Rhisis.Core/Resources/Dyo/NpcDyoElement.cs
@@ -3,20 +3,64 @@ using System.Text;
 
 namespace Rhisis.Core.Resources.Dyo
 {
+    /// <summary>
+    /// Represents a NPC in a dyo file.
+    /// </summary>
     public class NpcDyoElement : DyoElement
     {
+        /// <summary>
+        /// Gets the Npc Korean name.
+        /// </summary>
         public string Name { get; private set; }
 
+        /// <summary>
+        /// Gets the Npc dialog name.
+        /// </summary>
+        public string DialogName { get; private set; }
+
+        /// <summary>
+        /// Gets the Npc key.
+        /// </summary>
+        public string CharacterKey { get; private set; }
+
+        /// <summary>
+        /// Gets the Npc belligerence.
+        /// </summary>
+        public int Belligerence { get; set; }
+
+        /// <summary>
+        /// Gets the Npc extra flags.
+        /// </summary>
+        public int ExtraFlag { get; set; }
+
+        /// <summary>
+        /// Reads the NPC informations.
+        /// </summary>
+        /// <param name="reader"></param>
         public override void Read(BinaryReader reader)
         {
             base.Read(reader);
 
-            reader.ReadBytes(64); // Korean name
-            reader.ReadBytes(32); // dialog name
-            this.Name = Encoding.GetEncoding(0).GetString(reader.ReadBytes(32));
-            this.Name = this.Name.Substring(0, this.Name.IndexOf('\0'));
-            reader.ReadInt32(); // ??
-            reader.ReadInt32(); // ??
+            this.Name = this.ConvertToString(reader.ReadBytes(64));
+            this.DialogName = this.ConvertToString(reader.ReadBytes(32));
+            this.CharacterKey = this.ConvertToString(reader.ReadBytes(32));
+            this.Belligerence = reader.ReadInt32();
+            this.ExtraFlag = reader.ReadInt32();
+        }
+
+        /// <summary>
+        /// Converts a buffer into a string.
+        /// </summary>
+        /// <remarks>
+        /// It trims the converted string if finds a '\0'.
+        /// </remarks>
+        /// <param name="buffer"></param>
+        /// <returns></returns>
+        private string ConvertToString(byte[] buffer)
+        {
+            string convertedString = Encoding.Default.GetString(buffer);
+
+            return convertedString.Substring(0, convertedString.IndexOf('\0'));
         }
     }
 }

--- a/src/Rhisis.World/Game/Entities/NpcEntity.cs
+++ b/src/Rhisis.World/Game/Entities/NpcEntity.cs
@@ -33,5 +33,8 @@ namespace Rhisis.World.Game.Entities
             this.Object.Type = WorldObjectType.Mover;
             this.Timers = new NpcTimerComponent();
         }
+
+        /// <inheritdoc />
+        public override string ToString() => $"{this.Object.Name}";
     }
 }

--- a/src/Rhisis.World/Systems/NpcShop/NpcShopSystem.cs
+++ b/src/Rhisis.World/Systems/NpcShop/NpcShopSystem.cs
@@ -58,7 +58,7 @@ namespace Rhisis.World.Systems.NpcShop
         /// <param name="e"></param>
         private void OpenShop(IPlayerEntity player, NpcShopOpenEventArgs e)
         {
-            var npc = player.Context.FindEntity<INpcEntity>(e.NpcObjectId);
+            var npc = player.Object.CurrentMap.FindEntity<INpcEntity>(e.NpcObjectId);
             if (npc == null)
             {
                 Logger.Error("ShopSystem: Cannot find NPC with object id : {0}", e.NpcObjectId);


### PR DESCRIPTION
This PR fixes the NPC loading by adding the `CommonControlDyoElement` class that loads a common control from the official DYO files. All NPCs weren't loading because there was a CommonControl element in the middle of the file that needed to be handled.

Also, this PR provides fixes to the map instance game loop.