### PR TITLE
#229 Fix Null ref when player doesn't have an item

### DIFF
--- a/src/Rhisis.World/Handlers/BattleHandler.cs
+++ b/src/Rhisis.World/Handlers/BattleHandler.cs
@@ -30,9 +30,9 @@ namespace Rhisis.World.Handlers
                 return;
             }
 
-            Item weaponItem = client.Player.Inventory[InventorySystem.RightWeaponSlot];
+            Item weaponItem = client.Player.Inventory.GetItem(x => x.Slot == InventorySystem.RightWeaponSlot) ?? InventorySystem.Hand;
 
-            if (weaponItem != null && weaponItem.Data.AttackSpeed != meleePacket.WeaponAttackSpeed)
+            if (weaponItem != null && weaponItem.Data?.AttackSpeed != meleePacket.WeaponAttackSpeed)
             {
                 Logger.LogCritical($"Player {client.Player.Object.Name} has changed his weapon speed.");
                 return;

--- a/src/Rhisis.World/Systems/Battle/BattleHelper.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleHelper.cs
@@ -1,10 +1,7 @@
 ﻿using Rhisis.Core.Data;
 using Rhisis.Core.Helpers;
 using Rhisis.Core.Structures;
-using Rhisis.World.Game.Common;
 using Rhisis.World.Game.Entities;
-using Rhisis.World.Game.Structures;
-using Rhisis.World.Systems.Inventory;
 using System;
 
 namespace Rhisis.World.Systems.Battle

--- a/src/Rhisis.World/Systems/Battle/MeleeAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/MeleeAttackArbiter.cs
@@ -45,10 +45,7 @@ namespace Rhisis.World.Systems.Battle
             
             if (this._attacker is IPlayerEntity player)
             {
-                Item rightWeapon = player.Inventory.GetItem(x => x.Slot == InventorySystem.RightWeaponSlot);
-
-                if (rightWeapon == null)
-                    rightWeapon = InventorySystem.Hand;
+                Item rightWeapon = player.Inventory.GetItem(x => x.Slot == InventorySystem.RightWeaponSlot) ?? InventorySystem.Hand;
 
                 // TODO: GetDamagePropertyFactor()
                 int weaponAttack = BattleHelper.GetWeaponAttackDamages(rightWeapon.Data.WeaponType, player);
@@ -100,7 +97,7 @@ namespace Rhisis.World.Systems.Battle
         {
             // TODO: if attacker mode == ONEKILL_MODE, return AF_GENERIC
 
-            int hitRate = 0;
+            int hitRate;
             int hitRating = this.GetHitRating(this._attacker);
             int escapeRating = this.GetEspaceRating(this._defender);
 
@@ -110,7 +107,7 @@ namespace Rhisis.World.Systems.Battle
                 hitRate = (int)(((hitRating * 1.5f) / (hitRating + escapeRating)) * 2.0f *
                           (this._attacker.Object.Level * 0.5f / (this._attacker.Object.Level + this._defender.Object.Level * 0.3f)) * 100.0f);
             }
-            else 
+            else
             {
                 // Player VS Player or Player VS Monster
                 hitRate = (int)(((hitRating * 1.6f) / (hitRating + escapeRating)) * 1.5f *

--- a/src/Rhisis.World/WorldServerStartup.cs
+++ b/src/Rhisis.World/WorldServerStartup.cs
@@ -69,7 +69,11 @@ namespace Rhisis.World
             DependencyContainer.Instance.Configure(services => services.AddLogging(builder =>
             {
                 builder.AddFilter("Microsoft", LogLevel.Warning);
+#if DEBUG
                 builder.SetMinimumLevel(LogLevel.Trace);
+#else
+                builder.SetMinimumLevel(LogLevel.Warning);
+#endif
                 builder.AddNLog(new NLogProviderOptions
                 {
                     CaptureMessageTemplates = true,

--- a/src/Rhisis.World/nlog.config
+++ b/src/Rhisis.World/nlog.config
@@ -23,15 +23,6 @@
       <highlight-word text="[DEBUG]" foregroundColor="Blue"/>
       <highlight-word text="[TRACE]" foregroundColor="DarkBlue"/>
     </target>
-    <!--Basic colored console-->
-    <!--<target name="console" xsi:type="ColoredConsole"
-            layout="[${longdate}] [${uppercase:${level}}] [${logger:shortName=true}] ${message} ${exception:format=tostring}">
-      <highlight-row condition="level == LogLevel.Fatal" foregroundColor="DarkRed"/>
-      <highlight-row condition="level == LogLevel.Error" foregroundColor="Red"/>
-      <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow"/>
-      <highlight-row condition="level == LogLevel.Debug" foregroundColor="Blue"/>
-      <highlight-row condition="level == LogLevel.Trace	" foregroundColor="Gray"/>
-    </target>-->
   </targets>
   <rules>
     <logger name="*" writeTo="console,file" />


### PR DESCRIPTION
This PR fixes the `NullReferenceExeption` when a player try to attack a monster without any weapon.

When the player doesn't have any weapon equiped, the hand is used.