### PR TITLE
Add change job system

### DIFF
--- a/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
+++ b/src/Rhisis.CLI/Commands/Database/DatabaseConfigureCommand.cs
@@ -45,9 +45,7 @@ namespace Rhisis.CLI.Commands.Database
 
             dbConfiguration.Fill();
 
-            bool useEncryption = _consoleHelper.AskConfirmation("Use encryption?");
-
-            if (useEncryption)
+            if (databaseConfiguration.UseEncryption)
             {
                 if (string.IsNullOrEmpty(dbConfiguration.Value.EncryptionKey))
                 {

--- a/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
+++ b/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
@@ -129,7 +129,7 @@ namespace Rhisis.Cluster.Handlers
                 HairId = packet.HairMeshId,
                 BankCode = packet.BankPassword,
                 Gender = packet.Gender,
-                JobId = packet.Job,
+                JobId = (int)packet.Job,
                 Hp = HealthFormulas.GetMaxOriginHp(defaultCharacter.Level, defaultCharacter.Stamina,
                     jobData.MaxHpFactor),
                 Mp = HealthFormulas.GetMaxOriginMp(defaultCharacter.Level, defaultCharacter.Intelligence,

--- a/src/Rhisis.Core/Resources/GameResources.cs
+++ b/src/Rhisis.Core/Resources/GameResources.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Rhisis.Core.Data;
 using Rhisis.Core.IO;
 using Rhisis.Core.Structures.Game;
 using Rhisis.Core.Structures.Game.Dialogs;
@@ -22,7 +23,7 @@ namespace Rhisis.Core.Resources
         private ConcurrentDictionary<int, ItemData> _items;
         private ConcurrentDictionary<string, DialogSet> _dialogs;
         private ConcurrentDictionary<string, ShopData> _shops;
-        private ConcurrentDictionary<int, JobData> _jobs;
+        private ConcurrentDictionary<DefineJob.Job, JobData> _jobs;
         private ConcurrentDictionary<string, NpcData> _npcs;
         private ConcurrentDictionary<int, IQuestScript> _quests;
         private ConcurrentDictionary<int, SkillData> _skills;
@@ -48,7 +49,7 @@ namespace Rhisis.Core.Resources
         public IReadOnlyDictionary<string, ShopData> Shops => GetCacheValue(GameResourcesConstants.Shops, ref _shops);
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<int, JobData> Jobs => GetCacheValue(GameResourcesConstants.Jobs, ref _jobs);
+        public IReadOnlyDictionary<DefineJob.Job, JobData> Jobs => GetCacheValue(GameResourcesConstants.Jobs, ref _jobs);
 
         /// <inheritdoc />
         public IReadOnlyDictionary<string, NpcData> Npcs => GetCacheValue(GameResourcesConstants.Npcs, ref _npcs);

--- a/src/Rhisis.Core/Resources/IGameResources.cs
+++ b/src/Rhisis.Core/Resources/IGameResources.cs
@@ -1,4 +1,5 @@
-﻿using Rhisis.Core.Structures.Game;
+﻿using Rhisis.Core.Data;
+using Rhisis.Core.Structures.Game;
 using Rhisis.Core.Structures.Game.Dialogs;
 using Rhisis.Core.Structures.Game.Quests;
 using System;
@@ -44,7 +45,7 @@ namespace Rhisis.Core.Resources
         /// <summary>
         /// Gets the jobs data.
         /// </summary>
-        IReadOnlyDictionary<int, JobData> Jobs { get; }
+        IReadOnlyDictionary<DefineJob.Job, JobData> Jobs { get; }
 
         /// <summary>
         /// Gets the npcs data.

--- a/src/Rhisis.Core/Resources/Loaders/JobLoader.cs
+++ b/src/Rhisis.Core/Resources/Loaders/JobLoader.cs
@@ -2,14 +2,10 @@
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Rhisis.Core.Data;
-using Rhisis.Core.Extensions;
-using Rhisis.Core.Resources.Include;
 using Rhisis.Core.Structures.Game;
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Rhisis.Core.Resources.Loaders
 {
@@ -51,7 +47,7 @@ namespace Rhisis.Core.Resources.Loaders
 
             string jobDefinitionFileContent = File.ReadAllText(jobsDefinitionFile);
             var jobDefinitions = JsonConvert.DeserializeObject<Dictionary<DefineJob.Job, JobDefinitionData>>(jobDefinitionFileContent);
-            var jobData = new ConcurrentDictionary<int, JobData>();
+            var jobData = new ConcurrentDictionary<DefineJob.Job, JobData>();
 
             using (var propJob = new ResourceTableFile(propJobFile, -1, new [] { '\t', ' ', '\r' }, _defines, null))
             {
@@ -67,16 +63,14 @@ namespace Rhisis.Core.Resources.Loaders
 
                 foreach (JobData job in jobData.Values)
                 {
-                    var jobId = (DefineJob.Job)job.Id;
-
-                    if (jobDefinitions.TryGetValue(jobId, out JobDefinitionData jobDefinition))
+                    if (jobDefinitions.TryGetValue(job.Id, out JobDefinitionData jobDefinition))
                     {
-                        job.Parent = jobDefinition.Parent.HasValue ? jobData[(int)jobDefinition.Parent.Value] : null;
+                        job.Parent = jobDefinition.Parent.HasValue ? jobData[jobDefinition.Parent.Value] : null;
                         job.Type = jobDefinition.Type;
                     }
                     else
                     {
-                        _logger.LogWarning($"Cannot find job '{jobId.ToString()}' definition.");
+                        _logger.LogWarning($"Cannot find job '{job.Id}' definition.");
                     }
                 }
             }

--- a/src/Rhisis.Core/Structures/Game/JobData.cs
+++ b/src/Rhisis.Core/Structures/Game/JobData.cs
@@ -9,10 +9,7 @@ namespace Rhisis.Core.Structures.Game
     public class JobData
     {
         [DataMember(Order = 0)]
-        public int Id { get; set; }
-
-        [DataMember(Order = 0)]
-        public DefineJob.Job Name { get; set; }
+        public DefineJob.Job Id { get; set; }
 
         [DataMember(Order = 1)]
         public float AttackSpeed { get; set; }

--- a/src/Rhisis.Database/Context/DatabaseContext.cs
+++ b/src/Rhisis.Database/Context/DatabaseContext.cs
@@ -58,19 +58,26 @@ namespace Rhisis.Database.Context
             : base(options)
         {
             if (string.IsNullOrEmpty(configuration.EncryptionKey))
+            {
                 return;
+            }
 
-            _encryptionProvider = new AesProvider(
-                Convert.FromBase64String(configuration.EncryptionKey), 
-                Enumerable.Repeat<byte>(0, 16).ToArray(), 
-                CipherMode.CBC, 
-                PaddingMode.Zeros);
+            if (configuration.UseEncryption)
+            {
+                _encryptionProvider = new AesProvider(
+                    Convert.FromBase64String(configuration.EncryptionKey),
+                    Enumerable.Repeat<byte>(0, 16).ToArray(),
+                    CipherMode.CBC,
+                    PaddingMode.Zeros);
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             if (_encryptionProvider != null)
+            {
                 modelBuilder.UseEncryption(_encryptionProvider);
+            }
 
             modelBuilder.Entity<DbUser>()
                 .HasIndex(c => new { c.Username, c.Email })

--- a/src/Rhisis.Database/DatabaseConfiguration.cs
+++ b/src/Rhisis.Database/DatabaseConfiguration.cs
@@ -49,6 +49,14 @@ namespace Rhisis.Database
         public string Database { get; set; }
 
         /// <summary>
+        /// Gets or sets a value that indicates if the database should use encryption or not.
+        /// </summary>
+        [DataMember(Name = "useEncryption")]
+        [DefaultValue(false)]
+        [Display(Name = "Use encryption", Order = 5)]
+        public bool UseEncryption { get; set; }
+
+        /// <summary>
         /// Gets or sets the database encryption key.
         /// </summary>
         /// <remarks>

--- a/src/Rhisis.Network/Packets/Cluster/CreatePlayerPacket.cs
+++ b/src/Rhisis.Network/Packets/Cluster/CreatePlayerPacket.cs
@@ -1,4 +1,5 @@
-﻿using Sylver.Network.Data;
+﻿using Rhisis.Core.Data;
+using Sylver.Network.Data;
 
 namespace Rhisis.Network.Packets.Cluster
 {
@@ -24,7 +25,7 @@ namespace Rhisis.Network.Packets.Cluster
 
         public byte Gender { get; private set; }
 
-        public int Job { get; private set; }
+        public DefineJob.Job Job { get; private set; }
 
         public int HeadMesh { get; private set; }
 
@@ -44,7 +45,7 @@ namespace Rhisis.Network.Packets.Cluster
             HairMeshId = packet.Read<byte>();
             HairColor = packet.Read<uint>();
             Gender = packet.Read<byte>();
-            Job = packet.Read<byte>();
+            Job = (DefineJob.Job)packet.Read<byte>();
             HeadMesh = packet.Read<byte>();
             BankPassword = packet.Read<int>();
             AuthenticationKey = packet.Read<int>();

--- a/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
+++ b/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
@@ -55,7 +55,7 @@ namespace Rhisis.World.Game.Components
         /// <summary>
         /// Gets or sets the Job Id.
         /// </summary>
-        public int JobId => JobData.Id;
+        public DefineJob.Job Job => JobData.Id;
 
         /// <summary>
         /// Gets the job's data.

--- a/src/Rhisis.World/Game/Factories/Internal/PlayerFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/PlayerFactory.cs
@@ -104,7 +104,7 @@ namespace Rhisis.World.Game.Factories.Internal
                 Gold = character.Gold,
                 Authority = (AuthorityType)character.User.Authority,
                 Experience = character.Experience,
-                JobData = _gameResources.Jobs[character.JobId]
+                JobData = _gameResources.Jobs[(DefineJob.Job)character.JobId]
             };
             player.Moves = new MovableComponent
             {
@@ -167,6 +167,7 @@ namespace Rhisis.World.Game.Factories.Internal
                 character.SkinSetId = player.VisualAppearance.SkinSetId;
                 character.Level = player.Object.Level;
 
+                character.JobId = (int)player.PlayerData.Job;
                 character.Gold = player.PlayerData.Gold;
                 character.Experience = player.PlayerData.Experience;
 

--- a/src/Rhisis.World/Packets/IPlayerPacketFactory.cs
+++ b/src/Rhisis.World/Packets/IPlayerPacketFactory.cs
@@ -46,5 +46,11 @@ namespace Rhisis.World.Packets
         /// </summary>
         /// <param name="player">Current player.</param>
         void SendPlayerRevival(IPlayerEntity player);
+
+        /// <summary>
+        /// Sends a packet that updates the player's job.
+        /// </summary>
+        /// <param name="player">Current player.</param>
+        void SendPlayerJobUpdate(IPlayerEntity player);
     }
 }

--- a/src/Rhisis.World/Packets/Internal/PlayerPacketFactory.cs
+++ b/src/Rhisis.World/Packets/Internal/PlayerPacketFactory.cs
@@ -4,6 +4,7 @@ using Rhisis.Core.DependencyInjection;
 using Rhisis.Network;
 using Rhisis.Network.Packets;
 using Rhisis.World.Game.Entities;
+using System.Linq;
 
 namespace Rhisis.World.Packets.Internal
 {
@@ -106,6 +107,19 @@ namespace Rhisis.World.Packets.Internal
             using var packet = new FFPacket();
             
             packet.StartNewMergedPacket(player.Id, SnapshotType.REVIVAL_TO_LODESTAR);
+
+            SendToVisible(packet, player, sendToPlayer: true);
+        }
+
+        /// <inheritdoc />
+        public void SendPlayerJobUpdate(IPlayerEntity player)
+        {
+            using var packet = new FFPacket();
+
+            packet.StartNewMergedPacket(player.Id, SnapshotType.SET_JOB_SKILL);
+            packet.Write((int)player.PlayerData.Job);
+            player.SkillTree.Serialize(packet);
+            packet.Write(Enumerable.Repeat((byte)0, 128).ToArray(), 0, 128);
 
             SendToVisible(packet, player, sendToPlayer: true);
         }

--- a/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
+++ b/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
@@ -59,7 +59,7 @@ namespace Rhisis.World.Packets.Internal
                 packet.Write(player.VisualAppearance.HairColor);
                 packet.Write((byte)player.VisualAppearance.FaceId);
                 packet.Write(player.PlayerData.Id);
-                packet.Write((byte)player.PlayerData.JobId); // Job
+                packet.Write((byte)player.PlayerData.Job);
 
                 packet.Write((short)player.Attributes[DefineAttributes.STR]);
                 packet.Write((short)player.Attributes[DefineAttributes.STA]);

--- a/src/Rhisis.World/Systems/Job/IJobSystem.cs
+++ b/src/Rhisis.World/Systems/Job/IJobSystem.cs
@@ -1,0 +1,18 @@
+﻿using Rhisis.Core.Data;
+using Rhisis.World.Game.Entities;
+
+namespace Rhisis.World.Systems.Job
+{
+    /// <summary>
+    /// Describes the job system.
+    /// </summary>
+    public interface IJobSystem
+    {
+        /// <summary>
+        /// Changes a player's job.
+        /// </summary>
+        /// <param name="player">Current player.</param>
+        /// <param name="newJob">New player job.</param>
+        void ChangeJob(IPlayerEntity player, DefineJob.Job newJob);
+    }
+}

--- a/src/Rhisis.World/Systems/Job/JobSystem.cs
+++ b/src/Rhisis.World/Systems/Job/JobSystem.cs
@@ -1,0 +1,63 @@
+﻿using Rhisis.Core.Data;
+using Rhisis.Core.DependencyInjection;
+using Rhisis.Core.Resources;
+using Rhisis.Core.Structures.Game;
+using Rhisis.World.Game.Entities;
+using Rhisis.World.Game.Structures;
+using Rhisis.World.Systems.Skills;
+using System.Collections.Generic;
+using System.Linq;
+using Rhisis.World.Packets;
+
+namespace Rhisis.World.Systems.Job
+{
+    [Injectable]
+    public class JobSystem : IJobSystem
+    {
+        private readonly IGameResources _gameResources;
+        private readonly ISkillSystem _skillSystem;
+        private readonly IPlayerPacketFactory _playerPacketFactory;
+        private readonly ISpecialEffectPacketFactory _specialEffectPacketFactory;
+
+        public JobSystem(IGameResources gameResources, ISkillSystem skillSystem, IPlayerPacketFactory playerPacketFactory, ISpecialEffectPacketFactory specialEffectPacketFactory)
+        {
+            _gameResources = gameResources;
+            _skillSystem = skillSystem;
+            _playerPacketFactory = playerPacketFactory;
+            _specialEffectPacketFactory = specialEffectPacketFactory;
+        }
+
+        /// <inheritdoc />
+        public void ChangeJob(IPlayerEntity player, DefineJob.Job newJob)
+        {
+            if (!_gameResources.Jobs.TryGetValue(newJob, out JobData jobData))
+            {
+                throw new KeyNotFoundException($"Cannot find job '{newJob}'.");
+            }
+
+            IEnumerable<SkillInfo> jobSkills = _skillSystem.GetSkillsByJob(newJob);
+
+            var skillTree = new List<SkillInfo>();
+
+            foreach (SkillInfo skill in jobSkills)
+            {
+                SkillInfo playerSkill = player.SkillTree.GetSkill(skill.SkillId);
+
+                if (playerSkill != null)
+                {
+                    skillTree.Add(playerSkill);
+                }
+                else
+                {
+                    skillTree.Add(new SkillInfo(skill.SkillId, player.PlayerData.Id, skill.Data));
+                }
+            }
+
+            player.PlayerData.JobData = jobData;
+            player.SkillTree.Skills = skillTree.ToList();
+
+            _playerPacketFactory.SendPlayerJobUpdate(player);
+            _specialEffectPacketFactory.SendSpecialEffect(player, DefineSpecialEffects.XI_GEN_LEVEL_UP01, false);
+        }
+    }
+}

--- a/src/Rhisis.World/Systems/Quest/QuestSystem.cs
+++ b/src/Rhisis.World/Systems/Quest/QuestSystem.cs
@@ -15,6 +15,7 @@ using Rhisis.World.Game.Structures;
 using Rhisis.World.Packets;
 using Rhisis.World.Systems.Experience;
 using Rhisis.World.Systems.Inventory;
+using Rhisis.World.Systems.Job;
 using Rhisis.World.Systems.PlayerData;
 using System;
 using System.Collections.Generic;
@@ -45,6 +46,7 @@ namespace Rhisis.World.Systems.Quest
         private readonly IPlayerDataSystem _playerDataSystem;
         private readonly IInventorySystem _inventorySystem;
         private readonly IExperienceSystem _experienceSystem;
+        private readonly IJobSystem _jobSystem;
         private readonly IQuestPacketFactory _questPacketFactory;
         private readonly INpcDialogPacketFactory _npcDialogPacketFactory;
         private readonly ITextPacketFactory _textPacketFactory;
@@ -52,7 +54,9 @@ namespace Rhisis.World.Systems.Quest
         /// <inheritdoc />
         public int Order => 3;
 
-        public QuestSystem(ILogger<QuestSystem> logger, IDatabase database, IGameResources gameResources, IPlayerDataSystem playerDataSystem, IInventorySystem inventorySystem, IExperienceSystem experienceSystem, IQuestPacketFactory questPacketFactory, INpcDialogPacketFactory npcDialogPacketFactory, ITextPacketFactory textPacketFactory)
+        public QuestSystem(ILogger<QuestSystem> logger, IDatabase database, IGameResources gameResources, 
+            IPlayerDataSystem playerDataSystem, IInventorySystem inventorySystem, IExperienceSystem experienceSystem, IJobSystem jobSystem,
+            IQuestPacketFactory questPacketFactory, INpcDialogPacketFactory npcDialogPacketFactory, ITextPacketFactory textPacketFactory)
         {
             _logger = logger;
             _database = database;
@@ -60,6 +64,7 @@ namespace Rhisis.World.Systems.Quest
             _playerDataSystem = playerDataSystem;
             _inventorySystem = inventorySystem;
             _experienceSystem = experienceSystem;
+            _jobSystem = jobSystem;
             _questPacketFactory = questPacketFactory;
             _npcDialogPacketFactory = npcDialogPacketFactory;
             _textPacketFactory = textPacketFactory;
@@ -183,7 +188,7 @@ namespace Rhisis.World.Systems.Quest
                 return false;
             }
 
-            if (quest.StartRequirements.Jobs != null && !quest.StartRequirements.Jobs.Contains((DefineJob.Job)player.PlayerData.JobId))
+            if (quest.StartRequirements.Jobs != null && !quest.StartRequirements.Jobs.Contains(player.PlayerData.Job))
             {
                 _logger.LogTrace($"Cannot start quest '{quest.Name}' (id: '{quest.Id}') for player: '{player}'. Invalid job.");
                 return false;
@@ -489,7 +494,10 @@ namespace Rhisis.World.Systems.Quest
             {
                 DefineJob.Job newJob = quest.Rewards.GetJob(player);
 
-                // TODO: give new job
+                if (newJob != DefineJob.Job.JOB_VAGRANT)
+                {
+                    _jobSystem.ChangeJob(player, newJob);
+                }
             }
 
             // TODO: restat

--- a/src/Rhisis.World/Systems/Skills/ISkillSystem.cs
+++ b/src/Rhisis.World/Systems/Skills/ISkillSystem.cs
@@ -9,6 +9,13 @@ namespace Rhisis.World.Systems.Skills
     public interface ISkillSystem : IGameSystemLifeCycle
     {
         /// <summary>
+        /// Gets the skills for a given job.
+        /// </summary>
+        /// <param name="job">Job.</param>
+        /// <returns>Collection of <see cref="SkillInfo"/> for the given job.</returns>
+        IEnumerable<SkillInfo> GetSkillsByJob(DefineJob.Job job);
+
+        /// <summary>
         /// Updates the player skill tree.
         /// </summary>
         /// <param name="player">Current player.</param>

--- a/src/Rhisis.World/Systems/Skills/SkillSystem.cs
+++ b/src/Rhisis.World/Systems/Skills/SkillSystem.cs
@@ -65,7 +65,7 @@ namespace Rhisis.World.Systems.Skills
         /// <inheritdoc />
         public void Initialize(IPlayerEntity player)
         {
-            IEnumerable<SkillInfo> jobSkills = GetSkillsByJob(player, player.PlayerData.JobId);
+            IEnumerable<SkillInfo> jobSkills = GetSkillsByJob(player.PlayerData.Job);
             IEnumerable<DbSkill> playerSkills = _database.Skills.GetCharacterSkills(player.PlayerData.Id).AsQueryable().AsNoTracking().AsEnumerable();
 
             player.SkillTree.Skills = (from x in jobSkills
@@ -109,20 +109,20 @@ namespace Rhisis.World.Systems.Skills
             _database.Complete();
         }
 
-        private IEnumerable<SkillInfo> GetSkillsByJob(IPlayerEntity player, int jobId)
+        public IEnumerable<SkillInfo> GetSkillsByJob(DefineJob.Job job)
         {
             var skillsList = new List<SkillInfo>();
 
-            if (_gameResources.Jobs.TryGetValue(jobId, out JobData job) && job.Parent != null)
+            if (_gameResources.Jobs.TryGetValue(job, out JobData jobData) && jobData.Parent != null)
             {
-                skillsList.AddRange(GetSkillsByJob(player, job.Parent.Id));
+                skillsList.AddRange(GetSkillsByJob(jobData.Parent.Id));
             }
 
             IEnumerable<SkillInfo> jobSkills = from x in _gameResources.Skills.Values
-                                               where x.Job == job.Name &&
+                                               where x.Job == jobData.Id &&
                                                      x.JobType != DefineJob.JobType.JTYPE_COMMON &&
                                                      x.JobType != DefineJob.JobType.JTYPE_TROUPE
-                                               select new SkillInfo(x.Id, player.PlayerData.Id, x);
+                                               select new SkillInfo(x.Id, -1, x);
 
             skillsList.AddRange(jobSkills);
 


### PR DESCRIPTION
This PR adds the support for changing its job when a quest ends.
It also introduces a new option for the database configuration: the boolean `UseEncryption`. If it sets to true, it will use the `EncryptionKey` of the `database.json` file; otherwise, the data will be stored in clear in the database.