### PR TITLE
Add blinkwing item usage

### DIFF
--- a/src/Rhisis.Core/Data/DefineJob.cs
+++ b/src/Rhisis.Core/Data/DefineJob.cs
@@ -1,132 +1,150 @@
 ﻿namespace Rhisis.Core.Data
 {
-    public enum DefineJob
+    public class DefineJob
     {
-        JTYPE_BASE = 0,
-        JTYPE_EXPERT = 1,
-        JTYPE_PRO = 2,
-        JTYPE_TROUPE = 3,
-        JTYPE_COMMON = 4,
-        JTYPE_MASTER = 5,
-        JTYPE_HERO = 6,
+        public enum JobType : int
+        {
+            JTYPE_BASE = 0,
+            JTYPE_EXPERT = 1,
+            JTYPE_PRO = 2,
+            JTYPE_TROUPE = 3,
+            JTYPE_COMMON = 4,
+            JTYPE_MASTER = 5,
+            JTYPE_HERO = 6,
+        }
 
-        MAX_JOB_SKILL = 3,
-        MAX_EXPERT_SKILL = 20,
-        MAX_PRO_SKILL = 20,
-        MAX_TROUPE_SKILL = 9,
-        MAX_MASTER_SKILL = 1,
-        MAX_HERO_SKILL = 1,
+        public enum JobMax : int
+        {
+            MAX_JOB_SKILL = 3,
+            MAX_EXPERT_SKILL = 20,
+            MAX_PRO_SKILL = 20,
+            MAX_TROUPE_SKILL = 9,
+            MAX_MASTER_SKILL = 1,
+            MAX_HERO_SKILL = 1,
 
-        MAX_JOB_LEVEL = 15,
-        MAX_EXP_LEVEL = 45,
-        MAX_PRO_LEVEL = 30,
-        MAX_TROUPE_LEVEL = 1,
+            MAX_JOB_LEVEL = 15,
+            MAX_EXP_LEVEL = 45,
+            MAX_PRO_LEVEL = 30,
+            MAX_TROUPE_LEVEL = 1,
 
-        MAX_LEGEND_LEVEL = 129,
-        MAX_MONSTER_LEVEL = 160,
-        MAX_LEVEL = 120,
+            MAX_LEGEND_LEVEL = 129,
+            MAX_MONSTER_LEVEL = 160,
+            MAX_LEVEL = 120,
+            MAX_JOBBASE = 1,
+            MAX_EXPERT = 6,
+            MAX_PROFESSIONAL = 16,
+            MAX_MASTER = 24,
+            MAX_HERO = 32,
+            MAX_JOB = 32,
+        }
 
-        JOB_VAGRANT = 0,
-        MAX_JOBBASE = 1,
+        public enum Job : int
+        {
+            JOB_VAGRANT = 0,
 
-        // Expert
-        JOB_MERCENARY = 1,
-        JOB_ACROBAT = 2,
-        JOB_ASSIST = 3,
-        JOB_MAGICIAN = 4,
-        JOB_PUPPETEER = 5,
-        MAX_EXPERT = 6,
+            // Expert
+            JOB_MERCENARY = 1,
+            JOB_ACROBAT = 2,
+            JOB_ASSIST = 3,
+            JOB_MAGICIAN = 4,
+            JOB_PUPPETEER = 5,
 
-        // Professional
-        JOB_KNIGHT = 6,
-        JOB_BLADE = 7,
-        JOB_JESTER = 8,
-        JOB_RANGER = 9,
-        JOB_RINGMASTER = 10,
-        JOB_BILLPOSTER = 11,
-        JOB_PSYCHIKEEPER = 12,
-        JOB_ELEMENTOR = 13,
-        JOB_GATEKEEPER = 14,
-        JOB_DOPPLER = 15,
-        MAX_PROFESSIONAL = 16,
+            // Professional
+            JOB_KNIGHT = 6,
+            JOB_BLADE = 7,
+            JOB_JESTER = 8,
+            JOB_RANGER = 9,
+            JOB_RINGMASTER = 10,
+            JOB_BILLPOSTER = 11,
+            JOB_PSYCHIKEEPER = 12,
+            JOB_ELEMENTOR = 13,
+            JOB_GATEKEEPER = 14,
+            JOB_DOPPLER = 15,
 
-        // Master
-        JOB_KNIGHT_MASTER = 16,
-        JOB_BLADE_MASTER = 17,
-        JOB_JESTER_MASTER = 18,
-        JOB_RANGER_MASTER = 19,
-        JOB_RINGMASTER_MASTER = 20,
-        JOB_BILLPOSTER_MASTER = 21,
-        JOB_PSYCHIKEEPER_MASTER = 22,
-        JOB_ELEMENTOR_MASTER = 23,
-        MAX_MASTER = 24,
+            // Master
+            JOB_KNIGHT_MASTER = 16,
+            JOB_BLADE_MASTER = 17,
+            JOB_JESTER_MASTER = 18,
+            JOB_RANGER_MASTER = 19,
+            JOB_RINGMASTER_MASTER = 20,
+            JOB_BILLPOSTER_MASTER = 21,
+            JOB_PSYCHIKEEPER_MASTER = 22,
+            JOB_ELEMENTOR_MASTER = 23,
 
-        // Hero
-        JOB_KNIGHT_HERO = 24,
-        JOB_BLADE_HERO = 25,
-        JOB_JESTER_HERO = 26,
-        JOB_RANGER_HERO = 27,
-        JOB_RINGMASTER_HERO = 28,
-        JOB_BILLPOSTER_HERO = 29,
-        JOB_PSYCHIKEEPER_HERO = 30,
-        JOB_ELEMENTOR_HERO = 31,
-        MAX_HERO = 32,
+            // Hero
+            JOB_KNIGHT_HERO = 24,
+            JOB_BLADE_HERO = 25,
+            JOB_JESTER_HERO = 26,
+            JOB_RANGER_HERO = 27,
+            JOB_RINGMASTER_HERO = 28,
+            JOB_BILLPOSTER_HERO = 29,
+            JOB_PSYCHIKEEPER_HERO = 30,
+            JOB_ELEMENTOR_HERO = 31,
 
-        MAX_JOB = 32,
-        JOB_ALL = 32,
+            JOB_ALL = 32,
+        }
 
-        // SkillGroup (Disciple)
-        DIS_VAGRANT = 0,
-        DIS_SWORD = 1,
-        DIS_DOUBLE = 2,
-        DIS_CASE = 3,
-        DIS_JUGGLING = 4,
-        DIS_YOYO = 5,
-        DIS_RIFLE = 6,
-        DIS_MARIONETTE = 7,
-        DIS_BOW = 32, // 새로 추가된 것
-                      // 방어기술군 
-        DIS_SHIELD = 8,
-        DIS_DANCE = 9,
-        DIS_ACROBATIC = 10,
-        DIS_SUPPORT = 23, // 머서너리용 보조스킬
+        public enum SkillGroupDisciple : int
+        {
+            // SkillGroup (Disciple)
+            DIS_VAGRANT = 0,
+            DIS_SWORD = 1,
+            DIS_DOUBLE = 2,
+            DIS_CASE = 3,
+            DIS_JUGGLING = 4,
+            DIS_YOYO = 5,
+            DIS_RIFLE = 6,
+            DIS_MARIONETTE = 7,
+            DIS_BOW = 32, // 새로 추가된 것
+                          // 방어기술군 
+            DIS_SHIELD = 8,
+            DIS_DANCE = 9,
+            DIS_ACROBATIC = 10,
+            DIS_SUPPORT = 23, // 머서너리용 보조스킬
 
-        // 마법연계 기술군
-        DIS_HEAL = 11,
-        DIS_CHEER = 12,
-        DIS_ACTING = 13,
-        DIS_POSTER = 14,
-        DIS_FIRE = 15,
-        DIS_WIND = 16,
-        DIS_WATER = 17,
-        DIS_EARTH = 18,
-        DIS_ELECTRICITY = 24,
+            // 마법연계 기술군
+            DIS_HEAL = 11,
+            DIS_CHEER = 12,
+            DIS_ACTING = 13,
+            DIS_POSTER = 14,
+            DIS_FIRE = 15,
+            DIS_WIND = 16,
+            DIS_WATER = 17,
+            DIS_EARTH = 18,
+            DIS_ELECTRICITY = 24,
 
-        // 특수 기술
-        DIS_STRINGDANCE = 19,
-        DIS_GIGAPUPPET = 20,
-        DIS_KNUCKLE = 21,
-        DIS_MAGIC = 22,
+            // 특수 기술
+            DIS_STRINGDANCE = 19,
+            DIS_GIGAPUPPET = 20,
+            DIS_KNUCKLE = 21,
+            DIS_MAGIC = 22,
 
-        DIS_MULTY = 23,
-        DIS_PSYCHIC = 24,
-        DIS_CURSE = 25,
-        DIS_HOLY = 26,
-        DIS_TWOHANDWEAPON = 27,
-        DIS_TWOHANDSWORD = 28,
-        DIS_TWOHANDAXE = 29,
-        DIS_DOUBLESWORD = 30,
-        DIS_DOUBLEAXE = 31,
+            DIS_MULTY = 23,
+            DIS_PSYCHIC = 24,
+            DIS_CURSE = 25,
+            DIS_HOLY = 26,
+            DIS_TWOHANDWEAPON = 27,
+            DIS_TWOHANDSWORD = 28,
+            DIS_TWOHANDAXE = 29,
+            DIS_DOUBLESWORD = 30,
+            DIS_DOUBLEAXE = 31,
+        }
 
-        // 극단 소속
-        TRO_MASTER = 0, // 단장
-        TRO_MEMBERE = 1, // 멤버
+        public enum TroupRank : int
+        {
+            // 극단 소속
+            TRO_MASTER = 0, // 단장
+            TRO_MEMBERE = 1, // 멤버
+        }
 
-        // 길드소속
-        GUD_MASTER = 0, // 마스터
-        GUD_KINGPIN = 1, // 킹핀
-        GUD_CAPTAIN = 2, // 캡틴
-        GUD_SUPPORTER = 3, // 서포터
-        GUD_ROOKIE = 4, // 루키
+        public enum GuildRank : int
+        {
+            // 길드소속
+            GUD_MASTER = 0, // 마스터
+            GUD_KINGPIN = 1, // 킹핀
+            GUD_CAPTAIN = 2, // 캡틴
+            GUD_SUPPORTER = 3, // 서포터
+            GUD_ROOKIE = 4, // 루키
+        }
     }
 }

