### PR TITLE
#246 Fix equipement bug for female characters

### DIFF
--- a/src/Rhisis.Core/Resources/Loaders/ItemLoader.cs
+++ b/src/Rhisis.Core/Resources/Loaders/ItemLoader.cs
@@ -96,15 +96,15 @@ namespace Rhisis.Core.Resources.Loaders
         {
             var itemParams = new Dictionary<DefineAttributes, int>();
 
-            if (item.DestParam1 != "0")
+            if (item.DestParam1 != null && item.DestParam1 != "0")
             {
                 itemParams.Add(item.DestParam1.Replace("DST_", string.Empty).ToEnum<DefineAttributes>(), item.AdjustParam1);
             }
-            if (item.DestParam2 != "0")
+            if (item.DestParam2 != null && item.DestParam2 != "0")
             {
                 itemParams.Add(item.DestParam2.Replace("DST_", string.Empty).ToEnum<DefineAttributes>(), item.AdjustParam2);
             }
-            if (item.DestParam3 != "0")
+            if (item.DestParam3 != null && item.DestParam3 != "0")
             {
                 itemParams.Add(item.DestParam3.Replace("DST_", string.Empty).ToEnum<DefineAttributes>(), item.AdjustParam3);
             }

--- a/src/Rhisis.Core/Structures/Game/ItemData.cs
+++ b/src/Rhisis.Core/Structures/Game/ItemData.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Core.Data;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Runtime.Serialization;
 
 namespace Rhisis.Core.Structures.Game
@@ -32,6 +33,7 @@ namespace Rhisis.Core.Structures.Game
         public ItemKind3 ItemKind3 { get; set; }
 
         [DataMember(Name = "dwItemSex")]
+        [DefaultValue(int.MaxValue)]
         public int ItemSex { get; set; }
 
         [DataMember(Name = "dwCost")]

--- a/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
@@ -30,7 +30,7 @@ namespace Rhisis.World.Systems.Inventory
         /// <returns>True if the player can equip the item; false otherwise.</returns>
         public bool IsItemEquipable(IPlayerEntity player, Item item)
         {
-            if (item.Data.ItemSex != player.VisualAppearance.Gender)
+            if (item.Data.ItemSex != int.MaxValue && item.Data.ItemSex != player.VisualAppearance.Gender)
             {
                 this._logger.LogDebug("Wrong sex for armor");
                 WorldPacketFactory.SendDefinedText(player, DefineText.TID_GAME_WRONGSEX, item.Data.Name);


### PR DESCRIPTION
This PR fixes issue #246 about item equipement. The problem was due to a resource loading issue. When loading items, there is a property names `dwItemSex` indicating which gender can use/equip the item.

Some weapons have the `=` value which was translated to `0`. Other weapons and suits, gloves, boots, etc.. have a `SEX_MALE` and `SEX_FEMALE`. These two directives have the following values:
* `SEX_MALE` = `0`
* `SEX_FEMALE` = `1`

Has you notice, there weapons with value `=` behave the same way has the items with `SEX_MALE`.

I have introduced a fix that allow to define a default value to the properties when they have a `=` value.

How to use:
```cs
[DataMember(Name = "dwItemSex")]
[DefaultValue(int.MaxValue)] // Use the default value attribute on a property
public int ItemSex { get; set; }
```