### PR TITLE
Feature/world task manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ jobs:
         - dotnet test test/Rhisis.World.Tests/ -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[xunit*]*"
         name: "Rhisis Tests"
 
-after_script:
-  - bash <(curl -s https://codecov.io/bash) 
+# after_script:
+#  - bash <(curl -s https://codecov.io/bash) 

--- a/src/Rhisis.Core/Helpers/TaskHelper.cs
+++ b/src/Rhisis.Core/Helpers/TaskHelper.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhisis.Core.Extensions
+{
+    /// <summary>
+    /// Provides helpers to the <see cref="Task"/> object.
+    /// </summary>
+    public static class TaskHelper
+    {
+        /// <summary>
+        /// Creates a new long running task repeated every X times on the default task scheduler.
+        /// </summary>
+        /// <param name="taskToExecute">Task</param>
+        /// <param name="delay">Repeat time delay.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task</returns>
+        public static Task CreateLongRunningTask(Func<Task> taskToExecute, TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Factory.StartNew(async () =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    await taskToExecute();
+                    await Task.Delay(delay, cancellationToken);
+                }
+            },
+            cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+        }
+    }
+}

--- a/src/Rhisis.Core/Structures/Vector3.cs
+++ b/src/Rhisis.Core/Structures/Vector3.cs
@@ -308,10 +308,15 @@ namespace Rhisis.Core.Structures
             float angle = (float)Math.Atan2(dist.X, -dist.Z);
 
             angle = MathHelper.ToDegree(angle);
+
             if (angle < 0)
+            {
                 angle += 360;
+            }
             else if (angle >= 360)
+            {
                 angle -= 360;
+            }
 
             return angle;
         }

--- a/src/Rhisis.Core/Structures/Vector3.cs
+++ b/src/Rhisis.Core/Structures/Vector3.cs
@@ -143,6 +143,17 @@ namespace Rhisis.Core.Structures
         }
 
         /// <summary>
+        /// Copies the other vector values into the current vector.
+        /// </summary>
+        /// <param name="otherVector">Other vector.</param>
+        public void Copy(Vector3 otherVector)
+        {
+            X = otherVector.X;
+            Y = otherVector.Y;
+            Z = otherVector.Z;
+        }
+
+        /// <summary>
         /// Check if the Vector3 is zero.
         /// </summary>
         /// <returns></returns>
@@ -318,9 +329,38 @@ namespace Rhisis.Core.Structures
             float power = RandomHelper.FloatRandom(0f, radius);
 
             newVector.X += (float)Math.Sin(angle) * power;
-            newVector.Z -= (float)Math.Cos(angle) * power;
+            newVector.Z += (float)Math.Cos(angle) * power;
 
             return newVector;
+        }
+
+        /// <summary>
+        /// Gets the 2D distance between two vectors.
+        /// </summary>
+        /// <param name="from">Origin vector.</param>
+        /// <param name="to">Target vector.</param>
+        /// <returns>Distance</returns>
+        public static float Distance2D(Vector3 from, Vector3 to)
+        {
+            float x = from.X - to.X;
+            float z = from.Z - to.Z;
+
+            return (float)Math.Sqrt(x * x + z * z);
+        }
+
+        /// <summary>
+        /// Gets the 3D distance between two vectors.
+        /// </summary>
+        /// <param name="from">Origin vector.</param>
+        /// <param name="to">Target vector.</param>
+        /// <returns>Distance</returns>
+        public static float Distance3D(Vector3 from, Vector3 to)
+        {
+            float x = from.X - to.X;
+            float y = from.Y - to.Y;
+            float z = from.Z - to.Z;
+
+            return (float)Math.Sqrt(x * x + y * y + z * z);
         }
 
         /// <summary>

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultMonsterBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultMonsterBehavior.cs
@@ -1,12 +1,19 @@
-﻿using Rhisis.Core.Data;
+﻿using Microsoft.Extensions.Options;
+using Rhisis.Core.Data;
 using Rhisis.Core.Helpers;
 using Rhisis.Core.IO;
+using Rhisis.Core.Resources;
 using Rhisis.Core.Structures;
+using Rhisis.Core.Structures.Configuration.World;
+using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Battle;
+using Rhisis.World.Systems.Drop;
 using Rhisis.World.Systems.Follow;
 using Rhisis.World.Systems.Mobility;
+using System.Linq;
 
 namespace Rhisis.World.Game.Behaviors
 {
@@ -19,17 +26,30 @@ namespace Rhisis.World.Game.Behaviors
         private const float MovingRange = 40f;
 
         private readonly IMonsterEntity _monster;
+        private readonly WorldConfiguration _worldConfiguration;
+        private readonly IGameResources _gameResources;
         private readonly IMobilitySystem _mobilitySystem;
         private readonly IBattleSystem _battleSystem;
         private readonly IFollowSystem _followSystem;
+        private readonly IDropSystem _dropSystem;
         private readonly IMoverPacketFactory _moverPacketFactory;
 
-        public DefaultMonsterBehavior(IMonsterEntity monster, IMobilitySystem mobilitySystem, IBattleSystem battleSystem, IFollowSystem followSystem, IMoverPacketFactory moverPacketFactory)
+        public DefaultMonsterBehavior(IMonsterEntity monster,
+            IOptions<WorldConfiguration> worldConfiguration,
+            IGameResources gameResources, 
+            IMobilitySystem mobilitySystem, 
+            IBattleSystem battleSystem, 
+            IFollowSystem followSystem, 
+            IDropSystem dropSystem, 
+            IMoverPacketFactory moverPacketFactory)
         {
             _monster = monster;
+            _worldConfiguration = worldConfiguration.Value;
+            _gameResources = gameResources;
             _mobilitySystem = mobilitySystem;
             _battleSystem = battleSystem;
             _followSystem = followSystem;
+            _dropSystem = dropSystem;
             _moverPacketFactory = moverPacketFactory;
         }
 
@@ -69,6 +89,63 @@ namespace Rhisis.World.Game.Behaviors
             _monster.Follow.Reset();
         }
 
+        /// <inheritdoc />
+        public void OnKilled(ILivingEntity killerEntity)
+        {
+            _monster.Timers.DespawnTime = Time.TimeInSeconds() + 5; // TODO: Configure this timer on world configuration
+
+            // Drop items
+            int itemCount = 0;
+            foreach (DropItemData dropItem in _monster.Data.DropItems)
+            {
+                if (itemCount >= _monster.Data.MaxDropItem)
+                    break;
+
+                long dropChance = RandomHelper.LongRandom(0, DropSystem.MaxDropChance);
+
+                if (dropItem.Probability * _worldConfiguration.Rates.Drop >= dropChance)
+                {
+                    var item = new Item(dropItem.ItemId, 1, -1, -1, -1, (byte)RandomHelper.Random(0, dropItem.ItemMaxRefine));
+
+                    _dropSystem.DropItem(_monster, item, killerEntity);
+                    itemCount++;
+                }
+            }
+
+            // Drop item kinds
+            foreach (DropItemKindData dropItemKind in _monster.Data.DropItemsKind)
+            {
+                var itemsDataByItemKind = _gameResources.Items.Values.Where(x => x.ItemKind3 == dropItemKind.ItemKind && x.Rare >= dropItemKind.UniqueMin && x.Rare <= dropItemKind.UniqueMax);
+
+                if (!itemsDataByItemKind.Any())
+                {
+                    continue;
+                }
+
+                var itemData = itemsDataByItemKind.ElementAt(RandomHelper.Random(0, itemsDataByItemKind.Count() - 1));
+
+                int itemRefine = RandomHelper.Random(0, 10);
+
+                for (int i = itemRefine; i >= 0; i--)
+                {
+                    long itemDropProbability = (long)(_gameResources.ExpTables.GetDropLuck(itemData.Level > 120 ? 119 : itemData.Level, itemRefine) * (_monster.Data.CorrectionValue / 100f));
+                    long dropChance = RandomHelper.LongRandom(0, DropSystem.MaxDropChance);
+
+                    if (dropChance < itemDropProbability * _worldConfiguration.Rates.Drop)
+                    {
+                        var item = new Item(itemData.Id, 1, -1, -1, -1, (byte)itemRefine);
+
+                        _dropSystem.DropItem(_monster, item, killerEntity);
+                        break;
+                    }
+                }
+            }
+
+            // Drop gold
+            int goldDropped = RandomHelper.Random(_monster.Data.DropGoldMin, _monster.Data.DropGoldMax);
+            _dropSystem.DropGold(_monster, goldDropped, killerEntity);
+        }
+
         /// <summary>
         /// Update monster moves.
         /// </summary>
@@ -80,10 +157,10 @@ namespace Rhisis.World.Game.Behaviors
                 if (monster.Timers.NextMoveTime < Time.TimeInSeconds())
                 {
                     monster.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;
-                    monster.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE; 
+                    monster.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;
                     monster.Moves.DestinationPosition.Copy(monster.Region.GetRandomPosition());
                     monster.Object.Angle = Vector3.AngleBetween(monster.Object.Position, monster.Moves.DestinationPosition);
-                    
+
                     _moverPacketFactory.SendDestinationPosition(monster);
                     _moverPacketFactory.SendDestinationAngle(monster, false);
                 }

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultNpcBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultNpcBehavior.cs
@@ -50,7 +50,9 @@ namespace Rhisis.World.Game.Behaviors
         private void UpdateOralText()
         {
             if (_npc.NpcData == null)
+            {
                 return;
+            }
 
             if (_npc.Timers.LastSpeakTime <= Time.TimeInSeconds())
             {

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultNpcBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultNpcBehavior.cs
@@ -44,6 +44,12 @@ namespace Rhisis.World.Game.Behaviors
             throw new NotImplementedException();
         }
 
+        /// <inheritdoc />
+        public void OnKilled(ILivingEntity killerEntity)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Update NPC oral text.
         /// </summary>

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultPlayerBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultPlayerBehavior.cs
@@ -67,10 +67,9 @@ namespace Rhisis.World.Game.Behaviors
                 return;
             }
 
-            _mobilitySystem.CalculatePosition(_player);
-            _regionTriggerSystem.CheckWrapzones(_player);
-
             ProcessIdleHeal();
+            _regionTriggerSystem.CheckWrapzones(_player);
+            _mobilitySystem.CalculatePosition(_player);
         }
 
         /// <inheritdoc />