--- a/src/Rhisis.Core/Resources/Dyo/CommonControlDyoElement.cs
+++ b/src/Rhisis.Core/Resources/Dyo/CommonControlDyoElement.cs
@@ -32,7 +32,7 @@ namespace Rhisis.Core.Resources.Dyo
 
         public uint SetGender { get; private set; }
 
-        public bool[] SetJob { get; private set; } = new bool[(int)DefineJob.MAX_JOB];
+        public bool[] SetJob { get; private set; } = new bool[(int)DefineJob.JobMax.MAX_JOB];
 
         public uint SetEndu { get; private set; }
 

--- a/src/Rhisis.Core/Structures/Game/ItemData.cs
+++ b/src/Rhisis.Core/Structures/Game/ItemData.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Core.Data;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.Serialization;
@@ -44,9 +45,6 @@ namespace Rhisis.Core.Structures.Game
 
         [DataMember(Name = "dwParts")]
         public int Parts { get; set; }
-
-        [DataMember(Name = "dwWeaponType")]
-        public WeaponType WeaponType { get; set; }
 
         [DataMember(Name = "dwAbilityMin")]
         public int AbilityMin { get; set; }
@@ -107,6 +105,24 @@ namespace Rhisis.Core.Structures.Game
 
         [DataMember(Name = "dwSkillReady")]
         public int CoolTime { get; set; }
