### PR TITLE
Remove matrix definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 # General build informations
 language: csharp
-sudo: required
 mono: none
+os: linux
 dist: xenial
 dotnet: 3.1.100
-
-matrix:
-  env:
-    - DOTNET_CLI_TELEMETRY_OPTOUT=1
 
 # Define the jobs
 jobs:


### PR DESCRIPTION
Fix issue #313 and removes the `matrix` definition in `.travis.yml`.

The `matrix` definition was overriding the `jobs` definition where the actual build script is defined.