### PR TITLE
Remove SQL Server support from Rhisis.Database

### DIFF
--- a/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
@@ -30,19 +30,11 @@ namespace Rhisis.CLI.Commands.Database
                 EncryptionKey = Convert.ToBase64String(AesProvider.GenerateKey(AesKeySize.AES256Bits).Key)
             };
 
-            Console.WriteLine("Select one of the available providers:");
-            _consoleHelper.DisplayEnum<DatabaseProvider>();
-            Console.Write("Database provider: ");
-            dbConfiguration.Provider = _consoleHelper.ReadEnum<DatabaseProvider>();
-
-            if (dbConfiguration.Provider == DatabaseProvider.MySql)
-            {
-                Console.Write("Port (3306): ");
-                dbConfiguration.Port = _consoleHelper.ReadIntegerOrDefault(3306);
-            }
-
             Console.Write("Host (localhost): ");
             dbConfiguration.Host = _consoleHelper.ReadStringOrDefault("localhost");
+
+            Console.Write("Port (3306): ");
+            dbConfiguration.Port = _consoleHelper.ReadIntegerOrDefault(3306);
 
             Console.Write("Username (root): ");
             dbConfiguration.Username = _consoleHelper.ReadStringOrDefault("root");
@@ -55,14 +47,10 @@ namespace Rhisis.CLI.Commands.Database
 
             Console.WriteLine("--------------------------------");
             Console.WriteLine("Configuration:");
-            Console.WriteLine($"Database Provider: {dbConfiguration.Provider.ToString()}");
             Console.WriteLine($"Host: {dbConfiguration.Host}");
             Console.WriteLine($"Username: {dbConfiguration.Username}");
             Console.WriteLine($"Database name: {dbConfiguration.Database}");
-
-            if (dbConfiguration.Provider == DatabaseProvider.MySql)
-                Console.WriteLine($"Port: {dbConfiguration.Port}");
-
+            Console.WriteLine($"Port: {dbConfiguration.Port}");
             Console.WriteLine("--------------------------------");
             
             bool response = _consoleHelper.AskConfirmation("Save this configuration?");

--- a/src/Rhisis.Database/ConfigureDatabase.cs
+++ b/src/Rhisis.Database/ConfigureDatabase.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Rhisis.Database.Context;
@@ -10,34 +9,15 @@ namespace Rhisis.Database
         private const string MySqlConnectionString =
             "server={0};userid={1};pwd={2};port={4};database={3};sslmode=none;";
 
-        private const string MsSqlConnectionString = "Server={0};Database={1};User Id={2};Password={3};";
-
         public static DbContextOptionsBuilder ConfigureCorrectDatabase(this DbContextOptionsBuilder optionsBuilder,
             DatabaseConfiguration configuration)
         {
-            switch (configuration.Provider)
-            {
-                case DatabaseProvider.MySql:
-                    optionsBuilder.UseMySql(
-                        string.Format(MySqlConnectionString,
+            optionsBuilder.UseMySql(string.Format(MySqlConnectionString,
                             configuration.Host,
                             configuration.Username,
                             configuration.Password,
                             configuration.Database,
                             configuration.Port));
-                    break;
-
-                case DatabaseProvider.MsSql:
-                    optionsBuilder.UseSqlServer(
-                        string.Format(MsSqlConnectionString,
-                            configuration.Host,
-                            configuration.Database,
-                            configuration.Username,
-                            configuration.Password));
-                    break;
-
-                default: throw new NotImplementedException($"Provider {configuration.Provider} not implemented yet.");
-            }
 
             return optionsBuilder;
         }

--- a/src/Rhisis.Database/DatabaseConfiguration.cs
+++ b/src/Rhisis.Database/DatabaseConfiguration.cs
@@ -36,12 +36,6 @@ namespace Rhisis.Database
         public string Database { get; set; }
 
         /// <summary>
-        /// Gets or sets the database provider.
-        /// </summary>
-        [DataMember(Name = "provider")]
-        public DatabaseProvider Provider { get; set; }
-
-        /// <summary>
         /// Gets or sets the database encryption key.
         /// </summary>
         /// <remarks>
@@ -63,6 +57,6 @@ namespace Rhisis.Database
 
         /// <inheritdoc />
         public override string ToString() 
-            => $"Host: {Host}, Port: {Port}, Username: {Username}, Password: {Password}, Database: {Database}, Provider: {Provider}";
+            => $"Host: {Host}, Port: {Port}, Username: {Username}, Password: {Password}, Database: {Database}";
     }
 }

--- a/src/Rhisis.Database/DatabaseProvider.cs
+++ b/src/Rhisis.Database/DatabaseProvider.cs
@@ -1,9 +1,0 @@
-﻿namespace Rhisis.Database
-{
-    public enum DatabaseProvider
-    {
-        Unknown = 0,
-        MySql,
-        MsSql
-    }
-}

--- a/src/Rhisis.Database/Rhisis.Database.csproj
+++ b/src/Rhisis.Database/Rhisis.Database.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="EntityFrameworkCore.DataEncryption" Version="1.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
This PR covers issue #230 and removes the support for multiple database providers and thus, SQL Server provider.
We will keep using the MySQL database engine.