+
+        [DataMember(Name = "dwWeaponType")]
+        public int WeaponTypeId { get; set; }
+
+        [DataMember(Name = "dwItemAtkOrder1")]
+        public int ItemAtkOrder1 { get; set; }
+
+        [DataMember(Name = "dwItemAtkOrder2")]
+        public int ItemAtkOrder2 { get; set; }
+
+        [DataMember(Name = "dwItemAtkOrder3")]
+        public int ItemAtkOrder3 { get; set; }
+
+        [DataMember(Name = "dwItemAtkOrder4")]
+        public int ItemAtkOrder4 { get; set; }
+
+        [IgnoreDataMember]
+        public WeaponType WeaponType => (WeaponType)Enum.ToObject(typeof(WeaponType), this.WeaponTypeId);
 
         [IgnoreDataMember]
         public bool IsStackable => this.PackMax > 1;

--- a/src/Rhisis.World/Game/Maps/MapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/MapInstance.cs
@@ -27,7 +27,8 @@ namespace Rhisis.World.Game.Maps
     {
         private const int DefaultMapLayerId = 1;
         private const int MapLandSize = 128;
-        private const int UpdateRate = 15;
+        private const int FrameRate = 60;
+        private const double UpdateRate = 1000f / FrameRate;
 
         private readonly string _mapPath;
         private readonly List<IMapLayer> _layers;

--- a/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
@@ -3,8 +3,12 @@ using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Helpers;
+using Rhisis.World.Game.Loaders;
+using Rhisis.World.Game.Maps;
+using Rhisis.World.Game.Maps.Regions;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
+using Rhisis.World.Systems.Teleport;
 using System;
 using System.Collections.Generic;
 
@@ -13,6 +17,7 @@ namespace Rhisis.World.Systems.Inventory
     internal sealed class InventoryItemUsage
     {
         private readonly ILogger<InventoryItemUsage> _logger;
+        private readonly MapLoader _mapLoader;
 
         /// <summary>
         /// Creates a new <see cref="InventoryItemUsage"/> instance.
@@ -20,6 +25,7 @@ namespace Rhisis.World.Systems.Inventory
         public InventoryItemUsage()
         {
             this._logger = DependencyContainer.Instance.Resolve<ILogger<InventoryItemUsage>>();
+            this._mapLoader = DependencyContainer.Instance.Resolve<MapLoader>();
         }
 
         /// <summary>
@@ -70,6 +76,9 @@ namespace Rhisis.World.Systems.Inventory
                 case ItemKind2.POTION:
                 case ItemKind2.FOOD:
                     this.UseFoodItem(player, itemToUse);
+                    break;
+                case ItemKind2.BLINKWING:
+                    this.UseBlinkwingItem(player, itemToUse);
                     break;
                 default:
                     this._logger.LogDebug($"Item usage for {itemToUse.Data.ItemKind2} is not implemented.");
@@ -145,6 +154,66 @@ namespace Rhisis.World.Systems.Inventory
                     WorldPacketFactory.SendFeatureNotImplemented(player, "skill with food");
                 }
             }
