### PR TITLE
Fix item drop and item move bug

### DIFF
--- a/src/Rhisis.World/Systems/Inventory/EventArgs/InventoryDropItemEventArgs.cs
+++ b/src/Rhisis.World/Systems/Inventory/EventArgs/InventoryDropItemEventArgs.cs
@@ -28,7 +28,7 @@ namespace Rhisis.World.Systems.Inventory.EventArgs
         /// <inheritdoc />
         public override bool CheckArguments()
         {
-            return (this.UniqueItemId >= 0 && this.UniqueItemId < InventorySystem.EquipOffset) && this.Quantity > 0;
+            return this.UniqueItemId >= 0 && this.Quantity > 0;
         }
     }
 }

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -109,12 +109,6 @@ namespace Rhisis.World.Systems.Inventory
                     };
                 }
             }
-
-            for (int i = EquipOffset; i < MaxItems; ++i)
-            {
-                if (inventory.Items[i].Id == -1)
-                    inventory.Items[i].UniqueId = -1;
-            }
         }
 
         /// <summary>
@@ -320,7 +314,13 @@ namespace Rhisis.World.Systems.Inventory
 
             if (inventoryItem == null)
             {
-                Logger.LogWarning($"Cannot find item with unique Id: {e.UniqueItemId}");
+                Logger.LogWarning($"{player.Object.Name}: Cannot find item with unique Id: {e.UniqueItemId}");
+                return;
+            }
+
+            if (inventoryItem.Slot >= EquipOffset)
+            {
+                Logger.LogWarning($"{player.Object.Name}: Cannot drop an equiped item.");
                 return;
             }
 


### PR DESCRIPTION
This PR fixes a minor issue with item drop and item moving in the inventory.

Item dropping wasn't working when the player unequip and item and tries to drop it.
As for the item moving system, when the player unequip an item, he could name move it again.