### PR TITLE
Fix core server configuration default port value

### DIFF
--- a/src/Rhisis.Core/Structures/Configuration/CoreConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/CoreConfiguration.cs
@@ -22,7 +22,7 @@ namespace Rhisis.Core.Structures.Configuration
         /// Gets or sets the port.
         /// </summary>
         [DataMember(Name = "port")]
-        [DefaultValue(23000)]
+        [DefaultValue(15000)]
         [Display(Name = "Core server listening port", Order = 1)]
         public int Port { get; set; }
 


### PR DESCRIPTION
This PR fixes the default port value of the `CoreServer` configuration. It was set to 23000 which is the same port as the `LoginServer`. This is due to a bad copy/paste operation.