+        }
+
+        /// <summary>
+        /// Uses blinkwing items.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="blinkwing"></param>
+        private void UseBlinkwingItem(IPlayerEntity player, Item blinkwing)
+        {
+            if (player.Object.Level < blinkwing.Data.LimitLevel)
+            {
+                this._logger.LogError($"Player {player.Object.Name} cannot use {blinkwing.Data.Name}. Level too low.");
+                WorldPacketFactory.SendDefinedText(player, DefineText.TID_GAME_USINGNOTLEVEL);
+                return;
+            }
+
+            // TODO: Check if player is sit
+            // TODO: Check if player is on Kebaras island
+            // TODO: Check if player is in guild war map
+
+            TeleportEventArgs teleportEvent;
+
+            if (blinkwing.Data.ItemKind3 == ItemKind3.TOWNBLINKWING)
+            {
+                IMapRevivalRegion revivalRegion = player.Object.CurrentMap.GetNearRevivalRegion(player.Object.Position);
+
+                if (revivalRegion == null)
+                {
+                    this._logger.LogError($"Cannot find any revival region for map '{player.Object.CurrentMap.Name}'.");
+                    return;
+                }
+                if (player.Object.MapId != revivalRegion.MapId)
+                {
+                    IMapInstance revivalMap = this._mapLoader.GetMapById(revivalRegion.MapId);
+
+                    if (revivalMap == null)
+                    {
+                        this._logger.LogError($"Cannot find revival map with id '{revivalRegion.MapId}'.");
+                        player.Connection.Server.DisconnectClient(player.Connection.Id);
+                        return;
+                    }
+
+                    revivalRegion = revivalMap.GetRevivalRegion(revivalRegion.Key);
+                }
+
+                teleportEvent = new TeleportEventArgs(revivalRegion.MapId, 
+                    revivalRegion.RevivalPosition.X, 
+                    revivalRegion.RevivalPosition.Z, 
+                    revivalRegion.RevivalPosition.Y);
+            }
+            else
+            {
+                teleportEvent = new TeleportEventArgs(blinkwing.Data.WeaponTypeId, // Map Id
+                    blinkwing.Data.ItemAtkOrder1, // X
+                    blinkwing.Data.ItemAtkOrder3, // Z
+                    blinkwing.Data.ItemAtkOrder2, // Y
+                    blinkwing.Data.ItemAtkOrder4); // Angle
+            }
+
+            player.NotifySystem<TeleportSystem>(teleportEvent);
         }
     }
 }

