### PR TITLE
Fix item drop refine

### DIFF
--- a/src/Rhisis.World/Game/Behaviors/DefaultPlayerBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/DefaultPlayerBehavior.cs
@@ -64,7 +64,7 @@ namespace Rhisis.World.Game.Behaviors
             }
             else
             {
-                var inventoryItemCreationEvent = new InventoryCreateItemEventArgs(droppedItem.Drop.Item.Id, droppedItem.Drop.Item.Quantity, -1);
+                var inventoryItemCreationEvent = new InventoryCreateItemEventArgs(droppedItem.Drop.Item.Id, droppedItem.Drop.Item.Quantity, -1, droppedItem.Drop.Item.Refine);
                 player.NotifySystem<InventorySystem>(inventoryItemCreationEvent);
                 WorldPacketFactory.SendDefinedText(player, DefineText.TID_GAME_REAPITEM, $"\"{droppedItem.Object.Name}\"");
             }

--- a/src/Rhisis.World/Systems/Inventory/EventArgs/InventoryCreateItemEventArgs.cs
+++ b/src/Rhisis.World/Systems/Inventory/EventArgs/InventoryCreateItemEventArgs.cs
@@ -23,22 +23,39 @@ namespace Rhisis.World.Systems.Inventory.EventArgs
         public int CreatorId { get; }
 
         /// <summary>
+        /// Gets or sets the item refine.
+        /// </summary>
+        public int Refine { get; set; }
+
+        /// <summary>
         /// Gets the data of the item to create.
         /// </summary>
         public ItemData ItemData { get; private set; }
 
-        /// <inheritdoc />
         /// <summary>
-        /// Creates a new <see cref="T:Rhisis.World.Systems.Inventory.EventArgs.InventoryCreateItemEventArgs" /> instance.
+        /// Creates a new <see cref="InventoryCreateItemEventArgs" /> instance.
         /// </summary>
         /// <param name="itemId">Item id</param>
         /// <param name="quantity">Item quantity</param>
         /// <param name="creatorId">Item creator id</param>
         public InventoryCreateItemEventArgs(int itemId, int quantity, int creatorId)
+            : this(itemId, quantity, creatorId, 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="InventoryCreateItemEventArgs"/> instance.
+        /// </summary>
+        /// <param name="itemId">Item id</param>
+        /// <param name="quantity">Item quantity</param>
+        /// <param name="creatorId">Item creator id</param>
+        /// <param name="refine">Item refine.</param>
+        public InventoryCreateItemEventArgs(int itemId, int quantity, int creatorId, int refine)
         {
             this.ItemId = itemId;
             this.Quantity = quantity;
             this.CreatorId = creatorId;
+            this.Refine = refine;
         }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -2,6 +2,7 @@
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Extensions;
+using Rhisis.Core.Helpers;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Core;
@@ -298,6 +299,7 @@ namespace Rhisis.World.Systems.Inventory
                     {
                         Slot = availableSlot,
                         UniqueId = player.Inventory.Items[availableSlot].UniqueId,
+                        Refine = (byte)Math.Max(e.Refine, 0)
                     };
 
                     player.Inventory.Items[availableSlot] = newItem;


### PR DESCRIPTION
This PR fixes issue #234.

Items with refine picked up from the ground have the correct refine in inventory.