### PR TITLE
#274 Migrate from Ether.Network to Sylver.Network

### DIFF
--- a/src/Rhisis.Cluster/Client/IClusterClient.cs
+++ b/src/Rhisis.Cluster/Client/IClusterClient.cs
@@ -1,8 +1,9 @@
-﻿using Ether.Network.Common;
+﻿using Sylver.Network.Common;
+using Sylver.Network.Server;
 
 namespace Rhisis.Cluster.Client
 {
-    public interface IClusterClient : INetUser
+    public interface IClusterClient : INetServerClient
     {
         /// <summary>
         /// Gets the ID assigned to this session.
@@ -14,11 +15,6 @@ namespace Rhisis.Cluster.Client
         /// This value is random and valid only for this session in order to secure num pad disposition.
         /// </summary>
         int LoginProtectValue { get; set; }
-
-        /// <summary>
-        /// Gets the remote end point (IP and port) for this client.
-        /// </summary>
-        string RemoteEndPoint { get; }
 
         /// <summary>
         /// Disconnects the current cluster client.

--- a/src/Rhisis.Cluster/CoreClient/ClusterCoreClient.cs
+++ b/src/Rhisis.Cluster/CoreClient/ClusterCoreClient.cs
@@ -1,18 +1,19 @@
-﻿using Ether.Network.Client;
-using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Rhisis.Core.Structures.Configuration;
 using Rhisis.Network.Core;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Client;
+using Sylver.Network.Data;
 using System;
 using System.Collections.Generic;
-using System.Net.Sockets;
 
 namespace Rhisis.Cluster.CoreClient
 {
     public sealed class ClusterCoreClient : NetClient, IClusterCoreClient
     {
+        private const int BufferSize = 64;
+
         private readonly ILogger<ClusterCoreClient> _logger;
         private readonly CoreConfiguration _coreConfiguration;
         private readonly IHandlerInvoker _handlerInvoker;
@@ -24,26 +25,19 @@ namespace Rhisis.Cluster.CoreClient
         public IList<WorldServerInfo> WorldServers { get; }
 
         /// <summary>
-        /// Gets the remote end point (IP and port) for this client.
-        /// </summary>
-        public string RemoteEndPoint => this.Socket.RemoteEndPoint.ToString();
-
-        /// <summary>
         /// Creates a new <see cref="ClusterCoreClient"/> instance.
         /// </summary>
         /// <param name="logger">Logger.</param>
+        /// <param name="handlerInvoker">Handler invoker.</param>
         /// <param name="clusterConfiguration">Cluster server configuration.</param>
         /// <param name="coreConfiguration">Core server configuration.</param>
-        /// <param name="handlerInvoker">Handler invoker.</param>
-        public ClusterCoreClient(ILogger<ClusterCoreClient> logger, IOptions<ClusterConfiguration> clusterConfiguration, IOptions<CoreConfiguration> coreConfiguration, IHandlerInvoker handlerInvoker)
+        public ClusterCoreClient(ILogger<ClusterCoreClient> logger, IHandlerInvoker handlerInvoker, IOptions<ClusterConfiguration> clusterConfiguration, IOptions<CoreConfiguration> coreConfiguration)
         {
             this._logger = logger;
+            this._handlerInvoker = handlerInvoker;
             this._coreConfiguration = coreConfiguration.Value;
             this.ClusterConfiguration = clusterConfiguration.Value;
-            this._handlerInvoker = handlerInvoker;
-            this.Configuration.Host = this._coreConfiguration.Host;
-            this.Configuration.Port = this._coreConfiguration.Port;
-            this.Configuration.BufferSize = 128;
+            this.ClientConfiguration = new NetClientConfiguration(this._coreConfiguration.Host, this._coreConfiguration.Port, BufferSize);
             this.WorldServers = new List<WorldServerInfo>();
         }
 
@@ -62,10 +56,10 @@ namespace Rhisis.Cluster.CoreClient
         }
 
         /// <inheritdoc />
-        protected override void OnSocketError(SocketError socketError)
-        {
-            this._logger.LogError($"An error occured on Cluster core client: {socketError}");
-        }
+        //protected override void OnSocketError(SocketError socketError)
+        //{
+        //    this._logger.LogError($"An error occured on Cluster core client: {socketError}");
+        //}
 
         /// <inheritdoc />
         public override void HandleMessage(INetPacketStream packet)
@@ -86,9 +80,9 @@ namespace Rhisis.Cluster.CoreClient
             catch (ArgumentNullException)
             {
                 if (Enum.IsDefined(typeof(CorePacketType), packetHeaderNumber))
-                    this._logger.LogWarning("Received an unimplemented Core packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(CorePacketType), packetHeaderNumber), packetHeaderNumber.ToString("X4"), this.RemoteEndPoint);
+                    this._logger.LogWarning("Received an unimplemented Core packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(CorePacketType), packetHeaderNumber), packetHeaderNumber.ToString("X4"), this.Socket.RemoteEndPoint);
                 else
-                    this._logger.LogWarning("[SECURITY] Received an unknown Core packet 0x{0} from {1}.", packetHeaderNumber.ToString("X4"), this.RemoteEndPoint);
+                    this._logger.LogWarning("[SECURITY] Received an unknown Core packet 0x{0} from {1}.", packetHeaderNumber.ToString("X4"), this.Socket.RemoteEndPoint);
             }
             catch (Exception exception)
             {

--- a/src/Rhisis.Cluster/CoreClient/Handlers/CommonCoreHandlers.cs
+++ b/src/Rhisis.Cluster/CoreClient/Handlers/CommonCoreHandlers.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Cluster.CoreClient.Packets;
 using Rhisis.Network.Core;
 using Sylver.HandlerInvoker.Attributes;
+using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Cluster.CoreClient.Handlers
@@ -43,7 +43,7 @@ namespace Rhisis.Cluster.CoreClient.Handlers
         /// <param name="client"></param>
         /// <param name="packet"></param>
         [HandlerAction(CorePacketType.AuthenticationResult)]
-        public void OnAuthenticationResult(IClusterCoreClient client, INetPacketStream packet)
+        public void OnAuthenticationResult(IClusterCoreClient _, INetPacketStream packet)
         {
             var authenticationResult = (CoreAuthenticationResultType)(packet.Read<uint>());
 
@@ -76,7 +76,7 @@ namespace Rhisis.Cluster.CoreClient.Handlers
         /// <param name="client"></param>
         /// <param name="packet"></param>
         [HandlerAction(CorePacketType.UpdateClusterWorldsList)]
-        public void OnUpdateClusterWorldsList(IClusterCoreClient client, INetPacketStream packet)
+        public void OnUpdateClusterWorldsList(IClusterCoreClient _, INetPacketStream packet)
         {
             int numberOfWorldServers = packet.Read<int>();
 

--- a/src/Rhisis.Cluster/CoreClient/Packets/CorePacketFactory.cs
+++ b/src/Rhisis.Cluster/CoreClient/Packets/CorePacketFactory.cs
@@ -1,6 +1,6 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Core.Structures.Configuration;
+﻿using Rhisis.Core.Structures.Configuration;
 using Rhisis.Network.Core;
+using Sylver.Network.Data;
 
 namespace Rhisis.Cluster.CoreClient.Packets
 {

--- a/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
+++ b/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
@@ -54,7 +54,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (selectedWorldServer == null)
             {
-                this._logger.LogWarning($"Unable to get characters list for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"Unable to get characters list for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: client requested the list on a not connected World server.");
                 client.Disconnect();
                 return;
@@ -64,7 +64,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (dbUser == null)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to load character list for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to load character list for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: bad presented credentials compared to the database.");
                 client.Disconnect();
                 return;
@@ -91,7 +91,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (dbUser == null)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to create new character for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to create new character for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: bad presented credentials compared to the database.");
                 client.Disconnect();
                 return;
@@ -100,7 +100,7 @@ namespace Rhisis.Cluster.Handlers
             if (this._database.Characters.HasAny(x => x.Name == packet.Name))
             {
                 this._logger.LogWarning(
-                        $"Unable to create new character for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                        $"Unable to create new character for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                         $"Reason: character name '{packet.Name}' already exists.");
 
                 this._clusterPacketFactory.SendClusterError(client, ErrorType.USER_EXISTS);
@@ -159,7 +159,7 @@ namespace Rhisis.Cluster.Handlers
             this._database.Characters.Create(newCharacter);
             this._database.Complete();
 
-            this._logger.LogInformation($"Character '{newCharacter.Name}' has been created successfully for user '{dbUser.Username}' from {client.RemoteEndPoint}.");
+            this._logger.LogInformation($"Character '{newCharacter.Name}' has been created successfully for user '{dbUser.Username}' from {client.Socket.RemoteEndPoint}.");
 
             IEnumerable<DbCharacter> dbCharacters = this._database.Characters.GetCharacters(dbUser.Id);
 
@@ -178,7 +178,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (dbUser == null)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to create new character for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to create new character for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: bad presented credentials compared to the database.");
                 client.Disconnect();
                 return;
@@ -186,7 +186,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (!string.Equals(packet.Password, packet.PasswordConfirmation, StringComparison.OrdinalIgnoreCase))
             {
-                this._logger.LogWarning($"Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: passwords entered do not match.");
                 this._clusterPacketFactory.SendClusterError(client, ErrorType.WRONG_PASSWORD);
                 return;
@@ -197,7 +197,7 @@ namespace Rhisis.Cluster.Handlers
             // Check if character exist.
             if (characterToDelete == null)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: user doesn't have any character with this id.");
                 client.Disconnect();
                 return;
@@ -205,7 +205,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (characterToDelete.IsDeleted)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to delete character id '{packet.CharacterId}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                        "Reason: character is already deleted.");
                 return;
             }
@@ -213,7 +213,7 @@ namespace Rhisis.Cluster.Handlers
             this._database.Characters.Delete(characterToDelete);
             this._database.Complete();
 
-            this._logger.LogInformation($"Character '{characterToDelete.Name}' has been deleted successfully for user '{packet.Username}' from {client.RemoteEndPoint}.");
+            this._logger.LogInformation($"Character '{characterToDelete.Name}' has been deleted successfully for user '{packet.Username}' from {client.Socket.RemoteEndPoint}.");
 
             IEnumerable<DbCharacter> dbCharacters = this._database.Characters.GetCharacters(dbUser.Id);
 
@@ -232,7 +232,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (character == null)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to prejoin character id '{packet.CharacterName}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to prejoin character id '{packet.CharacterName}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                       $"Reason: no character with id {packet.CharacterId}.");
                 client.Disconnect();
                 return;
@@ -240,7 +240,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (character.IsDeleted)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to prejoin with character '{character.Name}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to prejoin with character '{character.Name}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                                 "Reason: character is deleted.");
                 client.Disconnect();
                 return;
@@ -248,7 +248,7 @@ namespace Rhisis.Cluster.Handlers
 
             if (character.Name != packet.CharacterName)
             {
-                this._logger.LogWarning($"[SECURITY] Unable to prejoin character '{character.Name}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"[SECURITY] Unable to prejoin character '{character.Name}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                        "Reason: character is not owned by this user.");
                 client.Disconnect();
                 return;
@@ -257,7 +257,7 @@ namespace Rhisis.Cluster.Handlers
             if (this._clusterServer.ClusterConfiguration.EnableLoginProtect &&
                 LoginProtect.GetNumPadToPassword(client.LoginProtectValue, packet.BankCode) != character.BankCode)
             {
-                this._logger.LogWarning($"Unable to prejoin character '{character.Name}' for user '{packet.Username}' from {client.RemoteEndPoint}. " +
+                this._logger.LogWarning($"Unable to prejoin character '{character.Name}' for user '{packet.Username}' from {client.Socket.RemoteEndPoint}. " +
                     "Reason: bad bank code.");
                 client.LoginProtectValue = new Random().Next(0, 1000);
                 this._clusterPacketFactory.SendLoginProtect(client, client.LoginProtectValue);
@@ -265,7 +265,7 @@ namespace Rhisis.Cluster.Handlers
             }
 
             this._clusterPacketFactory.SendJoinWorld(client);
-            this._logger.LogInformation($"Character '{character.Name}' has prejoin successfully the game for user '{packet.Username}' from {client.RemoteEndPoint}.");
+            this._logger.LogInformation($"Character '{character.Name}' has prejoin successfully the game for user '{packet.Username}' from {client.Socket.RemoteEndPoint}.");
         }
     }
 }

--- a/src/Rhisis.Cluster/IClusterServer.cs
+++ b/src/Rhisis.Cluster/IClusterServer.cs
@@ -1,6 +1,6 @@
-﻿using Ether.Network.Server;
-using Rhisis.Core.Structures.Configuration;
+﻿using Rhisis.Core.Structures.Configuration;
 using Rhisis.Network.Core;
+using Sylver.Network.Server;
 using System.Collections.Generic;
 
 namespace Rhisis.Cluster

--- a/src/Rhisis.Cluster/Program.cs
+++ b/src/Rhisis.Cluster/Program.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -13,6 +12,7 @@ using Rhisis.Core.Structures.Configuration;
 using Rhisis.Database;
 using Rhisis.Network.Packets;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Data;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ether.Network" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.3" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.Network" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
+++ b/src/Rhisis.Core/Common/Game/Structures/Shortcut.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Core.Common.Game.Structures
 {

--- a/src/Rhisis.Core/Rhisis.Core.csproj
+++ b/src/Rhisis.Core/Rhisis.Core.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="Ether.Network" Version="3.0.0" />
+    <PackageReference Include="Sylver.Network" Version="1.1.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />

--- a/src/Rhisis.Login/Client/ILoginClient.cs
+++ b/src/Rhisis.Login/Client/ILoginClient.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Common;
+﻿using Sylver.Network.Common;
 
 namespace Rhisis.Login.Client
 {
@@ -13,11 +13,6 @@ namespace Rhisis.Login.Client
         /// Gets the client's logged username.
         /// </summary>
         string Username { get; }
-
-        /// <summary>
-        /// Gets the remote end point (IP and port) for this client.
-        /// </summary>
-        string RemoteEndPoint { get; }
 
         /// <summary>
         /// Check if the client is connected.

--- a/src/Rhisis.Login/Core/CoreServerClient.cs
+++ b/src/Rhisis.Login/Core/CoreServerClient.cs
@@ -1,26 +1,31 @@
-﻿using Ether.Network.Common;
-using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Network.Core;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Data;
+using Sylver.Network.Server;
 using System;
+using System.Net.Sockets;
 
 namespace Rhisis.Login.Core
 {
-    public class CoreServerClient : NetUser, ICoreServerClient
+    public class CoreServerClient : NetServerClient, ICoreServerClient
     {
         private ILogger<CoreServerClient> _logger;
         private IHandlerInvoker _handlerInvoker;
 
         /// <summary>
-        /// Gets the remote end point (IP and port).
-        /// </summary>
-        public string RemoteEndPoint { get; private set; }
-
-        /// <summary>
         /// Gets or sets the server informations.
         /// </summary>
         public ServerInfo ServerInfo { get; internal set; }
+
+        /// <summary>
+        /// Creates a new <see cref="CoreServerClient"/> instance.
+        /// </summary>
+        /// <param name="socketConnection"></param>
+        public CoreServerClient(Socket socketConnection) 
+            : base(socketConnection)
+        {
+        }
 
         /// <summary>
         /// Initialize the <see cref="CoreServerClient"/>.
@@ -31,7 +36,6 @@ namespace Rhisis.Login.Core
         {
             this._logger = logger;
             this._handlerInvoker = handlerInvoker;
-            this.RemoteEndPoint = this.Socket.RemoteEndPoint.ToString();
         }
 
         /// <inheritdoc />
@@ -41,7 +45,7 @@ namespace Rhisis.Login.Core
 
             if (this.Socket == null)
             {
-                this._logger.LogTrace("Skip to handle core packet from {0}. Reason: socket is not connected.", this.RemoteEndPoint);
+                this._logger.LogTrace("Skip to handle core packet from {0}. Reason: socket is not connected.", this.Socket.RemoteEndPoint);
                 return;
             }
 
@@ -57,11 +61,11 @@ namespace Rhisis.Login.Core
                     this._logger.LogWarning("Received an unimplemented Core packet {0} (0x{1}) from {2}.",
                         Enum.GetName(typeof(CorePacketType), packetHeaderNumber),
                         packetHeaderNumber.ToString("X2"),
-                        this.RemoteEndPoint);
+                        this.Socket.RemoteEndPoint);
                 }
                 else
                 {
-                    this._logger.LogWarning($"Received an unknown Core packet 0x{packetHeaderNumber.ToString("X2")} from {this.RemoteEndPoint}.");
+                    this._logger.LogWarning($"Received an unknown Core packet 0x{packetHeaderNumber.ToString("X2")} from {this.Socket.RemoteEndPoint}.");
                 }
             }
             catch (Exception exception)

--- a/src/Rhisis.Login/Core/Handlers/AuthenticationHandler.cs
+++ b/src/Rhisis.Login/Core/Handlers/AuthenticationHandler.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Login.Core.Packets;
 using Rhisis.Network.Core;
 using Sylver.HandlerInvoker.Attributes;
+using Sylver.Network.Data;
 
 namespace Rhisis.Login.Core.Handlers
 {
@@ -44,14 +44,14 @@ namespace Rhisis.Login.Core.Handlers
             {
                 if (this._coreServer.HasCluster(id))
                 {
-                    this._logger.LogWarning($"Cluster Server '{name}' incoming connection from {client.RemoteEndPoint} refused. Reason: An other Cluster server with id '{id}' is already connected.");
+                    this._logger.LogWarning($"Cluster Server '{name}' incoming connection from {client.Socket.RemoteEndPoint} refused. Reason: An other Cluster server with id '{id}' is already connected.");
                     this._corePacketFactory.SendAuthenticationResult(client, CoreAuthenticationResultType.FailedClusterExists);
                     this._coreServer.DisconnectClient(client.Id);
                     return;
                 }
 
                 client.ServerInfo = new ClusterServerInfo(id, name, host, port);
-                this._logger.LogInformation($"Cluster server '{name}' connected to ISC server from {client.RemoteEndPoint}.");
+                this._logger.LogInformation($"Cluster server '{name}' connected to ISC server from {client.Socket.RemoteEndPoint}.");
             }
             else if (type == ServerType.World)
             {
@@ -61,7 +61,7 @@ namespace Rhisis.Login.Core.Handlers
 
                 if (parentClusterServer == null)
                 {
-                    this._logger.LogWarning($"World server '{name}' incoming connection from {client.RemoteEndPoint} refused. Reason: Cluster server with id '{parentClusterId}' is not connected.");
+                    this._logger.LogWarning($"World server '{name}' incoming connection from {client.Socket.RemoteEndPoint} refused. Reason: Cluster server with id '{parentClusterId}' is not connected.");
 
                     this._corePacketFactory.SendAuthenticationResult(client, CoreAuthenticationResultType.FailedNoCluster);
                     this._coreServer.DisconnectClient(client.Id);
@@ -70,7 +70,7 @@ namespace Rhisis.Login.Core.Handlers
 
                 if (this._coreServer.HasWorld(parentClusterId, id))
                 {
-                    this._logger.LogWarning($"World server '{name}' incoming connection from {client.RemoteEndPoint} refused. Reason: An other World server with id '{id}' is already connected to Cluster Server '{parentClusterServer.ServerInfo.Name}'.");
+                    this._logger.LogWarning($"World server '{name}' incoming connection from {client.Socket.RemoteEndPoint} refused. Reason: An other World server with id '{id}' is already connected to Cluster Server '{parentClusterServer.ServerInfo.Name}'.");
                     this._corePacketFactory.SendAuthenticationResult(client, CoreAuthenticationResultType.FailedWorldExists);
                     this._coreServer.DisconnectClient(client.Id);
                     return;
@@ -82,11 +82,11 @@ namespace Rhisis.Login.Core.Handlers
                 cluster.Worlds.Add(worldInfo);
                 client.ServerInfo = worldInfo;
                 this._corePacketFactory.SendUpdateWorldList(parentClusterServer, cluster.Worlds);
-                this._logger.LogInformation($"World server '{name}' join cluster '{cluster.Name}' and is connected to ISC server from {client.RemoteEndPoint}.");
+                this._logger.LogInformation($"World server '{name}' join cluster '{cluster.Name}' and is connected to ISC server from {client.Socket.RemoteEndPoint}.");
             }
             else
             {
-                this._logger.LogWarning($"Incoming core connection from {client.RemoteEndPoint} refused. Reason: server type is unknown.");
+                this._logger.LogWarning($"Incoming core connection from {client.Socket.RemoteEndPoint} refused. Reason: server type is unknown.");
                 this._corePacketFactory.SendAuthenticationResult(client, CoreAuthenticationResultType.FailedUnknownServer);
                 this._coreServer.DisconnectClient(client.Id);
                 return;

--- a/src/Rhisis.Login/Core/ICoreServer.cs
+++ b/src/Rhisis.Login/Core/ICoreServer.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Server;
-using Rhisis.Network.Core;
+﻿using Rhisis.Network.Core;
+using Sylver.Network.Server;
 using System.Collections.Generic;
 
 namespace Rhisis.Login.Core

--- a/src/Rhisis.Login/Core/ICoreServerClient.cs
+++ b/src/Rhisis.Login/Core/ICoreServerClient.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Common;
-using Rhisis.Network.Core;
+﻿using Rhisis.Network.Core;
+using Sylver.Network.Common;
 
 namespace Rhisis.Login.Core
 {

--- a/src/Rhisis.Login/Core/Packets/CorePacketFactory.cs
+++ b/src/Rhisis.Login/Core/Packets/CorePacketFactory.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Network.Core;
+﻿using Rhisis.Network.Core;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Rhisis.Login/ILoginServer.cs
+++ b/src/Rhisis.Login/ILoginServer.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Server;
-using Rhisis.Login.Client;
+﻿using Rhisis.Login.Client;
+using Sylver.Network.Server;
 
 namespace Rhisis.Login
 {

--- a/src/Rhisis.Login/LoginHandler.cs
+++ b/src/Rhisis.Login/LoginHandler.cs
@@ -104,7 +104,7 @@ namespace Rhisis.Login
 
                     this._loginPacketFactory.SendServerList(client, certifyPacket.Username, this._coreServer.GetConnectedClusters());
                     client.SetClientUsername(certifyPacket.Username);
-                    this._logger.LogInformation($"User '{client.Username}' logged succesfully from {client.RemoteEndPoint}.");
+                    this._logger.LogInformation($"User '{client.Username}' logged succesfully from {client.Socket.RemoteEndPoint}.");
                     break;
                 default:
                     break;
@@ -139,7 +139,7 @@ namespace Rhisis.Login
         /// <param name="disconnectClient">A boolean value that indicates if we disconnect the client or not.</param>
         private void AuthenticationFailed(ILoginClient client, ErrorType error, string reason, bool disconnectClient = true)
         {
-            this._logger.LogWarning($"Unable to authenticate user from {client.RemoteEndPoint}. Reason: {reason}");
+            this._logger.LogWarning($"Unable to authenticate user from {client.Socket.RemoteEndPoint}. Reason: {reason}");
             this._loginPacketFactory.SendLoginError(client, error);
 
             if (disconnectClient)

--- a/src/Rhisis.Login/Program.cs
+++ b/src/Rhisis.Login/Program.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -12,6 +11,7 @@ using Rhisis.Login.Core.Packets;
 using Rhisis.Login.Packets;
 using Rhisis.Network.Packets;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Data;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ether.Network" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.3" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.Network" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Network/Core/ICoreClient.cs
+++ b/src/Rhisis.Network/Core/ICoreClient.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Client;
+﻿using Sylver.Network.Client;
 
 namespace Rhisis.Network.Core
 {

--- a/src/Rhisis.Network/FlyffPacketProcessor.cs
+++ b/src/Rhisis.Network/FlyffPacketProcessor.cs
@@ -1,12 +1,19 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Network
 {
     public class FlyffPacketProcessor : IPacketProcessor
     {
+        /// <summary>
+        /// Gets the FlyFF packet header size.
+        /// </summary>
         public int HeaderSize => 13;
+
+        /// <inheritdoc />
         public bool IncludeHeader => false;
+
+        /// <inheritdoc />
         public int GetMessageLength(byte[] buffer)
         {
             if (buffer[0] == FFPacket.Header)
@@ -21,6 +28,7 @@ namespace Rhisis.Network
             return 0;
         }
 
+        /// <inheritdoc />
         public INetPacketStream CreatePacket(byte[] buffer) => new FFPacket(buffer);
     }
 }

--- a/src/Rhisis.Network/PacketHandlers.cs
+++ b/src/Rhisis.Network/PacketHandlers.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Exceptions;
 using Rhisis.Core.IO;
 using System;

--- a/src/Rhisis.Network/Packets/Cluster/CreatePlayerPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/CreatePlayerPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {

--- a/src/Rhisis.Network/Packets/Cluster/DeletePlayerPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/DeletePlayerPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {

--- a/src/Rhisis.Network/Packets/Cluster/GetPlayerListPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/GetPlayerListPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {

--- a/src/Rhisis.Network/Packets/Cluster/PreJoinPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/PreJoinPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {

--- a/src/Rhisis.Network/Packets/Cluster/QueryTickCountPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/QueryTickCountPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {

--- a/src/Rhisis.Network/Packets/CommonPacketFactory.cs
+++ b/src/Rhisis.Network/Packets/CommonPacketFactory.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Common;
+﻿using Sylver.Network.Common;
 
 namespace Rhisis.Network.Packets
 {

--- a/src/Rhisis.Network/Packets/IPacketDeserializer.cs
+++ b/src/Rhisis.Network/Packets/IPacketDeserializer.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets
 {

--- a/src/Rhisis.Network/Packets/Login/CertifyPacket.cs
+++ b/src/Rhisis.Network/Packets/Login/CertifyPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Microsoft.Extensions.Options;
 using Rhisis.Core.Cryptography;
 using Rhisis.Core.Structures.Configuration;
@@ -28,7 +28,7 @@ namespace Rhisis.Network.Packets.Login
 
             if (this._configuration.PasswordEncryption)
             {
-                byte[] encryptedPassword = packet.ReadArray<byte>(16 * 42);
+                byte[] encryptedPassword = packet.Read<byte>(16 * 42);
                 byte[] encryptionKey = Aes.BuildEncryptionKeyFromString(this._configuration.EncryptionKey, 16);
 
                 this.Password = Aes.DecryptByteArray(encryptedPassword, encryptionKey);

--- a/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
+++ b/src/Rhisis.Network/Packets/Login/CloseConnectionPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Login
 {

--- a/src/Rhisis.Network/Packets/PacketHeader.cs
+++ b/src/Rhisis.Network/Packets/PacketHeader.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets
 {

--- a/src/Rhisis.Network/Packets/PingPacket.cs
+++ b/src/Rhisis.Network/Packets/PingPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Network.Packets

--- a/src/Rhisis.Network/Packets/World/ActMsgPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ActMsgPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/AwakeningPacket.cs
+++ b/src/Rhisis.Network/Packets/World/AwakeningPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/Bank/ChangeBankPasswordPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/ChangeBankPasswordPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/CloseBankWindowPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/CloseBankWindowPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/CloseGuildBankWindow.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/CloseGuildBankWindow.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/ConfirmBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/ConfirmBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/GetGoldBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/GetGoldBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/GetItemBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/GetItemBankPacket.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/GetItemGuildBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/GetItemGuildBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/OpenBankWindowPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/OpenBankWindowPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/OpenGuildBankWindow.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/OpenGuildBankWindow.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/PutGoldBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/PutGoldBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/PutGoldBankToBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/PutGoldBankToBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/PutItemBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/PutItemBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/PutItemBankToBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/PutItemBankToBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/Bank/PutItemGuildBankPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Bank/PutItemGuildBankPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Bank
 {

--- a/src/Rhisis.Network/Packets/World/BlessednessCancelPacket.cs
+++ b/src/Rhisis.Network/Packets/World/BlessednessCancelPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/BuyChipItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/BuyChipItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/BuyItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/BuyItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ChangeFacePacket.cs
+++ b/src/Rhisis.Network/Packets/World/ChangeFacePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ChangeJobPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ChangeJobPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ChatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ChatPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/CloseShopWindowPacket.cs
+++ b/src/Rhisis.Network/Packets/World/CloseShopWindowPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/CorrReqPacket.cs
+++ b/src/Rhisis.Network/Packets/World/CorrReqPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/DialogPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DialogPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/DoUseItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DoUseItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/DoUseItemTargetPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DoUseItemTargetPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/DropGoldPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DropGoldPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/DropItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DropItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/Duel/DuelNoPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/DuelNoPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/Duel/DuelRequestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/DuelRequestPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/Duel/DuelYesPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/DuelYesPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/Duel/PartyDuelNoPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/PartyDuelNoPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/Duel/PartyDuelRequestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/PartyDuelRequestPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/Duel/PartyDuelYesPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Duel/PartyDuelYesPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Duel
 {

--- a/src/Rhisis.Network/Packets/World/EquipItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/EquipItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ErrorPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ErrorPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ExpBoxInfoPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ExpBoxInfoPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ExperiencePacket.cs
+++ b/src/Rhisis.Network/Packets/World/ExperiencePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/FocusObjectPacket.cs
+++ b/src/Rhisis.Network/Packets/World/FocusObjectPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/GetClockPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GetClockPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/GetItemGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/GetItemGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/GetPenyaGuildGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/GetPenyaGuildGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/GetPenyaPlayerGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/GetPenyaPlayerGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/InGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/InGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat

--- a/src/Rhisis.Network/Packets/World/GuildCombat/JoinGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/JoinGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/OutGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/OutGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/PlayerPointGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/PlayerPointGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/RequestStatusPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/RequestStatusPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/SelectMapGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/SelectMapGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/SelectPlayerGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/SelectPlayerGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/GuildCombat/TeleGuildCombatPacket.cs
+++ b/src/Rhisis.Network/Packets/World/GuildCombat/TeleGuildCombatPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.GuildCombat
 {

--- a/src/Rhisis.Network/Packets/World/IncJobLevelPacket.cs
+++ b/src/Rhisis.Network/Packets/World/IncJobLevelPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/IncStatLevelPacket.cs
+++ b/src/Rhisis.Network/Packets/World/IncStatLevelPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/JoinPacket.cs
+++ b/src/Rhisis.Network/Packets/World/JoinPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/KeepAlivePacket.cs
+++ b/src/Rhisis.Network/Packets/World/KeepAlivePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/LocalPosFromIAPacket.cs
+++ b/src/Rhisis.Network/Packets/World/LocalPosFromIAPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/MagicAttackPacket.cs
+++ b/src/Rhisis.Network/Packets/World/MagicAttackPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Data;
 using System;
 

--- a/src/Rhisis.Network/Packets/World/Mailbox/QueryGetMailGoldPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Mailbox/QueryGetMailGoldPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Mailbox
 {

--- a/src/Rhisis.Network/Packets/World/Mailbox/QueryGetMailItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Mailbox/QueryGetMailItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Mailbox
 {

--- a/src/Rhisis.Network/Packets/World/Mailbox/QueryPostMailPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Mailbox/QueryPostMailPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Mailbox
 {

--- a/src/Rhisis.Network/Packets/World/Mailbox/QueryRemoveMailPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Mailbox/QueryRemoveMailPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Mailbox
 {

--- a/src/Rhisis.Network/Packets/World/Mailbox/ReadMailPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Mailbox/ReadMailPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Mailbox
 {

--- a/src/Rhisis.Network/Packets/World/MeleeAttack2Packet.cs
+++ b/src/Rhisis.Network/Packets/World/MeleeAttack2Packet.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Data;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/MeleeAttackPacket.cs
+++ b/src/Rhisis.Network/Packets/World/MeleeAttackPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Data;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/ModifyStatusPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ModifyStatusPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/MoveBankItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/MoveBankItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/MoveItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/MoveItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/MoverFocusPacket.cs
+++ b/src/Rhisis.Network/Packets/World/MoverFocusPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/OpenShopWindowPacket.cs
+++ b/src/Rhisis.Network/Packets/World/OpenShopWindowPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyAddMemberPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyAddMemberPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyChangeExperienceModePacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyChangeExperienceModePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyChangeItemModePacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyChangeItemModePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyChangeLeaderPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyChangeLeaderPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Packet
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyChangeNamePacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyChangeNamePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Packet
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyChangeTroupPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyChangeTroupPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyMemberRequestCancelPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyMemberRequestCancelPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyMemberRequestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyMemberRequestPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartyRemoveMemberPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartyRemoveMemberPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/Party/PartySkillUsePacket.cs
+++ b/src/Rhisis.Network/Packets/World/Party/PartySkillUsePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Party
 {

--- a/src/Rhisis.Network/Packets/World/PlayerAnglePacket.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerAnglePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/PlayerBehavior2Packet.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerBehavior2Packet.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/PlayerBehaviorPacket.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerBehaviorPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/PlayerDestObjectPacket.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerDestObjectPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/PlayerMoved2Packet.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerMoved2Packet.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/PlayerMovedPacket.cs
+++ b/src/Rhisis.Network/Packets/World/PlayerMovedPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/QueryPlayerData2Packet.cs
+++ b/src/Rhisis.Network/Packets/World/QueryPlayerData2Packet.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 using System.Collections.Generic;
 

--- a/src/Rhisis.Network/Packets/World/QueryPlayerDataPacket.cs
+++ b/src/Rhisis.Network/Packets/World/QueryPlayerDataPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/RangeAttackPacket.cs
+++ b/src/Rhisis.Network/Packets/World/RangeAttackPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Data;
 using System;
 

--- a/src/Rhisis.Network/Packets/World/RemoveInventoryItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/RemoveInventoryItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/RemoveItemLevelDownPacket.cs
+++ b/src/Rhisis.Network/Packets/World/RemoveItemLevelDownPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptAddExperiencePacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptAddExperiencePacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptAddGoldPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptAddGoldPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptCreateItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptCreateItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptEquipItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptEquipItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptRemoveAllItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptRemoveAllItemPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ScriptRemoveQuestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ScriptRemoveQuestPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/SellItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SellItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/SetDestPositionPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SetDestPositionPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/SetHairPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SetHairPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/SetQuestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SetQuestPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/SetTargetPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SetTargetPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Common;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/SfxIdPacket.cs
+++ b/src/Rhisis.Network/Packets/World/SfxIdPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/ShipActMsgPacket.cs
+++ b/src/Rhisis.Network/Packets/World/ShipActMsgPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/StateModePacket.cs
+++ b/src/Rhisis.Network/Packets/World/StateModePacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Data;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/TagPacket.cs
+++ b/src/Rhisis.Network/Packets/World/TagPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarAppletPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Common;
 
 namespace Rhisis.Network.Packets.World.Taskbar

--- a/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/AddTaskbarItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarAppletPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {

--- a/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/RemoveTaskbarItemPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Taskbar
 {

--- a/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Taskbar/TaskbarSkillPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
 using System;

--- a/src/Rhisis.Network/Packets/World/TeleSkillPacket.cs
+++ b/src/Rhisis.Network/Packets/World/TeleSkillPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 using Rhisis.Core.Structures;
 
 namespace Rhisis.Network.Packets.World

--- a/src/Rhisis.Network/Packets/World/Trade/TradeCancelPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Trade/TradeCancelPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Trade
 {

--- a/src/Rhisis.Network/Packets/World/Trade/TradePullPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Trade/TradePullPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Trade
 {

--- a/src/Rhisis.Network/Packets/World/Trade/TradePutGoldPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Trade/TradePutGoldPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Trade
 {

--- a/src/Rhisis.Network/Packets/World/Trade/TradePutPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Trade/TradePutPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Trade
 {

--- a/src/Rhisis.Network/Packets/World/Trade/TradeRequestPacket.cs
+++ b/src/Rhisis.Network/Packets/World/Trade/TradeRequestPacket.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World.Trade
 {

--- a/src/Rhisis.Network/Packets/World/UseSkillPacket.cs
+++ b/src/Rhisis.Network/Packets/World/UseSkillPacket.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Ether.Network.Packets;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.World
 {

--- a/src/Rhisis.Network/Rhisis.Network.csproj
+++ b/src/Rhisis.Network/Rhisis.Network.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Rhisis.Core\Rhisis.Core.csproj" />
   </ItemGroup>
 

--- a/src/Rhisis.World/Client/IWorldClient.cs
+++ b/src/Rhisis.World/Client/IWorldClient.cs
@@ -1,6 +1,5 @@
-﻿using Ether.Network.Common;
-using Rhisis.World.Game.Entities;
-using System;
+﻿using Rhisis.World.Game.Entities;
+using Sylver.Network.Common;
 
 namespace Rhisis.World.Client
 {
@@ -15,10 +14,5 @@ namespace Rhisis.World.Client
         /// Gets or sets the player entity.
         /// </summary>
         IPlayerEntity Player { get; set; }
-
-        /// <summary>
-        /// Gets the remote end point (IP and port) for this client.
-        /// </summary>
-        string RemoteEndPoint { get; }
     }
 }

--- a/src/Rhisis.World/CoreClient/Handlers/CommonCoreHandler.cs
+++ b/src/Rhisis.World/CoreClient/Handlers/CommonCoreHandler.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Network.Core;
 using Rhisis.World.CoreClient.Packets;
 using Sylver.HandlerInvoker.Attributes;
+using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.World.CoreClient.Handlers
@@ -30,7 +30,7 @@ namespace Rhisis.World.CoreClient.Handlers
         /// <param name="client">Client.</param>
         /// <param name="packet">Incoming packet.</param>
         [HandlerAction(CorePacketType.Welcome)]
-        public void OnWelcome(IWorldCoreClient client, INetPacketStream packet)
+        public void OnWelcome(IWorldCoreClient client, INetPacketStream _)
         {
             this._corePacketFactory.SendAuthentication(client, client.WorldServerConfiguration);
         }
@@ -41,7 +41,7 @@ namespace Rhisis.World.CoreClient.Handlers
         /// <param name="client">Client.</param>
         /// <param name="packet">Incoming packet.</param>
         [HandlerAction(CorePacketType.AuthenticationResult)]
-        public void OnAuthenticationResult(IWorldCoreClient client, INetPacketStream packet)
+        public void OnAuthenticationResult(IWorldCoreClient _, INetPacketStream packet)
         {
             var authenticationResult = (CoreAuthenticationResultType)(packet.Read<uint>());
 

--- a/src/Rhisis.World/CoreClient/Packets/CorePacketFactory.cs
+++ b/src/Rhisis.World/CoreClient/Packets/CorePacketFactory.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Structures.Configuration.World;
 using Rhisis.Network.Core;
+using Sylver.Network.Data;
 
 namespace Rhisis.World.CoreClient.Packets
 {

--- a/src/Rhisis.World/CoreClient/WorldCoreClient.cs
+++ b/src/Rhisis.World/CoreClient/WorldCoreClient.cs
@@ -1,18 +1,19 @@
-﻿using Ether.Network.Client;
-using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Rhisis.Core.Structures.Configuration;
 using Rhisis.Core.Structures.Configuration.World;
 using Rhisis.Network.Core;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Client;
+using Sylver.Network.Data;
 using System;
-using System.Net.Sockets;
 
 namespace Rhisis.World.CoreClient
 {
     public sealed class WorldCoreClient : NetClient, IWorldCoreClient
     {
+        public const int BufferSize = 128;
+
         private readonly ILogger<WorldCoreClient> _logger;
         private readonly IHandlerInvoker _handlerInvoker;
 
@@ -38,9 +39,7 @@ namespace Rhisis.World.CoreClient
             this.WorldServerConfiguration = worldConfiguration.Value;
             this.CoreClientConfiguration = coreConfiguration.Value;
             this._handlerInvoker = handlerInvoker;
-            this.Configuration.Host = this.CoreClientConfiguration.Host;
-            this.Configuration.Port = this.CoreClientConfiguration.Port;
-            this.Configuration.BufferSize = 128;
+            this.ClientConfiguration = new NetClientConfiguration(this.CoreClientConfiguration.Host, this.CoreClientConfiguration.Port, BufferSize);
         }
 
         /// <inheritdoc />
@@ -58,10 +57,10 @@ namespace Rhisis.World.CoreClient
         }
 
         /// <inheritdoc />
-        protected override void OnSocketError(SocketError socketError)
-        {
-            this._logger.LogError($"An error occured on {nameof(WorldCoreClient)}: {socketError}");
-        }
+        //protected override void OnSocketError(SocketError socketError)
+        //{
+        //    this._logger.LogError($"An error occured on {nameof(WorldCoreClient)}: {socketError}");
+        //}
 
         /// <inheritdoc />
         public override void HandleMessage(INetPacketStream packet)

--- a/src/Rhisis.World/Game/Components/HealthComponent.cs
+++ b/src/Rhisis.World/Game/Components/HealthComponent.cs
@@ -1,6 +1,4 @@
-﻿using Rhisis.Core.Data;
-
-namespace Rhisis.World.Game.Components
+﻿namespace Rhisis.World.Game.Components
 {
     public class HealthComponent
     {

--- a/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Ether.Network.Packets;
 using Rhisis.World.Game.Structures;
 using System.Collections.Generic;
 using System.Linq;
 using Rhisis.Core.Data;
 using Rhisis.Core.IO;
+using Sylver.Network.Data;
 
 namespace Rhisis.World.Game.Components
 {

--- a/src/Rhisis.World/Game/Components/ObjectContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/ObjectContainerComponent.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 using System.Collections.Generic;
 
 namespace Rhisis.World.Game.Components

--- a/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarAppletContainerComponent.cs
@@ -1,6 +1,6 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Core.Common;
+﻿using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Rhisis.World/Game/Components/TaskbarComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarComponent.cs
@@ -1,4 +1,4 @@
-﻿using Ether.Network.Packets;
+﻿using Sylver.Network.Data;
 
 namespace Rhisis.World.Game.Components
 {

--- a/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarItemContainerComponent.cs
@@ -1,6 +1,6 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Core.Common;
+﻿using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TaskbarQueueContainerComponent.cs
@@ -1,7 +1,6 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Core.Common;
+﻿using Rhisis.Core.Common;
 using Rhisis.Core.Common.Game.Structures;
-using Rhisis.World.Systems.Taskbar;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/IPlayerEntity.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Common;
-using Rhisis.World.Game.Components;
+﻿using Rhisis.World.Game.Components;
+using Sylver.Network.Common;
 
 namespace Rhisis.World.Game.Entities
 {

--- a/src/Rhisis.World/Game/Entities/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/PlayerEntity.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Common;
-using Rhisis.Core.Common;
+﻿using Rhisis.Core.Common;
 using Rhisis.World.Game.Behaviors;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Systems.PlayerData;
+using Sylver.Network.Common;
 
 namespace Rhisis.World.Game.Entities
 {

--- a/src/Rhisis.World/Game/Factories/IItemFactory.cs
+++ b/src/Rhisis.World/Game/Factories/IItemFactory.cs
@@ -1,5 +1,4 @@
-﻿using Rhisis.Core.Structures;
-using Rhisis.Core.Structures.Game;
+﻿using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Game.Structures;

--- a/src/Rhisis.World/Game/Factories/Internal/ItemFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/ItemFactory.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.Logging;
 using Rhisis.Core.Common;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Resources;
-using Rhisis.Core.Structures;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;

--- a/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;

--- a/src/Rhisis.World/Game/Structures/Item.cs
+++ b/src/Rhisis.World/Game/Structures/Item.cs
@@ -1,7 +1,6 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Core.Resources;
-using Rhisis.Core.Structures.Game;
+﻿using Rhisis.Core.Structures.Game;
 using Rhisis.World.Systems.Inventory;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 
 namespace Rhisis.World.Game.Structures

--- a/src/Rhisis.World/Handlers/PlayerHandler.cs
+++ b/src/Rhisis.World/Handlers/PlayerHandler.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Core.Data;
 using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World;
@@ -10,6 +9,7 @@ using Rhisis.World.Systems.Follow;
 using Rhisis.World.Systems.Interaction;
 using Rhisis.World.Systems.SpecialEffect;
 using Sylver.HandlerInvoker.Attributes;
+using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.World.Handlers

--- a/src/Rhisis.World/Handlers/SnapshotHandler.cs
+++ b/src/Rhisis.World/Handlers/SnapshotHandler.cs
@@ -1,9 +1,9 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Rhisis.Network.Packets;
 using Rhisis.World.Client;
 using Sylver.HandlerInvoker;
 using Sylver.HandlerInvoker.Attributes;
+using Sylver.Network.Data;
 using System;
 
 namespace Rhisis.World.Handlers
@@ -49,9 +49,9 @@ namespace Rhisis.World.Handlers
                 catch (ArgumentNullException)
                 {
                     if (Enum.IsDefined(typeof(SnapshotType), snapshotHeaderNumber))
-                        this._logger.LogWarning("Received an unimplemented World snapshot {0} (0x{1}) from {2}.", Enum.GetName(typeof(SnapshotType), snapshotHeaderNumber), snapshotHeaderNumber.ToString("X4"), client.RemoteEndPoint);
+                        this._logger.LogWarning("Received an unimplemented World snapshot {0} (0x{1}) from {2}.", Enum.GetName(typeof(SnapshotType), snapshotHeaderNumber), snapshotHeaderNumber.ToString("X4"), client.Socket.RemoteEndPoint);
                     else
-                        this._logger.LogWarning("[SECURITY] Received an unknown World snapshot 0x{0} from {1}.", snapshotHeaderNumber.ToString("X4"), client.RemoteEndPoint);
+                        this._logger.LogWarning("[SECURITY] Received an unknown World snapshot 0x{0} from {1}.", snapshotHeaderNumber.ToString("X4"), client.Socket.RemoteEndPoint);
                 }
                 catch (Exception exception)
                 {

--- a/src/Rhisis.World/Handlers/TradeHandler.cs
+++ b/src/Rhisis.World/Handlers/TradeHandler.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Packets;
-using Rhisis.Network.Packets;
+﻿using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World.Trade;
 using Rhisis.World.Client;
 using Rhisis.World.Systems.Trade;

--- a/src/Rhisis.World/IWorldServer.cs
+++ b/src/Rhisis.World/IWorldServer.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Server;
-using Rhisis.World.Game.Entities;
+﻿using Rhisis.World.Game.Entities;
+using Sylver.Network.Server;
 
 namespace Rhisis.World
 {

--- a/src/Rhisis.World/Packets/IPacketFactoryUtilities.cs
+++ b/src/Rhisis.World/Packets/IPacketFactoryUtilities.cs
@@ -1,5 +1,5 @@
-﻿using Ether.Network.Packets;
-using Rhisis.World.Game.Entities;
+﻿using Rhisis.World.Game.Entities;
+using Sylver.Network.Data;
 
 namespace Rhisis.World.Packets
 {

--- a/src/Rhisis.World/Packets/Internal/PacketFactoryUtilities.cs
+++ b/src/Rhisis.World/Packets/Internal/PacketFactoryUtilities.cs
@@ -1,8 +1,8 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Rhisis.Core.Common;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.World.Game.Entities;
+using Sylver.Network.Data;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/Rhisis.World/Program.cs
+++ b/src/Rhisis.World/Program.cs
@@ -1,5 +1,4 @@
-﻿using Ether.Network.Packets;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -13,6 +12,7 @@ using Rhisis.Database;
 using Rhisis.Network.Packets;
 using Rhisis.World.CoreClient;
 using Sylver.HandlerInvoker;
+using Sylver.Network.Data;
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Rhisis.World/Rhisis.World.csproj
+++ b/src/Rhisis.World/Rhisis.World.csproj
@@ -12,13 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ether.Network" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.2.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.5.3" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.Network" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.World/Systems/Death/DeathSystem.cs
+++ b/src/Rhisis.World/Systems/Death/DeathSystem.cs
@@ -66,7 +66,8 @@ namespace Rhisis.World.Systems.Death
                 if (revivalMap == null)
                 {
                     this._logger.LogError($"Cannot find revival map with id '{revivalRegion.MapId}'.");
-                    player.Connection.Server.DisconnectClient(player.Connection.Id);
+                    // TODO: disconnect client
+                    //player.Connection.Server.DisconnectClient(player.Connection.Id);
                     return;
                 }
 

--- a/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
@@ -122,7 +122,8 @@ namespace Rhisis.World.Systems.Inventory
                     if (revivalMap == null)
                     {
                         this._logger.LogError($"Cannot find revival map with id '{revivalRegion.MapId}'.");
-                        player.Connection.Server.DisconnectClient(player.Connection.Id);
+                        // TODO: disconnect client
+                        //player.Connection.Server.DisconnectClient(player.Connection.Id);
                         return;
                     }
 

--- a/src/Rhisis.World/Systems/Visibility/IVisibilitySystem.cs
+++ b/src/Rhisis.World/Systems/Visibility/IVisibilitySystem.cs
@@ -1,5 +1,4 @@
 ﻿using Rhisis.World.Game.Entities;
-using Rhisis.World.Game.Maps;
 
 namespace Rhisis.World.Systems.Visibility
 {

--- a/test/Rhisis.Login.Tests/LoginHandlerTest.cs
+++ b/test/Rhisis.Login.Tests/LoginHandlerTest.cs
@@ -14,6 +14,7 @@ using Rhisis.Network.Packets.Login;
 using Sylver.HandlerInvoker;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using Xunit;
 
 namespace Rhisis.Login.Tests
@@ -26,7 +27,8 @@ namespace Rhisis.Login.Tests
         {
             BuildVersion = BuildVersion
         };
-        private readonly LoginClient _loginClient = new LoginClient();
+        private readonly Socket _socket;
+        private readonly LoginClient _loginClient;
 
         private readonly Mock<ILogger<LoginHandler>> _loggerMock;
         private readonly Mock<ILoginServer> _loginServerMock;
@@ -41,6 +43,9 @@ namespace Rhisis.Login.Tests
 
         public LoginHandlerTest()
         {
+            this._socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            this._loginClient = new LoginClient(_socket);
+
             this._users = new UserGenerator().Generate(100);
 
             this._loggerMock = new Mock<ILogger<LoginHandler>>();


### PR DESCRIPTION
This PR removes the `Ether.Network` library and replaces it with the new `Sylver.Network` library.