--- a/src/Rhisis.World/Systems/Teleport/TeleportEventArgs.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportEventArgs.cs
@@ -15,9 +15,19 @@ namespace Rhisis.World.Systems.Teleport
         public float PositionX { get; }
 
         /// <summary>
-        /// Gets target Z position.
+        /// Gets the target Y position.
+        /// </summary>
+        public float? PositionY { get; }
+
+        /// <summary>
+        /// Gets the target Z position.
         /// </summary>
         public float PositionZ { get; }
+
+        /// <summary>
+        /// Gets the target angle.
+        /// </summary>
+        public float Angle { get; }
 
         /// <summary>
         /// Creates a new <see cref="TeleportEventArgs"/> instance.
@@ -26,16 +36,43 @@ namespace Rhisis.World.Systems.Teleport
         /// <param name="positionX">Target X position.</param>
         /// <param name="positionZ">Target Z position.</param>
         public TeleportEventArgs(int mapId, float positionX, float positionZ)
+            : this(mapId, positionX, positionZ, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TeleportEventArgs"/> instance.
+        /// </summary>
+        /// <param name="mapId">Target Map Id.</param>
+        /// <param name="positionX">Target X position.</param>
+        /// <param name="positionZ">Target Z position.</param>
+        /// <param name="positionY">Target Y position.</param>
+        public TeleportEventArgs(int mapId, float positionX, float positionZ, float? positionY)
+            : this(mapId, positionX, positionZ, positionY, 0)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="TeleportEventArgs"/> instance.
+        /// </summary>
+        /// <param name="mapId">Target Map Id.</param>
+        /// <param name="positionX">Target X position.</param>
+        /// <param name="positionZ">Target Z position.</param>
+        /// <param name="positionY">Target Y position.</param>
+        /// <param name="angle">Target angle.</param>
+        public TeleportEventArgs(int mapId, float positionX, float positionZ, float? positionY, float angle)
         {
             this.MapId = mapId;
             this.PositionX = positionX;
             this.PositionZ = positionZ;
+            this.PositionY = positionY;
+            this.Angle = angle;
         }
 
         /// <inheritdoc />
         public override bool CheckArguments()
         {
-            return this.MapId > 0 && this.PositionX > 0f && this.PositionZ > 0;
+            return this.MapId > 0 && this.PositionX > 0f && this.PositionZ > 0f;
         }
     }
 }

--- a/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
@@ -84,7 +84,8 @@ namespace Rhisis.World.Systems.Teleport
                 player.Object.LayerId = defaultMapLayer.Id;
 
                 // TODO: get map height at x/z position
-                player.Object.Position = new Vector3(e.PositionX, 100, e.PositionZ);
+                float positionY = e.PositionY ?? 100;
+                player.Object.Position = new Vector3(e.PositionX, positionY, e.PositionZ);
                 player.Moves.DestinationPosition = player.Object.Position.Clone();
 
                 WorldPacketFactory.SendReplaceObject(player);
@@ -100,7 +101,8 @@ namespace Rhisis.World.Systems.Teleport
                 }
 
                 // TODO: get map height at x/z position
-                player.Object.Position = new Vector3(e.PositionX, 100, e.PositionZ);
+                float positionY = e.PositionY ?? 100;
+                player.Object.Position = new Vector3(e.PositionX, positionY, e.PositionZ);
                 player.Moves.DestinationPosition = player.Object.Position.Clone();
             }
 


### PR DESCRIPTION
This PR covers issue #228 and adds the support for blinkwings items.
* Town blinkwings teleports the player to the nearest town (based on revival regions)
* Flaris, St.Morning,  Darkon, etc... blinkwings teleports to the define positions in the `propItem.txt`. (fields: `dwWeaponType`, `dwItemAtkOrder1`, `dwItemAtkOrder2`, `dwItemAtkOrder3`, `dwItemAtkOrder4`).