### PR TITLE
Teleport system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This is the changelog of the Rhisis project. All notable changes to this project
 - Death System and resurection (PR [#206](https://github.com/Eastrall/Rhisis/pull/206))
 - Experience and Level up (PR [#214](https://github.com/Eastrall/Rhisis/pull/214), [#218](https://github.com/Eastrall/Rhisis/pull/218))
 - Experience loss on death (PR [#216](https://github.com/Eastrall/Rhisis/pull/216))
+- Teleport system (PR [#222](https://github.com/Eastrall/Rhisis/pull/222))
 
 #### Resources
 

--- a/src/Rhisis.Core/Resources/Wld/WldFile.cs
+++ b/src/Rhisis.Core/Resources/Wld/WldFile.cs
@@ -9,6 +9,7 @@ namespace Rhisis.Core.Resources
     /// </summary>
     public class WldFile : FileStream, IDisposable
     {
+        private const int DefaultMPU = 4;
         private static readonly char[] SplitCharacters = new[] { ' ', '\t' };
         public WldFileInformations WorldInformations { get; private set; }
 
@@ -31,7 +32,7 @@ namespace Rhisis.Core.Resources
             Vector3 size = null;
             bool isIndoor = false;
             bool canFly = false;
-            int mpu = 0;
+            int mpu = DefaultMPU;
             int revivalMapId = 0;
             string revivalKey = string.Empty;
 

--- a/src/Rhisis.World/Game/Chat/TeleportCommand.cs
+++ b/src/Rhisis.World/Game/Chat/TeleportCommand.cs
@@ -1,10 +1,7 @@
 ﻿using NLog;
 using Rhisis.Core.Common;
-using Rhisis.Core.DependencyInjection;
 using Rhisis.World.Game.Entities;
-using Rhisis.World.Game.Loaders;
-using Rhisis.World.Game.Maps;
-using Rhisis.World.Packets;
+using Rhisis.World.Systems.Teleport;
 using System;
 
 namespace Rhisis.World.Game.Chat
@@ -17,42 +14,35 @@ namespace Rhisis.World.Game.Chat
         [ChatCommand("/teleport", AuthorityType.GameMaster)]
         public static void TeleportCommand(IPlayerEntity player, string[] parameters)
         {
-            Logger.Debug("{0} want to teleport", player.Object.Name);
-
             switch (parameters.Length)
             {
                 case 2: // when you write 2 parameters in the command
-                    TeleportationParameters.TeleportCommandTwoParam(player, parameters);
+                    TeleportCommandTwoParam(player, parameters);
                     break;
                 case 3: // when you write 3 parameters in the command
-                    TeleportationParameters.TeleportCommandThreeParam(player, parameters);
+                    TeleportCommandThreeParam(player, parameters);
                     break;
                 case 4: // when you write 4 parameters in the command
-                    TeleportationParameters.TeleportCommandFourParam(player, parameters);
+                    TeleportCommandFourParam(player, parameters);
                     break;
                 default: // when you write more than 4 or less than 2 parameters in the command
                     Logger.Error("Chat: /teleport command must have 2, 3 or 4 parameters.");
                     return;
             }
-            WorldPacketFactory.SendPlayerTeleport(player);
         }
-    }
-    internal static class TeleportationParameters
-    {
-        private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
-        private static readonly MapLoader Maps = DependencyContainer.Instance.Resolve<MapLoader>();
 
-        public static void TeleportCommandTwoParam(IPlayerEntity player, string[] parameters)
+        private static void TeleportCommandTwoParam(IPlayerEntity player, string[] parameters)
         {
             if (!float.TryParse(parameters[0], out float posXValue) || !float.TryParse(parameters[1], out float posZValue))
             {
                 throw new ArgumentException("You must write numbers for teleport command's parameters");
             }
 
-            player.Object.Position.X = posXValue;
-            player.Object.Position.Z = posZValue;
+            player.NotifySystem<TeleportSystem>(new TeleportEventArgs(player.Object.MapId, posXValue, posZValue));
+
         }
-        public static void TeleportCommandThreeParam(IPlayerEntity player, string[] parameters)
+
+        private static void TeleportCommandThreeParam(IPlayerEntity player, string[] parameters)
         {
             if (!ushort.TryParse(parameters[0], out ushort mapIdValue) || !float.TryParse(parameters[1], out float posXValue)
                 || !float.TryParse(parameters[2], out float posZValue))
@@ -60,19 +50,11 @@ namespace Rhisis.World.Game.Chat
                 throw new ArgumentException("You must write numbers for teleport command's parameters");
             }
 
-            IMapInstance mapIdResult = Maps[mapIdValue];
 
-            if (mapIdResult == null)
-            {
-                Logger.Error($"Cannot find map Id in define files: {mapIdResult}. Please check you defineWorld.h file.");
-                return;
-            }
-
-            player.Object.MapId = mapIdValue;
-            player.Object.Position.X = posXValue;
-            player.Object.Position.Z = posZValue;
+            player.NotifySystem<TeleportSystem>(new TeleportEventArgs(mapIdValue, posXValue, posZValue));
         }
-        public static void TeleportCommandFourParam(IPlayerEntity player, string[] parameters)
+
+        private static void TeleportCommandFourParam(IPlayerEntity player, string[] parameters)
         {
             if (!ushort.TryParse(parameters[0], out ushort mapIdValue) || !float.TryParse(parameters[1], out float posXValue)
             || !float.TryParse(parameters[2], out float posYValue) || !float.TryParse(parameters[3], out float posZValue))
@@ -80,19 +62,7 @@ namespace Rhisis.World.Game.Chat
                 throw new ArgumentException("You must write numbers for teleport command's parameters");
             }
 
-            IMapInstance mapIdResult = Maps[mapIdValue];
-
-            if (mapIdResult == null)
-            {
-                Logger.Error($"Cannot find map Id in define files: {mapIdValue}. Please check you defineWorld.h file.");
-
-                return;
-            }
-
-            player.Object.MapId = mapIdValue;
-            player.Object.Position.X = posXValue;
-            player.Object.Position.Y = posYValue;
-            player.Object.Position.Z = posZValue;
+            player.NotifySystem<TeleportSystem>(new TeleportEventArgs(mapIdValue, posXValue, posZValue));
         }
     }
 }

--- a/src/Rhisis.World/Game/Maps/IMapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/IMapInstance.cs
@@ -21,6 +21,16 @@ namespace Rhisis.World.Game.Maps
         string Name { get; }
 
         /// <summary>
+        /// Gets the map instance width.
+        /// </summary>
+        int Width { get; }
+
+        /// <summary>
+        /// Gets the map instance length.
+        /// </summary>
+        int Length { get; }
+
+        /// <summary>
         /// Gets the map default revival region.
         /// </summary>
         IMapRevivalRegion DefaultRevivalRegion { get; }
@@ -106,5 +116,12 @@ namespace Rhisis.World.Game.Maps
         /// <param name="isChaoMode">Region is chao mode (PK mode).</param>
         /// <returns>Revival region matching the key and the chao mode.</returns>
         IMapRevivalRegion GetRevivalRegion(string revivalKey, bool isChaoMode);
+
+        /// <summary>
+        /// Checks if the given position is enters the map bounds.
+        /// </summary>
+        /// <param name="position">Position.</param>
+        /// <returns>True; if the position is in the map bounds; false otherwise.</returns>
+        bool ContainsPosition(Vector3 position);
     }
 }

--- a/src/Rhisis.World/Game/Maps/MapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/MapInstance.cs
@@ -28,6 +28,7 @@ namespace Rhisis.World.Game.Maps
     public class MapInstance : Context, IMapInstance
     {
         private const int DefaultMapLayerId = 1;
+        private const int MapLandSize = 128;
 
         private readonly string _mapPath;
         private readonly List<IMapLayer> _layers;
@@ -49,14 +50,10 @@ namespace Rhisis.World.Game.Maps
         /// <inheritdoc />
         public IMapRevivalRegion DefaultRevivalRegion { get; private set; }
 
-        /// <summary>
-        /// Gets the map instance width.
-        /// </summary>
+        /// <inheritdoc />
         public int Width => this._worldInformations.Width;
 
-        /// <summary>
-        /// Gets the map instance length.
-        /// </summary>
+        /// <inheritdoc />
         public int Length => this._worldInformations.Length;
 
         /// <inheritdoc />
@@ -335,6 +332,18 @@ namespace Rhisis.World.Game.Maps
                                                            select x;
 
             return revivalRegion.FirstOrDefault() ?? this.DefaultRevivalRegion;
+        }
+
+        /// <inheritdoc />
+        public bool ContainsPosition(Vector3 position)
+        {
+            float x = position.X / this._worldInformations.MPU;
+            float z = position.Z / this._worldInformations.MPU;
+
+            if (x < 0 || x > this.Width * MapLandSize || z < 0 || z > this.Length * MapLandSize)
+                return false;
+
+            return true;
         }
 
         /// <summary>

--- a/src/Rhisis.World/Systems/Teleport/TeleportEventArgs.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportEventArgs.cs
@@ -1,0 +1,41 @@
+﻿using Rhisis.World.Game.Core.Systems;
+
+namespace Rhisis.World.Systems.Teleport
+{
+    public class TeleportEventArgs : SystemEventArgs
+    {
+        /// <summary>
+        /// Gets the target map id.
+        /// </summary>
+        public int MapId { get; }
+
+        /// <summary>
+        /// Gets the target X position.
+        /// </summary>
+        public float PositionX { get; }
+
+        /// <summary>
+        /// Gets target Z position.
+        /// </summary>
+        public float PositionZ { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="TeleportEventArgs"/> instance.
+        /// </summary>
+        /// <param name="mapId">Target Map Id.</param>
+        /// <param name="positionX">Target X position.</param>
+        /// <param name="positionZ">Target Z position.</param>
+        public TeleportEventArgs(int mapId, float positionX, float positionZ)
+        {
+            this.MapId = mapId;
+            this.PositionX = positionX;
+            this.PositionZ = positionZ;
+        }
+
+        /// <inheritdoc />
+        public override bool CheckArguments()
+        {
+            return this.MapId > 0 && this.PositionX > 0f && this.PositionZ > 0;
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
@@ -67,7 +67,7 @@ namespace Rhisis.World.Systems.Teleport
 
                 if (destinationMap == null)
                 {
-                    this._logger.LogError($"Cannot find map with id '{destinationMap.Id}'.");
+                    this._logger.LogError($"Cannot find map with id '{e.MapId}'.");
                     return;
                 }
 

--- a/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Extensions.Logging;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.World.Game.Core;
+using Rhisis.World.Game.Core.Systems;
+using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World.Systems.Teleport
+{
+    /// <summary>
+    /// Teleport system used to teleport player to a target map at a given position.
+    /// </summary>
+    [System(SystemType.Notifiable)]
+    public sealed class TeleportSystem : ISystem
+    {
+        private readonly ILogger<TeleportSystem> _logger;
+
+        /// <summary>
+        /// Creates a new <see cref="TeleportSystem"/> instance.
+        /// </summary>
+        public TeleportSystem()
+        {
+            this._logger = DependencyContainer.Instance.Resolve<ILogger<TeleportSystem>>();
+        }
+
+        /// <inheritdoc />
+        public WorldEntityType Type => WorldEntityType.Player;
+
+        /// <inheritdoc />
+        public void Execute(IEntity entity, SystemEventArgs args)
+        {
+            if (!(entity is IPlayerEntity player))
+            {
+                this._logger.LogError($"Cannot execute {nameof(TeleportSystem)}. {entity.Object.Name} is not a player.");
+                return;
+            }
+
+            if (!args.CheckArguments())
+            {
+                this._logger.LogError($"Cannot execute {nameof(TeleportSystem)} action: {args.GetType()} due to invalid arguments.");
+                return;
+            }
+
+            switch (args)
+            {
+                case TeleportEventArgs e:
+                    this.Teleport(player, e);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Teleports the player to the given map and position.
+        /// </summary>
+        /// <param name="player">Player.</param>
+        /// <param name="e">Teleport args.</param>
+        private void Teleport(IPlayerEntity player, TeleportEventArgs e)
+        {
+            // TODO
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
@@ -1,8 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Structures;
 using Rhisis.World.Game.Core;
 using Rhisis.World.Game.Core.Systems;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Loaders;
+using Rhisis.World.Game.Maps;
+using Rhisis.World.Packets;
 
 namespace Rhisis.World.Systems.Teleport
 {
@@ -13,6 +17,7 @@ namespace Rhisis.World.Systems.Teleport
     public sealed class TeleportSystem : ISystem
     {
         private readonly ILogger<TeleportSystem> _logger;
+        private readonly MapLoader _mapLoader;
 
         /// <summary>
         /// Creates a new <see cref="TeleportSystem"/> instance.
@@ -20,6 +25,7 @@ namespace Rhisis.World.Systems.Teleport
         public TeleportSystem()
         {
             this._logger = DependencyContainer.Instance.Resolve<ILogger<TeleportSystem>>();
+            this._mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
         }
 
         /// <inheritdoc />
@@ -55,7 +61,50 @@ namespace Rhisis.World.Systems.Teleport
         /// <param name="e">Teleport args.</param>
         private void Teleport(IPlayerEntity player, TeleportEventArgs e)
         {
-            // TODO
+            if (player.Object.MapId != e.MapId)
+            {
+                IMapInstance destinationMap = this._mapLoader.GetMapById(e.MapId);
+
+                if (destinationMap == null)
+                {
+                    this._logger.LogError($"Cannot find map with id '{destinationMap.Id}'.");
+                    return;
+                }
+
+                if (!destinationMap.ContainsPosition(new Vector3(e.PositionX, 0, e.PositionZ)))
+                {
+                    this._logger.LogError($"Cannot teleport. Destination position is out of map bounds.");
+                    return;
+                }
+
+                IMapLayer defaultMapLayer = destinationMap.GetDefaultMapLayer();
+                player.SwitchContext(defaultMapLayer);
+                player.Object.Spawned = false;
+                player.Object.MapId = destinationMap.Id;
+                player.Object.LayerId = defaultMapLayer.Id;
+
+                // TODO: get map height at x/z position
+                player.Object.Position = new Vector3(e.PositionX, 100, e.PositionZ);
+                player.Moves.DestinationPosition = player.Object.Position.Clone();
+
+                WorldPacketFactory.SendReplaceObject(player);
+                WorldPacketFactory.SendPlayerSpawn(player);
+                player.Object.Spawned = true;
+            }
+            else
+            {
+                if (!player.Object.CurrentMap.ContainsPosition(new Vector3(e.PositionX, 0, e.PositionZ)))
+                {
+                    this._logger.LogError($"Cannot teleport. Destination position is out of map bounds.");
+                    return;
+                }
+
+                // TODO: get map height at x/z position
+                player.Object.Position = new Vector3(e.PositionX, 100, e.PositionZ);
+                player.Moves.DestinationPosition = player.Object.Position.Clone();
+            }
+
+            WorldPacketFactory.SendPlayerTeleport(player);
         }
     }
 }


### PR DESCRIPTION
This PR adds the `TeleportSystem`. This system is mainly used by the `/tp` and `/teleport` commands, but is also used for revival.

To use the system, simply call it like this:
```csharp
var teleportEvent = new TeleportEventArgs(mapId, posX, posZ);
player.NotifySystem<TeleportSystem>(teleportEvent);
```