@@ -136,12 +135,9 @@ namespace Rhisis.World.Game.Behaviors
         /// <param name="player"></param>
         private void ProcessIdleHeal()
         {
-            if (_player.Timers.NextHealTime <= Time.TimeInSeconds())
+            if (_player.Timers.NextHealTime <= Time.TimeInSeconds() && !_player.Battle.IsFighting)
             {
-                if (!_player.Battle.IsFighting)
-                {
-                    _recoverySystem.IdleRecevory(_player, isSitted: false);
-                }
+                _recoverySystem.IdleRecevory(_player, isSitted: false);
             }
         }
     }

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultPlayerBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultPlayerBehavior.cs
@@ -1,10 +1,13 @@
-﻿using Rhisis.Core.Common;
+﻿using Microsoft.Extensions.Options;
+using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.IO;
+using Rhisis.Core.Structures.Configuration.World;
 using Rhisis.Core.Structures.Game.Quests;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems;
+using Rhisis.World.Systems.Experience;
 using Rhisis.World.Systems.Inventory;
 using Rhisis.World.Systems.Mobility;
 using Rhisis.World.Systems.PlayerData;
@@ -17,12 +20,14 @@ namespace Rhisis.World.Game.Behaviors
     public sealed class DefaultPlayerBehavior : IBehavior
     {
         private readonly IPlayerEntity _player;
+        private readonly WorldConfiguration _worldConfiguration;
         private readonly IMobilitySystem _mobilitySystem;
         private readonly IInventorySystem _inventorySystem;
         private readonly IPlayerDataSystem _playerDataSystem;
         private readonly IRecoverySystem _recoverySystem;
         private readonly IRegionTriggerSystem _regionTriggerSystem;
         private readonly IQuestSystem _questSystem;
+        private readonly IExperienceSystem _experienceSystem;
         private readonly IMoverPacketFactory _moverPacketFactory;
         private readonly ITextPacketFactory _textPacketFactory;
 
@@ -30,31 +35,37 @@ namespace Rhisis.World.Game.Behaviors
         /// Creates a new <see cref="DefaultPlayerBehavior"/> instance.
         /// </summary>
         /// <param name="player">Current player.</param>
+        /// <param name="worldConfiguration">World Server configuration.</param>
         /// <param name="mobilitySystem">Mobility system.</param>
         /// <param name="inventorySystem">Inventory system.</param>
         /// <param name="playerDataSystem">Player data system.</param>
         /// <param name="recoverySystem">Recovery system.</param>
         /// <param name="regionTriggerSystem">Region trigger system.</param>
         /// <param name="questSystem">Quest system.</param>
+        /// <param name="experienceSystem">Experience system.</param>
         /// <param name="moverPacketFactory">Mover packet factory.</param>
         /// <param name="textPacketFactory">Text packet factory.</param>
         public DefaultPlayerBehavior(IPlayerEntity player, 
+            IOptions<WorldConfiguration> worldConfiguration,
             IMobilitySystem mobilitySystem, 
             IInventorySystem inventorySystem, 
             IPlayerDataSystem playerDataSystem, 
             IRecoverySystem recoverySystem, 
             IRegionTriggerSystem regionTriggerSystem,
             IQuestSystem questSystem,
+            IExperienceSystem experienceSystem,
             IMoverPacketFactory moverPacketFactory, 
             ITextPacketFactory textPacketFactory)
         {
             _player = player;
+            _worldConfiguration = worldConfiguration.Value;
             _mobilitySystem = mobilitySystem;
             _inventorySystem = inventorySystem;
             _playerDataSystem = playerDataSystem;
             _recoverySystem = recoverySystem;
             _regionTriggerSystem = regionTriggerSystem;
             _questSystem = questSystem;
+            _experienceSystem = experienceSystem;
             _moverPacketFactory = moverPacketFactory;
             _textPacketFactory = textPacketFactory;
         }
@@ -91,9 +102,18 @@ namespace Rhisis.World.Game.Behaviors
         {
             if (killedEntity is IMonsterEntity deadMonster)
             {
+                // Give experience
+                _experienceSystem.GiveExeperience(_player, deadMonster.Data.Experience * _worldConfiguration.Rates.Experience);
+
                 // Quest check
                 _questSystem.UpdateQuestDiary(_player, QuestActionType.KillMonster, deadMonster.Data.Id, 1);
             }
+        }
+
+        /// <inheritdoc />
+        public void OnKilled(ILivingEntity killerEntity)
+        {
+            // TODO:
         }
 
         /// <summary>

--- a/src/Rhisis.World/Game/Behaviors/IBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/IBehavior.cs
@@ -22,5 +22,11 @@ namespace Rhisis.World.Game.Behaviors
         /// </summary>
         /// <param name="killedEntity">Killed entity.</param>
         void OnTargetKilled(ILivingEntity killedEntity);
+
+        /// <summary>
+        /// Process an action when the current entity is killed.
+        /// </summary>
+        /// <param name="killerEntity">Killer.</param>
+        void OnKilled(ILivingEntity killerEntity);
     }
 }

--- a/src/Rhisis.World/Game/Components/MovableComponent.cs
+++ b/src/Rhisis.World/Game/Components/MovableComponent.cs
@@ -12,7 +12,7 @@ namespace Rhisis.World.Game.Components
         
         public Vector3 DestinationPosition { get; set; }
 
-        public bool HasArrived { get; set; }
+        public bool HasArrived => DestinationPosition.IsZero();
 
         public float Speed { get; set; }
 

--- a/src/Rhisis.World/Game/Components/TimerComponent.cs
+++ b/src/Rhisis.World/Game/Components/TimerComponent.cs
@@ -10,8 +10,6 @@
 
         public long NextAttackTime { get; set; }
 
-        public long LastAICheck { get; set; }
-
         public long NextHealTime { get; set; }
 
         public long LastSpeakTime { get; set; }

--- a/src/Rhisis.World/Game/Entities/Internal/ItemEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/ItemEntity.cs
@@ -2,7 +2,7 @@
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Maps.Regions;
 
-namespace Rhisis.World.Game.Entities
+namespace Rhisis.World.Game.Entities.Internal
 {
     public class ItemEntity : WorldEntity, IItemEntity
     {

--- a/src/Rhisis.World/Game/Entities/Internal/MonsterEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/MonsterEntity.cs
@@ -6,7 +6,7 @@ using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Maps.Regions;
 using Rhisis.World.Game.Structures;
 
-namespace Rhisis.World.Game.Entities
+namespace Rhisis.World.Game.Entities.Internal
 {
     /// <summary>
     /// Describes the Monster entity.
@@ -65,5 +65,7 @@ namespace Rhisis.World.Game.Entities
             Battle = new BattleComponent();
             Attributes = new AttributeComponent();
         }
+
+        public override string ToString() => Object.Name;
     }
 }

--- a/src/Rhisis.World/Game/Entities/Internal/NpcEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/NpcEntity.cs
@@ -7,7 +7,7 @@ using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Structures;
 using System.Collections.Generic;
 
-namespace Rhisis.World.Game.Entities
+namespace Rhisis.World.Game.Entities.Internal
 {
     public class NpcEntity : WorldEntity, INpcEntity
     {

--- a/src/Rhisis.World/Game/Entities/Internal/PlayerEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/PlayerEntity.cs
@@ -7,7 +7,7 @@ using Rhisis.World.Game.Factories;
 using Rhisis.World.Game.Structures;
 using Sylver.Network.Common;
 
-namespace Rhisis.World.Game.Entities
+namespace Rhisis.World.Game.Entities.Internal
 {
     public class PlayerEntity : WorldEntity, IPlayerEntity
     {

--- a/src/Rhisis.World/Game/Entities/Internal/WorldEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/WorldEntity.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Components;
 using System;
 using System.Linq;
 
-namespace Rhisis.World.Game.Entities
+namespace Rhisis.World.Game.Entities.Internal
 {
     public abstract class WorldEntity : IWorldEntity
     {
@@ -34,7 +34,7 @@ namespace Rhisis.World.Game.Entities
         }
 
         /// <inheritdoc />
-        public TEntity FindEntity<TEntity>(uint id) where TEntity : IWorldEntity 
+        public TEntity FindEntity<TEntity>(uint id) where TEntity : IWorldEntity
             => (TEntity)Object.Entities.FirstOrDefault(x => x is TEntity && x.Id == id);
 
         /// <inheritdoc />
@@ -52,11 +52,10 @@ namespace Rhisis.World.Game.Entities
         public bool Equals(IWorldEntity x, IWorldEntity y) => x.Equals(y);
 
         /// <inheritdoc />
-        public bool Equals(IWorldEntity other)
-            => (Id, Type, Object.MapId, Object.LayerId) == (other.Id, other.Type, other.Object.MapId, other.Object.LayerId);
+        public bool Equals(IWorldEntity other) => Id == other.Id;
 
         /// <inheritdoc />
-        public int GetHashCode(IWorldEntity obj) => (obj.Id, obj.Type, obj.Object.Name, obj.Object.Type).GetHashCode();
+        public int GetHashCode(IWorldEntity obj) => obj.Id.GetHashCode();
 
         /// <summary>
         /// Disposes the <see cref="WorldEntity"/> resources.

--- a/src/Rhisis.World/Game/Factories/Internal/ItemFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/ItemFactory.cs
@@ -8,6 +8,7 @@ using Rhisis.Core.Structures.Game;
 using Rhisis.Database.Entities;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Game.Structures;
 using System;
@@ -97,8 +98,6 @@ namespace Rhisis.World.Game.Factories.Internal
                 Owner = owner,
                 Item = CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine)
             };
-
-            currentMapLayerContext.AddEntity(itemEntity);
 
             return itemEntity;
         }

--- a/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
@@ -8,6 +8,7 @@ using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Behaviors;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Game.Maps.Regions;
 using System;
@@ -61,8 +62,7 @@ namespace Rhisis.World.Game.Factories.Internal
 
             monster.Moves = new MovableComponent
             {
-                Speed = moverData.Speed / 2,
-                DestinationPosition = monster.Object.Position.Clone()
+                Speed = moverData.Speed
             };
 
             monster.Data = moverData;

--- a/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
@@ -3,6 +3,7 @@ using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Helpers;
+using Rhisis.Core.IO;
 using Rhisis.Core.Resources;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Behaviors;
@@ -56,7 +57,7 @@ namespace Rhisis.World.Game.Factories.Internal
                 },
                 Timers = new TimerComponent
                 {
-                    NextMoveTime = RandomHelper.LongRandom(8, 20)
+                    NextMoveTime = Time.TimeInSeconds() + RandomHelper.LongRandom(8, 20)
                 }
             };
 

--- a/src/Rhisis.World/Game/Factories/Internal/NpcFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/NpcFactory.cs
@@ -9,6 +9,7 @@ using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Behaviors;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Game.Structures;
 using System;

--- a/src/Rhisis.World/Game/Factories/Internal/PlayerFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/PlayerFactory.cs
@@ -12,6 +12,7 @@ using Rhisis.Database.Entities;
 using Rhisis.World.Game.Behaviors;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Systems.Recovery;
 using System;
