### PR TITLE
Update NuGet packages

### DIFF
--- a/src/Rhisis.CLI/Rhisis.CLI.csproj
+++ b/src/Rhisis.CLI/Rhisis.CLI.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.5.1" />
-    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="2.5.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.6.0" />
+    <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" Version="2.6.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
-    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+    <PackageReference Include="Sylver.Network" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Core/Rhisis.Core.csproj
+++ b/src/Rhisis.Core/Rhisis.Core.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+    <PackageReference Include="Sylver.Network" Version="1.2.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
-    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+    <PackageReference Include="Sylver.Network" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Network/FFPacket.cs
+++ b/src/Rhisis.Network/FFPacket.cs
@@ -17,10 +17,10 @@ namespace Rhisis.Network
         private short _mergedPacketCount;
 
         /// <inheritdoc />
-        protected override Encoding StringReadEncoding => FlyFFReadStringEncoding;
+        protected override Encoding ReadEncoding => FlyFFReadStringEncoding;
 
         /// <inheritdoc />
-        protected override Encoding StringWriteEncoding => FlyFFWriteStringEncoding;
+        protected override Encoding WriteEncoding => FlyFFWriteStringEncoding;
 
         /// <summary>
         /// Gets the FFPacket buffer.

--- a/src/Rhisis.Network/Rhisis.Network.csproj
+++ b/src/Rhisis.Network/Rhisis.Network.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+    <PackageReference Include="Sylver.Network" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.Scripting/Rhisis.Scripting.csproj
+++ b/src/Rhisis.Scripting/Rhisis.Scripting.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLua" Version="1.4.29" />
+    <PackageReference Include="NLua" Version="1.4.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rhisis.World/Rhisis.World.csproj
+++ b/src/Rhisis.World/Rhisis.World.csproj
@@ -15,9 +15,9 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.2" />
     <PackageReference Include="NLog" Version="4.6.8" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
-    <PackageReference Include="Sylver.Network" Version="1.1.0" />
+    <PackageReference Include="Sylver.Network" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates some nuget packages to newer version, including the Sylver.Network library that had a major issue with packet parsing.