### PR TITLE
Remove blinkwing items from magic NPC shops

### DIFF
--- a/bin/data/shops/MaDa_Haven.json
+++ b/bin/data/shops/MaDa_Haven.json
@@ -133,30 +133,6 @@
         "elementRefine": 0
       },
       {
-        "itemId": 4807,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4808,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4809,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4810,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
         "itemId": 4811,
         "refine": 0,
         "element": 0,

--- a/bin/data/shops/MaFl_Marche.json
+++ b/bin/data/shops/MaFl_Marche.json
@@ -73,30 +73,6 @@
         "elementRefine": 0
       },
       {
-        "itemId": 4807,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4808,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4809,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4810,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
         "itemId": 4811,
         "refine": 0,
         "element": 0,

--- a/bin/data/shops/MaSa_Martin.json
+++ b/bin/data/shops/MaSa_Martin.json
@@ -133,30 +133,6 @@
         "elementRefine": 0
       },
       {
-        "itemId": 4807,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4808,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4809,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
-        "itemId": 4810,
-        "refine": 0,
-        "element": 0,
-        "elementRefine": 0
-      },
-      {
         "itemId": 4811,
         "refine": 0,
         "element": 0,

--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>

--- a/src/Rhisis.World/Rhisis.World.csproj
+++ b/src/Rhisis.World/Rhisis.World.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>

--- a/src/Rhisis.World/Systems/Dialog/DialogSystem.cs
+++ b/src/Rhisis.World/Systems/Dialog/DialogSystem.cs
@@ -107,6 +107,12 @@ namespace Rhisis.World.Systems.Dialog
                     if (!npc.NpcData.HasDialog)
                     {
                         _logger.LogError($"NPC '{npc.Object.Name}' doesn't have a dialog.");
+
+                        if (dialogKey == DialogConstants.Bye)
+                        {
+                            _npcDialogPacketFactory.SendCloseDialog(player);
+                        }
+
                         return;
                     }
 


### PR DESCRIPTION
This PR fixes issue #367 and removes blinkwing items from all magic NPC shops.