@@ -107,8 +108,7 @@ namespace Rhisis.World.Game.Factories.Internal
             };
             player.Moves = new MovableComponent
             {
-                Speed = _gameResources.Movers[player.Object.ModelId].Speed,
-                DestinationPosition = player.Object.Position.Clone(),
+                Speed = _gameResources.Movers[player.Object.ModelId]?.Speed ?? 0.1f,
                 LastMoveTime = Time.GetElapsedTime(),
                 NextMoveTime = Time.GetElapsedTime() + 10
             };

--- a/src/Rhisis.World/Game/Maps/IMapInstance.cs
+++ b/src/Rhisis.World/Game/Maps/IMapInstance.cs
@@ -44,12 +44,12 @@ namespace Rhisis.World.Game.Maps
         /// <summary>
         /// Gets the map layers.
         /// </summary>
-        IReadOnlyList<IMapLayer> Layers { get; }
+        IEnumerable<IMapLayer> Layers { get; }
 
         /// <summary>
         /// Gets the map regions.
         /// </summary>
-        IReadOnlyList<IMapRegion> Regions { get; }
+        IEnumerable<IMapRegion> Regions { get; }
 
         /// <summary>
         /// Creates a new map layer and gives it a random id.
@@ -76,16 +76,6 @@ namespace Rhisis.World.Game.Maps
         /// </summary>
         /// <param name="id"></param>
         void DeleteMapLayer(int id);
-
-        /// <summary>
-        /// Starts a context in a parallel task.
-        /// </summary>
-        void StartUpdateTask();
-
-        /// <summary>
-        /// Stops the context and the task.
-        /// </summary>
-        void StopUpdateTask();
 
         /// <summary>
         /// Gets the nearest revival region from a given position.

--- a/src/Rhisis.World/Game/Maps/IMapLayer.cs
+++ b/src/Rhisis.World/Game/Maps/IMapLayer.cs
@@ -17,10 +17,5 @@ namespace Rhisis.World.Game.Maps
         /// Gets the regions of the current layer.
         /// </summary>
         ICollection<IMapRegion> Regions { get; }
-
-        /// <summary>
-        /// Updates the layer entities.
-        /// </summary>
-        void Update();
     }
 }

--- a/src/Rhisis.World/Game/Maps/IMapManager.cs
+++ b/src/Rhisis.World/Game/Maps/IMapManager.cs
@@ -1,20 +1,23 @@
-﻿namespace Rhisis.World.Game.Maps
+﻿using Rhisis.Core.Resources;
+using System.Collections.Generic;
+
+namespace Rhisis.World.Game.Maps
 {
     /// <summary>
     /// Provides a mechanism to manage all maps of a world server.
     /// </summary>
-    public interface IMapManager
+    public interface IMapManager : IGameResourceLoader
     {
+        /// <summary>
+        /// Gets a collection of all maps available on the server.
+        /// </summary>
+        IEnumerable<IMapInstance> Maps { get; }
+
         /// <summary>
         /// Gets a map instance by its id.
         /// </summary>
         /// <param name="id">Map id.</param>
         /// <returns>Map instance.</returns>
         IMapInstance GetMap(int id);
-
-        /// <summary>
-        /// Loads all maps.
-        /// </summary>
-        void Load();
     }
 }

--- a/src/Rhisis.World/Game/Maps/MapLayer.cs
+++ b/src/Rhisis.World/Game/Maps/MapLayer.cs
@@ -1,6 +1,5 @@
 ﻿using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps.Regions;
-using Rhisis.World.Systems;
 using Rhisis.World.Systems.Visibility;
 using System.Collections.Generic;
 
