### PR TITLE
#235 Fix death bug

### DIFF
--- a/src/Rhisis.World/Game/Behaviors/DefaultMonsterBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/DefaultMonsterBehavior.cs
@@ -92,6 +92,14 @@ namespace Rhisis.World.Game.Behaviors
         /// <param name="monster"></param>
         private void ProcessMonsterFight(IMonsterEntity monster)
         {
+            if (monster.Battle.Target.Health.IsDead)
+            {
+                monster.Follow.Target = null;
+                monster.Battle.Target = null;
+                monster.Battle.Targets.Clear();
+                return;
+            }
+
             if (monster.Follow.IsFollowing)
             {
                 monster.Moves.DestinationPosition = monster.Follow.Target.Object.Position.Clone();


### PR DESCRIPTION
This PR fixes issue #235. When the player attacks several monsters and dies at battle. Only the monster that killed the player releases the target on the player and goes away. Other monsters will keep the target and follow the player to town to kill him again.

With this PR, all monsters targeting a dead player releases the target on him and go away.