@@ -9,7 +8,6 @@ namespace Rhisis.World.Game.Maps
     public sealed class MapLayer : MapContext, IMapLayer
     {
         private readonly IVisibilitySystem _visibilitySystem;
-        private readonly IRespawnSystem _respawnSystem;
 
         /// <inheritdoc />
         public IMapInstance ParentMap { get; }
@@ -23,29 +21,11 @@ namespace Rhisis.World.Game.Maps
         /// <param name="parentMapInstance">Parent map.</param>
         /// <param name="layerId">Layer id.</param>
         /// <param name="visibilitySystem">Visibility system.qvisual</param>
-        public MapLayer(IMapInstance parentMapInstance, int layerId, IVisibilitySystem visibilitySystem, IRespawnSystem respawnSystem)
+        public MapLayer(IMapInstance parentMapInstance, int layerId, IVisibilitySystem visibilitySystem)
         {
             Id = layerId;
             ParentMap = parentMapInstance;
             _visibilitySystem = visibilitySystem;
-            _respawnSystem = respawnSystem;
-        }
-
-        /// <inheritdoc />
-        public void Update()
-        {
-            foreach (var entity in Entities)
-            {
-                IWorldEntity layerEntity = entity.Value;
-
-                if (layerEntity is ILivingEntity livingEntity)
-                {
-                    livingEntity.Behavior?.Update();
-                }
-
-                _visibilitySystem.Execute(layerEntity);
-                _respawnSystem.Execute(layerEntity);
-            }
         }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/Game/Maps/MapManager.cs
+++ b/src/Rhisis.World/Game/Maps/MapManager.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Rhisis.Core.DependencyInjection;
@@ -20,24 +19,24 @@ namespace Rhisis.World.Game.Maps
     {
         private readonly ILogger<MapManager> _logger;
         private readonly WorldConfiguration _worldConfiguration;
-        private readonly IMemoryCache _cache;
         private readonly IGameResources _gameResources;
         private readonly IMapFactory _mapFactory;
         private readonly IDictionary<int, IMapInstance> _maps;
+
+        /// <inheritdoc />
+        public IEnumerable<IMapInstance> Maps => _maps.Values;
 
         /// <summary>
         /// Creates a new <see cref="MapManager"/> instance.
         /// </summary>
         /// <param name="logger">Logger.</param>
         /// <param name="worldConfiguration">World server configuration.</param>
-        /// <param name="cache">World server memory cache.</param>
         /// <param name="gameResources">Game resources.</param>
         /// <param name="mapFactory">Map factory.</param>
-        public MapManager(ILogger<MapManager> logger, IOptions<WorldConfiguration> worldConfiguration, IMemoryCache cache, IGameResources gameResources, IMapFactory mapFactory)
+        public MapManager(ILogger<MapManager> logger, IOptions<WorldConfiguration> worldConfiguration, IGameResources gameResources, IMapFactory mapFactory)
         {
             _logger = logger;
             _worldConfiguration = worldConfiguration.Value;
-            _cache = cache;
             _gameResources = gameResources;
             _mapFactory = mapFactory;
             _maps = new ConcurrentDictionary<int, IMapInstance>();
@@ -55,7 +54,9 @@ namespace Rhisis.World.Game.Maps
             using (var textFile = new TextFile(worldScriptPath))
             {
                 foreach (var text in textFile.Texts)
+                {
                     worldsPaths.Add(text.Key, text.Value.Replace('"', ' ').Trim());
+                }
             }
 
             foreach (string mapDefineName in _worldConfiguration.Maps)
@@ -79,9 +80,6 @@ namespace Rhisis.World.Game.Maps
                 }
 
                 IMapInstance map = _mapFactory.Create(Path.Combine(GameResourcesConstants.Paths.MapsPath, mapName), mapName, mapId);
-
-                map.CreateMapLayer();
-                map.StartUpdateTask();
 
                 _maps.Add(mapId, map);
             }

--- a/src/Rhisis.World/Handlers/BattleHandler.cs
+++ b/src/Rhisis.World/Handlers/BattleHandler.cs
@@ -6,7 +6,6 @@ using Rhisis.World.Client;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Systems.Battle;
-using Rhisis.World.Systems.Inventory;
 using Sylver.HandlerInvoker.Attributes;
 using System;
 
@@ -23,7 +22,6 @@ namespace Rhisis.World.Handlers
         /// </summary>
         /// <param name="logger">Logger.</param>
         /// <param name="battleSystem">Battle system.</param>
-        /// <param name="moverPacketFactory">Mover packet factory.</param>
         public BattleHandler(ILogger<BattleHandler> logger, IBattleSystem battleSystem)
         {
             _logger = logger;

--- a/src/Rhisis.World/Handlers/MovementHandler.cs
+++ b/src/Rhisis.World/Handlers/MovementHandler.cs
@@ -32,8 +32,7 @@ namespace Rhisis.World.Handlers
         {
             client.Player.Object.MovingFlags = ObjectState.OBJSTA_FMOVE;
             client.Player.Moves.DestinationPosition = new Vector3(packet.X, packet.Y, packet.Z);
-            client.Player.Object.Angle = Vector3.AngleBetween(client.Player.Object.Position, client.Player.Moves.DestinationPosition);
-            client.Player.Follow.Target = null;
+            client.Player.Follow.Reset();
 
             _moverPacketFactory.SendDestinationPosition(client.Player);
         }

--- a/src/Rhisis.World/IWorldServerTaskManager.cs
+++ b/src/Rhisis.World/IWorldServerTaskManager.cs
@@ -1,0 +1,18 @@
+﻿namespace Rhisis.World
+{
+    /// <summary>
+    /// Provides a mechanism to manage the world server running tasks.
+    /// </summary>
+    public interface IWorldServerTaskManager
+    {
+        /// <summary>
+        /// Starts the world server task manager process.
+        /// </summary>
+        void Start();
+
+        /// <summary>
+        /// Stops the world server task manager process.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
+++ b/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
@@ -288,17 +288,21 @@ namespace Rhisis.World.Packets.Internal
                 IEnumerable<Item> equipedItems = playerEntity.Inventory.GetEquipedItems();
 
                 foreach (var item in equipedItems)
-                    packet.Write(item.Refines);
+                {
+                    packet.Write(item?.Refines ?? 0);
+                }
 
                 for (var i = 0; i < 28; i++)
+                {
                     packet.Write(0);
+                }
 
                 // Serialize Equiped items
-                packet.Write((byte)equipedItems.Count(x => x.Id != -1));
+                packet.Write((byte)equipedItems.Count(x => x != null));
 
                 foreach (var item in equipedItems)
                 {
-                    if (item != null && item.Id > 0)
+                    if (item != null)
                     {
                         packet.Write((byte)(item.Slot - InventorySystem.EquipOffset));
                         packet.Write((short)item.Id);

--- a/src/Rhisis.World/Systems/Battle/Arbiters/AttackArbiterBase.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/AttackArbiterBase.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Common;
 using Rhisis.World.Game.Entities;
 using System;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     public abstract class AttackArbiterBase : IAttackArbiter
     {
@@ -48,23 +48,23 @@ namespace Rhisis.World.Systems.Battle
                 return Defender.Attributes[DefineAttributes.RESIST_MAGIC];
             }
 
-            int defense = 0;
-            bool isGenericAttack = attackResult.Flags.HasFlag(AttackFlags.AF_GENERIC);
+            var defense = 0;
+            var isGenericAttack = attackResult.Flags.HasFlag(AttackFlags.AF_GENERIC);
 
             if (Attacker.Type == WorldEntityType.Player && Defender.Type == WorldEntityType.Player)
                 isGenericAttack = true;
 
             if (isGenericAttack)
             {
-                float factor = 1f;
+                var factor = 1f;
 
                 if (Defender is IPlayerEntity player)
                     factor = player.PlayerData.JobData.DefenseFactor;
 
-                int stamina = Defender.Attributes[DefineAttributes.STA];
-                int level = Defender.Object.Level;
+                var stamina = Defender.Attributes[DefineAttributes.STA];
+                var level = Defender.Object.Level;
 
-                defense = (int)(((((level * 2) + (stamina / 2)) / 2.8f) - 4) + ((stamina - 14) * factor));
+                defense = (int)((level * 2 + stamina / 2) / 2.8f - 4 + (stamina - 14) * factor);
                 // TODO: add defense armor
                 // TODO: add DST_ADJDEF
 
@@ -90,7 +90,7 @@ namespace Rhisis.World.Systems.Battle
         /// <returns></returns>
         protected virtual float GetDefenseMultiplier(float defenseFactor = 1.0f)
         {
-            defenseFactor *= (1.0f + (Defender.Attributes[DefineAttributes.ADJDEF_RATE] / 100.0f));
+            defenseFactor *= 1.0f + Defender.Attributes[DefineAttributes.ADJDEF_RATE] / 100.0f;
 
             return defenseFactor;
         }
@@ -116,13 +116,13 @@ namespace Rhisis.World.Systems.Battle
         /// <returns>Player's defense.</returns>
         private int GetPlayerDefense(IPlayerEntity defenderPlayer, AttackFlags flags)
         {
-            int defense = 0;
+            var defense = 0;
 
             if (Attacker.Type == WorldEntityType.Player)
             {
                 if (flags.HasFlag(AttackFlags.AF_MAGIC))
                 {
-                    defense = (int)((defenderPlayer.Attributes[DefineAttributes.INT] * 9.04f) + (defenderPlayer.Object.Level * 35.98f));
+                    defense = (int)(defenderPlayer.Attributes[DefineAttributes.INT] * 9.04f + defenderPlayer.Object.Level * 35.98f);
                 }
                 else
                 {
@@ -145,22 +145,22 @@ namespace Rhisis.World.Systems.Battle
         {
             if (Defender.Type == WorldEntityType.Player)
             {
-                int blockRandomProbability = RandomHelper.Random(0, 80);
+                var blockRandomProbability = RandomHelper.Random(0, 80);
 
                 if (blockRandomProbability <= 5)
                     return 1f;
                 if (blockRandomProbability >= 75f)
                     return 0.1f;
 
-                int defenderLevel = Defender.Object.Level;
-                int defenderDexterity = Defender.Attributes[DefineAttributes.DEX];
+                var defenderLevel = Defender.Object.Level;
+                var defenderDexterity = Defender.Attributes[DefineAttributes.DEX];
 
-                float blockProbabilityA = defenderLevel / ((defenderLevel + Attacker.Object.Level) * 15.0f);
-                float blockProbabilityB = (defenderDexterity + Attacker.Attributes[DefineAttributes.DEX] + 2) * ((defenderDexterity - Attacker.Attributes[DefineAttributes.DEX]) / 800.0f);
+                var blockProbabilityA = defenderLevel / ((defenderLevel + Attacker.Object.Level) * 15.0f);
+                var blockProbabilityB = (defenderDexterity + Attacker.Attributes[DefineAttributes.DEX] + 2) * ((defenderDexterity - Attacker.Attributes[DefineAttributes.DEX]) / 800.0f);
 
                 if (blockProbabilityB > 10.0f)
                     blockProbabilityB = 10.0f;
-                float blockProbability = blockProbabilityA + blockProbabilityB;
+                var blockProbability = blockProbabilityA + blockProbabilityB;
                 if (blockProbability < 0.0f)
                     blockProbability = 0.0f;
 
@@ -170,7 +170,7 @@ namespace Rhisis.World.Systems.Battle
                 if (player is null)
                     return 0f;
 
-                int blockRate = (int)((defenderDexterity / 8.0f) * player.PlayerData.JobData.Blocking + blockProbability);
+                var blockRate = (int)(defenderDexterity / 8.0f * player.PlayerData.JobData.Blocking + blockProbability);
 
                 if (blockRate < 0)
                     blockRate = 0;
@@ -180,14 +180,14 @@ namespace Rhisis.World.Systems.Battle
             }
             else if (Defender.Type == WorldEntityType.Monster)
             {
-                int blockRandomProbability = RandomHelper.Random(0, 100);
+                var blockRandomProbability = RandomHelper.Random(0, 100);
 
                 if (blockRandomProbability <= 5)
                     return 1f;
                 if (blockRandomProbability >= 95)
                     return 0f;
 
-                int blockRate = (int)((GetEspaceRating(Defender) - Defender.Object.Level) * 0.5f);
+                var blockRate = (int)((GetEspaceRating(Defender) - Defender.Object.Level) * 0.5f);
 
                 if (blockRate < 0)
                     blockRate = 0;
@@ -224,13 +224,13 @@ namespace Rhisis.World.Systems.Battle
         /// <returns></returns>
         public float GetAttackMultiplier()
         {
-            float multiplier = 1.0f + (Attacker.Attributes[DefineAttributes.ATKPOWER_RATE] / 100f);
+            var multiplier = 1.0f + Attacker.Attributes[DefineAttributes.ATKPOWER_RATE] / 100f;
 
             if (Attacker is IPlayerEntity)
             {
                 // TODO: check SM mode SM_ATTACK_UP or SM_ATTACK_UP1 => multiplier *= 1.2f;
 
-                int damages = Attacker.Attributes[Defender.Type == WorldEntityType.Player ? DefineAttributes.PVP_DMG : DefineAttributes.MONSTER_DMG];
+                var damages = Attacker.Attributes[Defender.Type == WorldEntityType.Player ? DefineAttributes.PVP_DMG : DefineAttributes.MONSTER_DMG];
 
                 if (damages > 0)
                 {

--- a/src/Rhisis.World/Systems/Battle/Arbiters/MagicAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/MagicAttackArbiter.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 using System;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     /// <summary>
     /// Provides a mechanism to calculate a magic attack based on the attacker and defender statistics.
@@ -20,7 +20,7 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="attacker">Attacker entity.</param>
         /// <param name="defender">Defender entity.</param>
         /// <param name="magicAttackPower">Magic attack power.</param>
-        public MagicAttackArbiter(ILivingEntity attacker, ILivingEntity defender, int magicAttackPower) 
+        public MagicAttackArbiter(ILivingEntity attacker, ILivingEntity defender, int magicAttackPower)
             : base(attacker, defender)
         {
             _magicAttackPower = magicAttackPower;
@@ -41,7 +41,7 @@ namespace Rhisis.World.Systems.Battle
                 Item wandWeapon = player.Inventory.GetEquipedItem(ItemPartType.RightWeapon) ?? player.Hand;
 
                 weaponAttackResult = BattleHelper.GetWeaponAttackPower(Attacker, wandWeapon);
-                int weaponAttackDamages = BattleHelper.GetWeaponAttackDamages(WeaponType.MAGIC_WAND, player);
+                var weaponAttackDamages = BattleHelper.GetWeaponAttackDamages(WeaponType.MAGIC_WAND, player);
 
                 weaponAttackResult.AttackMin += weaponAttackDamages;
                 weaponAttackResult.AttackMax += weaponAttackDamages;

--- a/src/Rhisis.World/Systems/Battle/Arbiters/MagicSkillAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/MagicSkillAttackArbiter.cs
@@ -4,7 +4,7 @@ using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 using System;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     public class MagicSkillAttackArbiter : SkillAttackArbiter, IAttackArbiter
     {
@@ -14,7 +14,7 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="attacker">Attacker entity.</param>
         /// <param name="defender">Defender entity.</param>
         /// <param name="skill">Magic skill.</param>
-        public MagicSkillAttackArbiter(ILivingEntity attacker, ILivingEntity defender, SkillInfo skill) 
+        public MagicSkillAttackArbiter(ILivingEntity attacker, ILivingEntity defender, SkillInfo skill)
             : base(attacker, defender, skill)
         {
         }
@@ -22,7 +22,7 @@ namespace Rhisis.World.Systems.Battle
         /// <inheritdoc />
         public override AttackResult CalculateDamages()
         {
-            int damages = GetAttackerSkillPower();
+            var damages = GetAttackerSkillPower();
             DefineAttributes? skillMastryAttribute = Skill.Data.SpellType switch
             {
                 SpellType.Fire => DefineAttributes.MASTRY_FIRE,
@@ -35,9 +35,9 @@ namespace Rhisis.World.Systems.Battle
 
             if (skillMastryAttribute.HasValue)
             {
-                float ratio = Math.Max(0, Attacker.Attributes[skillMastryAttribute.Value] / 100f);
+                var ratio = Math.Max(0, Attacker.Attributes[skillMastryAttribute.Value] / 100f);
 
-                damages = (int)(damages + (damages * ratio));
+                damages = (int)(damages + damages * ratio);
             }
 
             damages *= (int)GetAttackMultiplier();
@@ -60,12 +60,12 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="attackResult">Current attack result.</param>
         private void PostCalculation(AttackResult attackResult)
         {
-            int damages = attackResult.Damages;
-            int defenderDefense = GetDefenderDefense(attackResult);
+            var damages = attackResult.Damages;
+            var defenderDefense = GetDefenderDefense(attackResult);
 
             damages -= damages * (int)(Defender.Attributes[DefineAttributes.RESIST_MAGIC_RATE] / 100f);
 
-            float damageDefenseDelta = (damages - defenderDefense) * (1.0f - GetMagicSkillResitanceRate(Defender, Skill));
+            var damageDefenseDelta = (damages - defenderDefense) * (1.0f - GetMagicSkillResitanceRate(Defender, Skill));
 
             attackResult.Damages = (int)(damageDefenseDelta * GetMagicSkillFactor(Attacker, Skill));
         }
@@ -78,7 +78,7 @@ namespace Rhisis.World.Systems.Battle
         /// <returns>Magic skill resistance.</returns>
         private float GetMagicSkillResistance(ILivingEntity entity, SkillInfo skill)
         {
-            float skillResistance = skill.Data.Element switch
+            var skillResistance = skill.Data.Element switch
             {
                 ElementType.Fire => entity.Data.FireResitance + entity.Attributes[DefineAttributes.RESIST_FIRE],
                 ElementType.Water => entity.Data.WaterResistance + entity.Attributes[DefineAttributes.RESIST_WATER],
@@ -120,10 +120,10 @@ namespace Rhisis.World.Systems.Battle
                     return 1.1f;
                 }
                 else if (
-                    (skillElementType == ElementType.Fire && weaponElementType == ElementType.Water) ||
-                    (skillElementType == ElementType.Water && weaponElementType == ElementType.Electricity) ||
-                    (skillElementType == ElementType.Electricity && weaponElementType == ElementType.Earth) ||
-                    (skillElementType == ElementType.Wind && weaponElementType == ElementType.Fire)
+                    skillElementType == ElementType.Fire && weaponElementType == ElementType.Water ||
+                    skillElementType == ElementType.Water && weaponElementType == ElementType.Electricity ||
+                    skillElementType == ElementType.Electricity && weaponElementType == ElementType.Earth ||
+                    skillElementType == ElementType.Wind && weaponElementType == ElementType.Fire
                     )
                 {
                     return 0.9f;

--- a/src/Rhisis.World/Systems/Battle/Arbiters/MeleeAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/MeleeAttackArbiter.cs
@@ -5,7 +5,7 @@ using Rhisis.World.Game.Common;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     /// <summary>
     /// Provides a mechanism to calculate a melee attack result based on the attacker and defender statistics.
@@ -32,7 +32,7 @@ namespace Rhisis.World.Systems.Battle
             {
                 Flags = GetAttackFlags()
             };
-            
+
             if (attackResult.Flags.HasFlag(AttackFlags.AF_MISS))
                 return attackResult;
 
@@ -41,7 +41,7 @@ namespace Rhisis.World.Systems.Battle
                 Item rightWeapon = player.Inventory.GetEquipedItem(ItemPartType.RightWeapon) ?? player.Hand;
 
                 // TODO: GetDamagePropertyFactor()
-                int weaponAttack = BattleHelper.GetWeaponAttackDamages(rightWeapon.Data.WeaponType, player);
+                var weaponAttack = BattleHelper.GetWeaponAttackDamages(rightWeapon.Data.WeaponType, player);
                 attackResult.AttackMin = rightWeapon.Data.AbilityMin * 2 + weaponAttack;
                 attackResult.AttackMax = rightWeapon.Data.AbilityMax * 2 + weaponAttack;
             }
@@ -72,7 +72,7 @@ namespace Rhisis.World.Systems.Battle
 
             if (attackResult.Damages > 0)
             {
-                float blockFactor = GetDefenderBlockFactor();
+                var blockFactor = GetDefenderBlockFactor();
                 if (blockFactor < 1f)
                 {
                     attackResult.Flags |= AttackFlags.AF_BLOCKING;
@@ -85,7 +85,7 @@ namespace Rhisis.World.Systems.Battle
                 attackResult.Flags &= ~AttackFlags.AF_CRITICAL;
                 attackResult.Flags &= ~AttackFlags.AF_FLYING;
             }
-            
+
             return attackResult;
         }
 
@@ -98,19 +98,19 @@ namespace Rhisis.World.Systems.Battle
             // TODO: if attacker mode == ONEKILL_MODE, return AF_GENERIC
 
             int hitRate;
-            int hitRating = GetHitRating(Attacker);
-            int escapeRating = GetEspaceRating(Defender);
+            var hitRating = GetHitRating(Attacker);
+            var escapeRating = GetEspaceRating(Defender);
 
             if (Attacker.Type == WorldEntityType.Monster && Defender.Type == WorldEntityType.Player)
             {
                 // Monster VS Player
-                hitRate = (int)(((hitRating * 1.5f) / (hitRating + escapeRating)) * 2.0f *
+                hitRate = (int)(hitRating * 1.5f / (hitRating + escapeRating) * 2.0f *
                           (Attacker.Object.Level * 0.5f / (Attacker.Object.Level + Defender.Object.Level * 0.3f)) * 100.0f);
             }
             else
             {
                 // Player VS Player or Player VS Monster
-                hitRate = (int)(((hitRating * 1.6f) / (hitRating + escapeRating)) * 1.5f *
+                hitRate = (int)(hitRating * 1.6f / (hitRating + escapeRating) * 1.5f *
                           (Attacker.Object.Level * 1.2f / (Attacker.Object.Level + Defender.Object.Level)) * 100.0f);
             }
 
@@ -145,8 +145,8 @@ namespace Rhisis.World.Systems.Battle
             if (currentAttackFlags.HasFlag(AttackFlags.AF_MELEESKILL) || currentAttackFlags.HasFlag(AttackFlags.AF_MAGICSKILL))
                 return false;
 
-            float criticalJobFactor = attacker is IPlayerEntity player ? player.PlayerData.JobData.Critical : 1f;
-            int criticalProbability = (int)((attacker.Attributes[DefineAttributes.DEX] / 10) * criticalJobFactor);
+            var criticalJobFactor = attacker is IPlayerEntity player ? player.PlayerData.JobData.Critical : 1f;
+            var criticalProbability = (int)(attacker.Attributes[DefineAttributes.DEX] / 10 * criticalJobFactor);
             // TODO: add DST_CHR_CHANCECRITICAL to criticalProbability
 
             if (criticalProbability < 0)
@@ -163,8 +163,8 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="attackResult">Attack result</param>
         public void CalculateCriticalDamages(AttackResult attackResult)
         {
-            float criticalMin = 1.1f;
-            float criticalMax = 1.4f;
+            var criticalMin = 1.1f;
+            var criticalMax = 1.4f;
 
             if (Attacker.Object.Level > Defender.Object.Level)
             {
@@ -196,7 +196,7 @@ namespace Rhisis.World.Systems.Battle
         /// <returns></returns>
         public bool IsKnockback(AttackFlags attackerAttackFlags)
         {
-            bool knockbackChance = RandomHelper.Random(0, 100) < 15;
+            var knockbackChance = RandomHelper.Random(0, 100) < 15;
 
             if (Defender.Type == WorldEntityType.Player)
                 return false;
@@ -211,13 +211,13 @@ namespace Rhisis.World.Systems.Battle
                 }
             }
 
-            bool canFly = false;
+            var canFly = false;
 
             // TODO: if is flying, return false
             if ((Defender.Object.MovingFlags & ObjectState.OBJSTA_DMG_FLY_ALL) == 0 && Defender is IMonsterEntity monster)
             {
-                canFly = monster.Data.Class != MoverClassType.RANK_SUPER && 
-                    monster.Data.Class != MoverClassType.RANK_MATERIAL && 
+                canFly = monster.Data.Class != MoverClassType.RANK_SUPER &&
+                    monster.Data.Class != MoverClassType.RANK_MATERIAL &&
                     monster.Data.Class != MoverClassType.RANK_MIDBOSS;
             }
 

--- a/src/Rhisis.World/Systems/Battle/Arbiters/MeleeSkillAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/MeleeSkillAttackArbiter.cs
@@ -6,16 +6,16 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     /// <summary>
     /// Provides a mechanism to calculate a melee skill attack result based on the attacker and defender statistics.
     /// </summary>
     public class MeleeSkillAttackArbiter : SkillAttackArbiter, IAttackArbiter
     {
-        private readonly IEnumerable<int> SkillsIgnoringDefense = new int[]
+        private static readonly IEnumerable<int> SkillsIgnoringDefense = new int[]
         {
-            DefineSkill.SI_BIL_PST_ASALRAALAIKUM, 
+            DefineSkill.SI_BIL_PST_ASALRAALAIKUM,
             DefineSkill.SI_JST_YOYO_HITOFPENYA
         };
 
@@ -33,7 +33,7 @@ namespace Rhisis.World.Systems.Battle
         /// <inheritdoc />
         public override AttackResult CalculateDamages()
         {
-            int damages = (int)(GetAttackerSkillPower() * GetAttackMultiplier()) + Attacker.Attributes[DefineAttributes.ATKPOWER];
+            var damages = (int)(GetAttackerSkillPower() * GetAttackMultiplier()) + Attacker.Attributes[DefineAttributes.ATKPOWER];
 
             var attackResult = new AttackResult
             {

--- a/src/Rhisis.World/Systems/Battle/Arbiters/SkillAttackArbiter.cs
+++ b/src/Rhisis.World/Systems/Battle/Arbiters/SkillAttackArbiter.cs
@@ -6,7 +6,7 @@ using Rhisis.World.Game.Structures;
 using Rhisis.World.Systems.Inventory;
 using System;
 
-namespace Rhisis.World.Systems.Battle
+namespace Rhisis.World.Systems.Battle.Arbiters
 {
     public class SkillAttackArbiter : AttackArbiterBase
     {
@@ -21,7 +21,7 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="attacker">Attacker living entity.</param>
         /// <param name="defender">Defender living entity.</param>
         /// <param name="skill">Skill.</param>
-        protected SkillAttackArbiter(ILivingEntity attacker, ILivingEntity defender, SkillInfo skill) 
+        protected SkillAttackArbiter(ILivingEntity attacker, ILivingEntity defender, SkillInfo skill)
             : base(attacker, defender)
         {
             Skill = skill;
@@ -36,20 +36,20 @@ namespace Rhisis.World.Systems.Battle
         /// <returns>Skill power.</returns>
         protected int GetAttackerSkillPower()
         {
-            int referStatistic1 = Attacker.Attributes[Skill.Data.ReferStat1];
-            int referStatistic2 = Attacker.Attributes[Skill.Data.ReferStat2];
+            var referStatistic1 = Attacker.Attributes[Skill.Data.ReferStat1];
+            var referStatistic2 = Attacker.Attributes[Skill.Data.ReferStat2];
 
             if (Skill.Data.ReferTarget1 == SkillReferTargetType.Attack && referStatistic1 != 0)
             {
-                referStatistic1 = (int)(((Skill.Data.ReferValue1 / 10f) * referStatistic1) + (Skill.Level * (referStatistic1 / 50f)));
+                referStatistic1 = (int)(Skill.Data.ReferValue1 / 10f * referStatistic1 + Skill.Level * (referStatistic1 / 50f));
             }
 
             if (Skill.Data.ReferTarget2 == SkillReferTargetType.Attack && referStatistic2 != 0)
             {
-                referStatistic2 = (int)(((Skill.Data.ReferValue2 / 10f) * referStatistic2) + (Skill.Level * (referStatistic2 / 50f)));
+                referStatistic2 = (int)(Skill.Data.ReferValue2 / 10f * referStatistic2 + Skill.Level * (referStatistic2 / 50f));
             }
 
-            int referStatistic = referStatistic1 + referStatistic2;
+            var referStatistic = referStatistic1 + referStatistic2;
             int attackMin;
             int attackMax;
 
@@ -89,7 +89,7 @@ namespace Rhisis.World.Systems.Battle
             powerMin += weaponExtraDamages;
             powerMax += weaponExtraDamages;
 
-            float attackMinMax = Math.Max((powerMax - powerMin) + 1, 1);
+            var attackMinMax = Math.Max(powerMax - powerMin + 1, 1);
 
             return (int)(powerMin + RandomHelper.FloatRandom(1f, attackMinMax));
         }

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Helpers;
@@ -97,11 +96,6 @@ namespace Rhisis.World.Systems.Battle
 
             attacker.Battle.Target = defender;
             defender.Battle.Target = attacker;
-
-            if (defender.Type == WorldEntityType.Monster)
-            {
-                defender.Follow.Target = attacker;
-            }
 
             if (attackResult.Flags.HasFlag(AttackFlags.AF_FLYING))
             {
@@ -262,9 +256,8 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="entity">Current entity.</param>
         private void ClearBattleTargets(ILivingEntity entity)
         {
-            entity.Follow.Target = null;
-            entity.Battle.Target = null;
-            entity.Battle.Targets.Clear();
+            entity.Follow.Reset();
+            entity.Battle.Reset();
         }
     }
 }

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -1,20 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
-using Rhisis.Core.Helpers;
-using Rhisis.Core.IO;
-using Rhisis.Core.Resources;
-using Rhisis.Core.Structures.Configuration.World;
-using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Common;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
-using Rhisis.World.Systems.Drop;
-using Rhisis.World.Systems.Experience;
+using Rhisis.World.Systems.Battle.Arbiters;
 using Rhisis.World.Systems.Projectile;
-using System.Linq;
 
 namespace Rhisis.World.Systems.Battle
 {
@@ -22,32 +14,22 @@ namespace Rhisis.World.Systems.Battle
     public class BattleSystem : IBattleSystem
     {
         private readonly ILogger<BattleSystem> _logger;
-        private readonly IGameResources _gameResources;
-        private readonly IDropSystem _dropSystem;
-        private readonly IExperienceSystem _experienceSystem;
         private readonly IProjectileSystem _projectileSystem;
         private readonly IBattlePacketFactory _battlePacketFactory;
         private readonly IMoverPacketFactory _moverPacketFactory;
-        private readonly WorldConfiguration _worldConfiguration;
 
         /// <summary>
         /// Creates a new <see cref="BattleSystem"/> instance.
         /// </summary>
         /// <param name="logger">Logger.</param>
         /// <param name="worldConfiguration">World server configuration.</param>
-        /// <param name="gameResources">Game resources.</param>
-        /// <param name="dropSystem">Drop system.</param>
         /// <param name="experienceSystem">Experience system.</param>
         /// <param name="projectileSystem">Projectile system.</param>
         /// <param name="battlePacketFactory">Battle packet factory.</param>
         /// <param name="moverPacketFactory">Mover packet factory.</param>
-        public BattleSystem(ILogger<BattleSystem> logger, IOptions<WorldConfiguration> worldConfiguration, IGameResources gameResources, IDropSystem dropSystem, IExperienceSystem experienceSystem, IProjectileSystem projectileSystem, IBattlePacketFactory battlePacketFactory, IMoverPacketFactory moverPacketFactory)
+        public BattleSystem(ILogger<BattleSystem> logger, IProjectileSystem projectileSystem, IBattlePacketFactory battlePacketFactory, IMoverPacketFactory moverPacketFactory)
         {
             _logger = logger;
-            _worldConfiguration = worldConfiguration.Value;
-            _gameResources = gameResources;
-            _dropSystem = dropSystem;
-            _experienceSystem = experienceSystem;
             _projectileSystem = projectileSystem;
             _battlePacketFactory = battlePacketFactory;
             _moverPacketFactory = moverPacketFactory;
@@ -183,63 +165,13 @@ namespace Rhisis.World.Systems.Battle
                 ClearBattleTargets(defender);
                 ClearBattleTargets(attacker);
 
-                if (defender is IMonsterEntity deadMonster && attacker is IPlayerEntity player)
+                if (defender is IMonsterEntity && attacker is IPlayerEntity player)
                 {
                     _battlePacketFactory.SendDie(player, defender, attacker, attackType);
-
-                    deadMonster.Timers.DespawnTime = Time.TimeInSeconds() + 5; // Configure this timer on world configuration
-
-                    // Drop items
-                    int itemCount = 0;
-                    foreach (DropItemData dropItem in deadMonster.Data.DropItems)
-                    {
-                        if (itemCount >= deadMonster.Data.MaxDropItem)
-                            break;
-
-                        long dropChance = RandomHelper.LongRandom(0, DropSystem.MaxDropChance);
-
-                        if (dropItem.Probability * _worldConfiguration.Rates.Drop >= dropChance)
-                        {
-                            var item = new Item(dropItem.ItemId, 1, -1, -1, -1, (byte)RandomHelper.Random(0, dropItem.ItemMaxRefine));
-
-                            _dropSystem.DropItem(defender, item, attacker);
-                            itemCount++;
-                        }
-                    }
-
-                    // Drop item kinds
-                    foreach (DropItemKindData dropItemKind in deadMonster.Data.DropItemsKind)
-                    {
-                        var itemsDataByItemKind = _gameResources.Items.Values.Where(x => x.ItemKind3 == dropItemKind.ItemKind && x.Rare >= dropItemKind.UniqueMin && x.Rare <= dropItemKind.UniqueMax);
-
-                        if (!itemsDataByItemKind.Any())
-                            continue;
-
-                        var itemData = itemsDataByItemKind.ElementAt(RandomHelper.Random(0, itemsDataByItemKind.Count() - 1));
-
-                        int itemRefine = RandomHelper.Random(0, 10);
-
-                        for (int i = itemRefine; i >= 0; i--)
-                        {
-                            long itemDropProbability = (long)(_gameResources.ExpTables.GetDropLuck(itemData.Level > 120 ? 119 : itemData.Level, itemRefine) * (deadMonster.Data.CorrectionValue / 100f));
-                            long dropChance = RandomHelper.LongRandom(0, DropSystem.MaxDropChance);
-
-                            if (dropChance < itemDropProbability * _worldConfiguration.Rates.Drop)
-                            {
-                                var item = new Item(itemData.Id, 1, -1, -1, -1, (byte)itemRefine);
-
-                                _dropSystem.DropItem(defender, item, attacker);
-                                break;
-                            }
-                        }
-                    }
-
-                    // Drop gold
-                    int goldDropped = RandomHelper.Random(deadMonster.Data.DropGoldMin, deadMonster.Data.DropGoldMax);
-                    _dropSystem.DropGold(deadMonster, goldDropped, attacker);
-
-                    // Give experience
-                    _experienceSystem.GiveExeperience(player, deadMonster.Data.Experience * _worldConfiguration.Rates.Experience);
+                }
+                else if (defender is IPlayerEntity && attacker is IPlayerEntity)
+                {
+                    // TODO: PVP
                 }
                 else if (defender is IPlayerEntity deadPlayer)
                 {
@@ -247,6 +179,7 @@ namespace Rhisis.World.Systems.Battle
                 }
 
                 attacker.Behavior.OnTargetKilled(defender);
+                defender.Behavior.OnKilled(attacker);
             }
         }
 
@@ -257,6 +190,10 @@ namespace Rhisis.World.Systems.Battle
         private void ClearBattleTargets(ILivingEntity entity)
         {
             entity.Follow.Reset();
+            entity.Object.MovingFlags &= ~ObjectState.OBJSTA_FMOVE;
+            entity.Object.MovingFlags |= ObjectState.OBJSTA_STAND;
+            entity.Moves.DestinationPosition.Reset();
+
             entity.Battle.Reset();
         }
     }

--- a/src/Rhisis.World/Systems/Drop/DropSystem.cs
+++ b/src/Rhisis.World/Systems/Drop/DropSystem.cs
@@ -48,6 +48,8 @@ namespace Rhisis.World.Systems.Drop
                 newItem.Drop.OwnershipTime = Time.TimeInSeconds() + _worldServerConfiguration.Drops.OwnershipTime;
                 newItem.Drop.DespawnTime = Time.TimeInSeconds() + _worldServerConfiguration.Drops.DespawnTime;
             }
+
+            owner.Object.CurrentLayer.AddEntity(newItem);
         }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/Systems/Follow/FollowSystem.cs
+++ b/src/Rhisis.World/Systems/Follow/FollowSystem.cs
@@ -24,8 +24,9 @@ namespace Rhisis.World.Systems.Follow
         public void Follow(ILivingEntity livingEntity, IWorldEntity targetEntity, float distance = 1f)
         {
             livingEntity.Follow.Target = targetEntity;
-            livingEntity.Moves.DestinationPosition = targetEntity.Object.Position.Clone();
-            livingEntity.Object.MovingFlags = ObjectState.OBJSTA_FMOVE;
+            livingEntity.Moves.DestinationPosition.Copy(targetEntity.Object.Position);
+            livingEntity.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;
+            livingEntity.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;
 
             _moverPacketFactory.SendFollowTarget(livingEntity, targetEntity, distance);
         }

--- a/src/Rhisis.World/Systems/Mobility/IMobilitySystem.cs
+++ b/src/Rhisis.World/Systems/Mobility/IMobilitySystem.cs
@@ -10,7 +10,7 @@ namespace Rhisis.World.Systems.Mobility
         /// <summary>
         /// Calculates the movable entities positions in real-time.
         /// </summary>
-        /// <param name="entity">Movable entity.</param>
-        void CalculatePosition(IMovableEntity entity);
+        /// <param name="entity">Living and moving entity.</param>
+        void CalculatePosition(ILivingEntity entity);
     }
 }

--- a/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
+++ b/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
@@ -1,9 +1,10 @@
 ﻿using Rhisis.Core.Common;
 using Rhisis.Core.Data;
 using Rhisis.Core.DependencyInjection;
-using Rhisis.Core.IO;
+using Rhisis.Core.Structures;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps;
+using Rhisis.World.Packets;
 using System;
 
 namespace Rhisis.World.Systems.Mobility
@@ -12,37 +13,42 @@ namespace Rhisis.World.Systems.Mobility
     public sealed class MobilitySystem : IMobilitySystem
     {
         private const float ArrivalRangeRadius = 1f;
+        private readonly float _updateRate = MapInstance.UpdateRate / MapInstance.FrameRate;
+        private readonly IMoverPacketFactory _moverPacketFactory;
+
+        public MobilitySystem(IMoverPacketFactory moverPacketFactory)
+        {
+            _moverPacketFactory = moverPacketFactory;
+        }
 
         /// <inheritdoc />
-        public void CalculatePosition(IMovableEntity entity)
+        public void CalculatePosition(ILivingEntity entity)
         {
             if (!entity.Object.Spawned)
+            {
                 return;
+            }
 
-            if (entity.Moves.NextMoveTime > Time.GetElapsedTime())
+            if (entity.Moves.DestinationPosition.IsZero() || entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_STAND))
+            {
                 return;
-
-            entity.Moves.NextMoveTime = Time.GetElapsedTime() + 10;
-
-            if (entity.Moves.DestinationPosition.IsZero())
-                return;
-
-            if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_STAND))
-                return;
+            }
 
             if (entity.Follow.IsFollowing)
             {
-                if (!entity.Object.Position.IsInCircle(entity.Follow.Target.Object.Position, entity.Follow.FollowDistance))
+                if (entity.Object.Position.IsInCircle(entity.Follow.Target.Object.Position, entity.Follow.FollowDistance))
                 {
-                    entity.Moves.DestinationPosition = entity.Follow.Target.Object.Position.Clone();
+                    entity.Moves.DestinationPosition.Reset();
+                    entity.Behavior?.OnArrived();
+
+                    entity.Object.MovingFlags &= ~ObjectState.OBJSTA_FMOVE;
+                    entity.Object.MovingFlags |= ObjectState.OBJSTA_STAND;
+                }
+                else
+                {
+                    entity.Moves.DestinationPosition.Copy(entity.Follow.Target.Object.Position);
                     entity.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;
                     entity.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;
-                }
-                if (entity.Object.Position.IsInCircle(entity.Follow.Target.Object.Position, entity.Follow.FollowDistance) &&
-                    !entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_STAND))
-                {
-                    // Arrived
-                    entity.Object.MovingFlags = ObjectState.OBJSTA_STAND;
                 }
             }
 
@@ -53,67 +59,95 @@ namespace Rhisis.World.Systems.Mobility
         /// Process the walk algorithm.
         /// </summary>
         /// <param name="entity">Current entity</param>
-        private void Walk(IMovableEntity entity)
+        private void Walk(ILivingEntity entity)
         {
             if (entity.Object.Position.IsInCircle(entity.Moves.DestinationPosition, ArrivalRangeRadius))
             {
-                entity.Moves.HasArrived = true;
-                entity.Moves.DestinationPosition = entity.Object.Position.Clone();
-                entity.Object.MovingFlags &= ~ObjectState.OBJSTA_FMOVE;
-                entity.Object.MovingFlags |= ObjectState.OBJSTA_STAND;
+                entity.Object.Position.Copy(entity.Moves.DestinationPosition);
+                entity.Moves.DestinationPosition.Reset();
 
-                if (entity is ILivingEntity livingEntity)
-                    livingEntity.Behavior.OnArrived();
+                if (!entity.Battle.IsFighting)
+                {
+                    entity.Object.MovingFlags &= ~ObjectState.OBJSTA_FMOVE;
+                    entity.Object.MovingFlags |= ObjectState.OBJSTA_STAND;
+                    _moverPacketFactory.SendMotion(entity, ObjectMessageType.OBJMSG_STAND);
+                }
+
+                entity.Behavior.OnArrived();
             }
             else
             {
-                entity.Moves.HasArrived = false;
-                //float entitySpeed = entity.Moves.Speed * entity.Moves.SpeedFactor; // TODO: Add speed bonuses
-
-                float entitySpeed = ((entity.Moves.Speed * entity.Moves.SpeedFactor * 100)) * ((float)MapInstance.UpdateRate / 1000f); // TODO: Add speed bonuses
+                entity.Object.Angle = Vector3.AngleBetween(entity.Object.Position, entity.Moves.DestinationPosition);
+                float entitySpeed = GetEntitySpeed(entity);
 
                 if (entity.Object.MotionFlags.HasFlag(StateFlags.OBJSTAF_WALK))
-                    entitySpeed /= 5f;
-                else if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_BMOVE))
+                {
                     entitySpeed /= 4f;
+                }
+                else if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_BMOVE))
+                {
+                    entitySpeed /= 5f;
+                }
 
                 float distanceX = entity.Moves.DestinationPosition.X - entity.Object.Position.X;
                 float distanceZ = entity.Moves.DestinationPosition.Z - entity.Object.Position.Z;
                 double distance = Math.Sqrt(distanceX * distanceX + distanceZ * distanceZ);
 
                 // Normalize
-                double deltaX = distanceX / distance;
-                double deltaZ = distanceZ / distance;
-                double offsetX = deltaX * entitySpeed;
-                double offsetZ = deltaZ * entitySpeed;
+                double offsetX = (distanceX / distance) * entitySpeed;
+                double offsetZ = (distanceZ / distance) * entitySpeed;
 
                 if (Math.Abs(offsetX) > Math.Abs(distanceX))
+                {
                     offsetX = distanceX;
+                }
+
                 if (Math.Abs(offsetZ) > Math.Abs(distanceZ))
+                {
                     offsetZ = distanceZ;
-
-                if (entity.Type == WorldEntityType.Player && entity.Moves.IsMovingWithKeyboard)
-                {
-                    float angle = entity.Object.Angle;
-                    var movementX = (float)(Math.Sin(angle * (Math.PI / 180)) * Math.Sqrt(offsetX * offsetX + offsetZ * offsetZ));
-                    var movementZ = (float)(Math.Cos(angle * (Math.PI / 180)) * Math.Sqrt(offsetX * offsetX + offsetZ * offsetZ));
-
-                    if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_FMOVE))
-                    {
-                        entity.Object.Position.X += movementX;
-                        entity.Object.Position.Z -= movementZ;
-                    }
-                    else if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_BMOVE))
-                    {
-                        entity.Object.Position.X -= movementX;
-                        entity.Object.Position.Z += movementZ;
-                    }
                 }
-                else
+
+                UpdatePosition(entity, (float)offsetX, (float)offsetZ);
+            }
+        }
+
+        private float GetEntitySpeed(ILivingEntity entity)
+        {
+            float entitySpeed = entity.Moves.Speed * entity.Moves.SpeedFactor; // TODO: Add speed bonuses
+
+            if (entity.Type == WorldEntityType.Monster)
+            {
+                entitySpeed /= 2f;
+            }
+
+            entitySpeed *= _updateRate;
+
+            return entitySpeed;
+        }
+
+        private void UpdatePosition(ILivingEntity entity, float x, float z)
+        {
+            if (entity is IPlayerEntity && entity.Moves.IsMovingWithKeyboard)
+            {
+                float angle = entity.Object.Angle;
+                var movementX = (float)(Math.Sin(angle * (Math.PI / 180)) * Math.Sqrt(x * x + z * z));
+                var movementZ = (float)(Math.Cos(angle * (Math.PI / 180)) * Math.Sqrt(x * x + z * z));
+
+                if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_FMOVE))
                 {
-                    entity.Object.Position.X += (float)offsetX;
-                    entity.Object.Position.Z += (float)offsetZ;
+                    entity.Object.Position.X += movementX;
+                    entity.Object.Position.Z -= movementZ;
                 }
+                else if (entity.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_BMOVE))
+                {
+                    entity.Object.Position.X -= movementX;
+                    entity.Object.Position.Z += movementZ;
+                }
+            }
+            else
+            {
+                entity.Object.Position.X += x;
+                entity.Object.Position.Z += z;
             }
         }
     }

--- a/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
+++ b/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
@@ -39,10 +39,9 @@ namespace Rhisis.World.Systems.Mobility
                 if (entity.Object.Position.IsInCircle(entity.Follow.Target.Object.Position, entity.Follow.FollowDistance))
                 {
                     entity.Moves.DestinationPosition.Reset();
-                    entity.Behavior?.OnArrived();
-
                     entity.Object.MovingFlags &= ~ObjectState.OBJSTA_FMOVE;
                     entity.Object.MovingFlags |= ObjectState.OBJSTA_STAND;
+                    entity.Behavior?.OnArrived();
                 }
                 else
                 {

--- a/src/Rhisis.World/Systems/Respawn/RespawnSystem.cs
+++ b/src/Rhisis.World/Systems/Respawn/RespawnSystem.cs
@@ -72,8 +72,11 @@ namespace Rhisis.World.Systems
             monster.Timers.NextMoveTime = Time.TimeInSeconds() + RandomHelper.LongRandom(5, 15);
             monster.Object.Spawned = true;
             monster.Object.Position = monster.Region.GetRandomPosition();
-            monster.Moves.DestinationPosition = monster.Object.Position.Clone();
+            monster.Object.MovingFlags = ObjectState.OBJSTA_STAND;
+            monster.Moves.DestinationPosition.Reset();
             monster.Moves.SpeedFactor = 1;
+            monster.Battle.Reset();
+            monster.Follow.Reset();
             monster.Attributes[DefineAttributes.HP] = monster.Data.AddHp;
             monster.Attributes[DefineAttributes.MP] = monster.Data.AddMp;
         }

--- a/src/Rhisis.World/Systems/Respawn/RespawnSystem.cs
+++ b/src/Rhisis.World/Systems/Respawn/RespawnSystem.cs
@@ -30,11 +30,13 @@ namespace Rhisis.World.Systems
                 {
                     _logger.LogDebug($"Despawning {monster.Object.Name}...");
                     monster.Object.Spawned = false;
-                    if (monster.Object.AbleRespawn != true) {
+                    
+                    if (!monster.Object.AbleRespawn)
+                    {
                         monster.Timers.RespawnTime = Time.TimeInSeconds() + monster.Region.Time;
-                    } 
+                    }
                 }
-                else if (!monster.Object.Spawned && monster.Timers.RespawnTime < Time.TimeInSeconds() && monster.Object.AbleRespawn != true )
+                else if (!monster.Object.Spawned && monster.Timers.RespawnTime < Time.TimeInSeconds() && !monster.Object.AbleRespawn)
                 {
                     _logger.LogDebug($"Respawning {monster.Object.Name}...");
                     ResetMonster(monster);

--- a/src/Rhisis.World/Systems/Skills/SkillSystem.cs
+++ b/src/Rhisis.World/Systems/Skills/SkillSystem.cs
@@ -10,6 +10,7 @@ using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Battle;
+using Rhisis.World.Systems.Battle.Arbiters;
 using Rhisis.World.Systems.Inventory;
 using Rhisis.World.Systems.Projectile;
 using System;

--- a/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
+++ b/src/Rhisis.World/Systems/Teleport/TeleportSystem.cs
@@ -67,8 +67,10 @@ namespace Rhisis.World.Systems.Teleport
                 // TODO: get map height at x/z position
                 float positionY = y ?? 100;
                 player.Object.Position = new Vector3(x, positionY, z);
-                player.Moves.DestinationPosition = player.Object.Position.Clone();
                 player.Object.MovingFlags = ObjectState.OBJSTA_STAND;
+                player.Moves.DestinationPosition.Reset();
+                player.Battle.Reset();
+                player.Follow.Reset();
 
                 _playerPacketFactory.SendPlayerReplace(player);
                 _worldSpawnPacketFactory.SendPlayerSpawn(player);
@@ -85,7 +87,10 @@ namespace Rhisis.World.Systems.Teleport
                 // TODO: get map height at x/z position
                 float positionY = y ?? 100;
                 player.Object.Position = new Vector3(x, positionY, z);
-                player.Moves.DestinationPosition = player.Object.Position.Clone();
+                player.Object.MovingFlags = ObjectState.OBJSTA_STAND;
+                player.Moves.DestinationPosition.Reset();
+                player.Battle.Reset();
+                player.Follow.Reset();
             }
 
             _playerPacketFactory.SendPlayerTeleport(player);

--- a/src/Rhisis.World/Systems/Visibility/VisibilitySystem.cs
+++ b/src/Rhisis.World/Systems/Visibility/VisibilitySystem.cs
@@ -31,7 +31,9 @@ namespace Rhisis.World.Systems.Visibility
         public void Execute(IWorldEntity worldEntity)
         {
             if (!worldEntity.Object.Spawned || worldEntity.Type != WorldEntityType.Player)
+            {
                 return;
+            }
 
             UpdateVisibility(worldEntity, worldEntity.Object.CurrentMap.Entities);
             UpdateVisibility(worldEntity, worldEntity.Object.CurrentLayer.Entities);
@@ -66,7 +68,9 @@ namespace Rhisis.World.Systems.Visibility
             foreach (var entity in entities)
             {
                 if (entity.Key == worldEntity.Id)
+                {
                     continue;
+                }
 
                 IWorldEntity otherEntity = entity.Value;
 
@@ -75,12 +79,16 @@ namespace Rhisis.World.Systems.Visibility
                 if (canSee && otherEntity.Object.Spawned)
                 {
                     if (!worldEntity.Object.Entities.Contains(otherEntity))
+                    {
                         SpawnOtherEntity(worldEntity, otherEntity);
+                    }
                 }
                 else
                 {
                     if (worldEntity.Object.Entities.Contains(otherEntity))
+                    {
                         DespawnOtherEntity(worldEntity, otherEntity);
+                    }
                 }
             }
         }
@@ -95,10 +103,14 @@ namespace Rhisis.World.Systems.Visibility
             entity.Object.Entities.Add(otherEntity);
 
             if (entity is IPlayerEntity player)
+            {
                 _worldSpawnPacketFactory.SendSpawnObjectTo(player, otherEntity);
+            }
 
             if (otherEntity.Type != WorldEntityType.Player && !otherEntity.Object.Entities.Contains(entity))
+            {
                 otherEntity.Object.Entities.Add(entity);
+            }
 
             if (otherEntity is IMovableEntity movableEntity &&
                 movableEntity.Moves.DestinationPosition != movableEntity.Object.Position)
@@ -115,12 +127,16 @@ namespace Rhisis.World.Systems.Visibility
         private void DespawnOtherEntity(IWorldEntity entity, IWorldEntity otherEntity)
         {
             if (entity is IPlayerEntity player)
+            {
                 _worldSpawnPacketFactory.SendDespawnObjectTo(player, otherEntity);
+            }
 
             entity.Object.Entities.Remove(otherEntity);
 
             if (otherEntity.Type != WorldEntityType.Player && otherEntity.Object.Entities.Contains(entity))
+            {
                 otherEntity.Object.Entities.Remove(entity);
+            }
         }
     }
 }

--- a/src/Rhisis.World/WorldServer.cs
+++ b/src/Rhisis.World/WorldServer.cs
@@ -25,6 +25,7 @@ namespace Rhisis.World
         private const int ClientBacklog = 50;
 
         private readonly ILogger<WorldServer> _logger;
+        private readonly IWorldServerTaskManager _worldServerTaskManager;
         private readonly WorldConfiguration _worldConfiguration;
         private readonly IGameResources _gameResources;
         private readonly IServiceProvider _serviceProvider;
@@ -35,9 +36,13 @@ namespace Rhisis.World
         /// <summary>
         /// Creates a new <see cref="WorldServer"/> instance.
         /// </summary>
-        public WorldServer(ILogger<WorldServer> logger, IOptions<WorldConfiguration> worldConfiguration, IGameResources gameResources, IServiceProvider serviceProvider, IMapManager mapManager, IBehaviorManager behaviorManager, IChatCommandManager chatCommandManager)
+        public WorldServer(ILogger<WorldServer> logger, IOptions<WorldConfiguration> worldConfiguration, 
+            IWorldServerTaskManager worldServerTaskManager,
+            IGameResources gameResources, IServiceProvider serviceProvider, 
+            IMapManager mapManager, IBehaviorManager behaviorManager, IChatCommandManager chatCommandManager)
         {
             _logger = logger;
+            _worldServerTaskManager = worldServerTaskManager;
             _worldConfiguration = worldConfiguration.Value;
             _gameResources = gameResources;
             _serviceProvider = serviceProvider;
@@ -72,8 +77,15 @@ namespace Rhisis.World
         /// <inheritdoc />
         protected override void OnAfterStart()
         {
+            _worldServerTaskManager.Start();
             _logger.LogInformation("'{0}' world server is started and listen on {1}:{2}.",
                 _worldConfiguration.Name, ServerConfiguration.Host, ServerConfiguration.Port);
+        }
+
+        /// <inheritdoc />
+        protected override void OnBeforeStop()
+        {
+            _worldServerTaskManager.Stop();
         }
 
         /// <inheritdoc />

--- a/src/Rhisis.World/WorldServerTaskManager.cs
+++ b/src/Rhisis.World/WorldServerTaskManager.cs
@@ -1,0 +1,118 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Extensions;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Maps;
+using Rhisis.World.Systems;
+using Rhisis.World.Systems.Visibility;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Rhisis.World
+{
+    [Injectable(ServiceLifetime.Singleton)]
+    public class WorldServerTaskManager : IWorldServerTaskManager
+    {
+        private readonly CancellationToken _cancellationToken;
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly ILogger<WorldServerTaskManager> _logger;
+        private readonly IMapManager _mapManager;
+        private readonly IVisibilitySystem _visibilitySystem;
+        private readonly IRespawnSystem _respawnSystem;
+
+        /// <summary>
+        /// Creates a new <see cref="WorldServerTaskManager"/> instance.
+        /// </summary>
+        /// <param name="logger">Logger.</param>
+        /// <param name="mapManager">Map manager.</param>
+        /// <param name="visibilitySystem">Visibility System.</param>
+        /// <param name="respawnSystem">Respawn System.</param>
+        public WorldServerTaskManager(ILogger<WorldServerTaskManager> logger, IMapManager mapManager, IVisibilitySystem visibilitySystem, IRespawnSystem respawnSystem)
+        {
+            _cancellationTokenSource = new CancellationTokenSource();
+            _cancellationToken = _cancellationTokenSource.Token;
+            _logger = logger;
+            _mapManager = mapManager;
+            _visibilitySystem = visibilitySystem;
+            _respawnSystem = respawnSystem;
+        }
+
+        /// <inheritdoc />
+        public void Start()
+        {
+            TaskHelper.CreateLongRunningTask(UpdateServerHeartbeat, TimeSpan.FromSeconds(1), _cancellationToken);
+            TaskHelper.CreateLongRunningTask(UpdateServerObjects, TimeSpan.FromMilliseconds(67), _cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public void Stop()
+        {
+            _cancellationTokenSource.Cancel();
+        }
+
+        /// <summary>
+        /// Update the server heartbeat every second.
+        /// </summary>
+        /// <returns></returns>
+        private Task UpdateServerHeartbeat()
+        {
+            return ForeachEntities(entity =>
+            {
+                try
+                {
+                    _visibilitySystem.Execute(entity);
+                    _respawnSystem.Execute(entity);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, $"An error occured while updating server timers for entity: '{entity}'.");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Updates the server living objects.
+        /// </summary>
+        /// <returns></returns>
+        private Task UpdateServerObjects()
+        {
+            return ForeachEntities(entity =>
+            {
+                try
+                {
+                    if (entity is ILivingEntity livingEntity)
+                    {
+                        livingEntity.Behavior?.Update();
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, $"An error occured while updating object: '{entity}'");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Loop throught each entities of each map layers.
+        /// </summary>
+        /// <param name="actionToExecute">Action to execute.</param>
+        /// <returns></returns>
+        private Task ForeachEntities(Action<IWorldEntity> actionToExecute)
+        {
+            foreach (IMapInstance map in _mapManager.Maps)
+            {
+                foreach (IMapLayer layer in map.Layers)
+                {
+                    foreach (IWorldEntity entity in layer.Entities.Values)
+                    {
+                        actionToExecute(entity);
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
+++ b/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
@@ -4,6 +4,7 @@ using Rhisis.Database;
 using Rhisis.Database.Entities;
 using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Factories;
 using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;


### PR DESCRIPTION
This PR includes the following:

## World Server Task manager

Previously, the server update system was tightly coupled with the `MapInstance` object. One `MapInstance` will create on long running task and update its entities.
Now, we have 2 tasks (and probably more in the future) :
* One that updates the object timers *every second*
* One task that updates every objects of each maps and layers *every 67ms*

With this technique, we separate the processes that were really CPU consumming, like the visibility system or the respawn system that only needs to be update every seconds. This reduces the calls to the garbage collector and CPU overhead.

## Entities position calculation

Finally, the legendary bug of position calculation and drops appearing far away from the monsters is (**almost**) solved.
I say almost, because some times, the drops goes a little bit away from the monster (maybe 2/3 points in X/Z coordinates). This might be related to the update rate, but I'm not sure for now.

The problem was actually related to the player. When we clicked on a monster, the player was supposed to follow the monster and update it's position, but due to a fail in the `FollowSystem`, the player's position wasn't updating and the the monster (on the server side), was seeing the player at its original position and not near it. That's why the items and gold were dropped far way (at player's original position).
The fail in the `FollowSystem` was due to this line:
```csharp
livingEntity.Object.MovingFlags &= ObjectState.OBJSTA_FMOVE;
```
Here we were doing some weird black magic with the flags. To fix this, I just did a simple:
```csharp
livingEntity.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;
```
to add the flag to the `MovingFlags`.

## Moving the monster drop process from the battle system to behavior.

The behaviors now have a method called `OnKilled()`. This method is called when the entity is considered as "dead" in the `BattleSystem`.

The drop item process when a monster is killed as been moved to the `DefaultMonsterBehavior.OnKilled()` method. Also, the give experience process has been moved to the `DefaultPlayerBehavior.OnTargetKilled()` (because, we gain experience when a monster is killed right? 😄 )