### PR TITLE
Fix consumable items

### DIFF
--- a/src/Rhisis.World/Game/Components/InventoryContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/InventoryContainerComponent.cs
@@ -54,7 +54,7 @@ namespace Rhisis.World.Game.Components
                 return null;
             }
 
-            return _items[_itemsMask[equipedItemSlot]];
+            return GetItemAtSlot(equipedItemSlot);
         }
 
         /// <summary>
@@ -72,7 +72,9 @@ namespace Rhisis.World.Game.Components
         public int? GetItemCoolTimeGroup(Item item)
         {
             if (item.Data.CoolTime <= 0)
+            {
                 return null;
+            }
 
             return item.Data.ItemKind2 switch
             {

--- a/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
@@ -44,8 +44,17 @@ namespace Rhisis.World.Game.Components
             MaxCapacity = maxCapacity;
             MaxStorageCapacity = maxStorageCapacity;
             ExtraCapacity = MaxCapacity - MaxStorageCapacity;
-            _items = new List<Item>(Enumerable.Repeat((Item)null, MaxCapacity));
             _itemsMask = Enumerable.Range(0, MaxCapacity).ToArray();
+            _items = new List<Item>(MaxCapacity);
+
+            for (int i = 0; i < MaxCapacity; i++)
+            {
+                _items.Add(new Item
+                {
+                    Slot = i,
+                    UniqueId = i
+                });
+            }
         }
 
         /// <summary>
@@ -53,7 +62,17 @@ namespace Rhisis.World.Game.Components
         /// </summary>
         /// <param name="predicate">Match predicate.</param>
         /// <returns>Item matching the predicate function; null otherwise.</returns>
-        public Item GetItem(Func<Item, bool> predicate) => _items.FirstOrDefault(predicate);
+        public Item GetItem(Func<Item, bool> predicate)
+        {
+            Item item = _items.FirstOrDefault(predicate);
+
+            if (item == null)
+            {
+                return null;
+            }
+
+            return item.Id != -1 ? item : null;
+        }
 
         /// <summary>
         /// Gets an item by its id.
@@ -74,7 +93,9 @@ namespace Rhisis.World.Game.Components
                 throw new IndexOutOfRangeException();
             }
 
-            return _items[_itemsMask[slot]];
+            Item item = _items[_itemsMask[slot]];
+
+            return item.Id != -1 ? item : null;
         }
 
         /// <summary>
@@ -89,14 +110,16 @@ namespace Rhisis.World.Game.Components
                 throw new IndexOutOfRangeException();
             }
 
-            return _items[index];
+            Item item = _items[index];
+
+            return item.Id != -1 ? item : null;
         }
 
         /// <summary>
         /// Gets the number of items of the inventory.
         /// </summary>
         /// <returns></returns>
-        public int GetItemCount() => _items.Count(x => x != null);
+        public int GetItemCount() => _items.Count(x => x.Id != -1);
 
         /// <summary>
         /// Check if there is available slots in the container.
@@ -112,7 +135,7 @@ namespace Rhisis.World.Game.Components
         {
             for (int i = 0; i < MaxStorageCapacity; i++)
             {
-                if (_items[_itemsMask[i]] == null)
+                if (_items[_itemsMask[i]].Id == -1)
                 {
                     return i;
                 }
@@ -171,13 +194,13 @@ namespace Rhisis.World.Game.Components
                 packet.Write(itemIndex);
             }
 
-            packet.Write((byte)_items.Count(x => x != null));
+            packet.Write((byte)GetItemCount());
 
             for (int i = 0; i < MaxCapacity; i++)
             {
                 Item item = _items.ElementAt(i);
 
-                if (item != null)
+                if (item.Id != -1)
                 {
                     packet.Write((byte)i);
                     item.Serialize(packet);
@@ -186,7 +209,7 @@ namespace Rhisis.World.Game.Components
 
             for (int i = 0; i < MaxCapacity; i++)
             {
-                packet.Write(_items[i]?.Slot ?? -1);
+                packet.Write(_items[i].Slot);
             }
         }
 

--- a/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/ItemContainerComponent.cs
@@ -95,6 +95,11 @@ namespace Rhisis.World.Game.Components
 
             Item item = _items[_itemsMask[slot]];
 
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item), $"No item found at slot {slot}.");
+            }
+
             return item.Id != -1 ? item : null;
         }
 
@@ -111,6 +116,11 @@ namespace Rhisis.World.Game.Components
             }
 
             Item item = _items[index];
+
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item), $"No item found at index {index}.");
+            }
 
             return item.Id != -1 ? item : null;
         }

--- a/src/Rhisis.World/Game/Structures/Item.cs
+++ b/src/Rhisis.World/Game/Structures/Item.cs
@@ -13,7 +13,7 @@ namespace Rhisis.World.Game.Structures
     /// <summary>
     /// FlyFF item structure.
     /// </summary>
-    [DebuggerDisplay("({Quantity}) {Data.Name} +{Refine} ({Element}+{ElementRefine})")]
+    [DebuggerDisplay("({Quantity}) {Data?.Name ?? \"Empty\"} +{Refine} ({Element}+{ElementRefine})")]
     public class Item : ItemDescriptor
     {
         public const int RefineMax = 10;
@@ -242,9 +242,6 @@ namespace Rhisis.World.Game.Structures
                 Quantity = Quantity
             };
         }
-
-        [Obsolete("This should not be used anymore")]
-        public bool IsEquipped() => Slot > InventorySystem.EquipOffset;
 
         /// <summary>
         /// Reset the item.

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -280,7 +280,8 @@ namespace Rhisis.World.Systems.Inventory
 
             if (itemToDelete.Quantity <= 0)
             {
-                player.Inventory.SetItemAtSlot(null, itemToDelete.Slot);
+                itemToDelete.Reset();
+                //player.Inventory.SetItemAtSlot(null, itemToDelete.Slot);
             }
 
             return quantityToDelete;

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -78,7 +78,10 @@ namespace Rhisis.World.Systems.Inventory
                 {
                     Item item = _itemFactory.CreateItem(databaseItem);
 
-                    player.Inventory.SetItemAtIndex(item, item.Slot);
+                    if (item != null)
+                    {
+                        player.Inventory.SetItemAtIndex(item, item.Slot);
+                    }
                 }
             }
         }
@@ -88,7 +91,7 @@ namespace Rhisis.World.Systems.Inventory
         {
             DbCharacter character = _database.Characters.Include(x => x.Items).FirstOrDefault(x => x.Id == player.PlayerData.Id);
             IEnumerable<DbItem> itemsToDelete = (from dbItem in character.Items
-                                                 let inventoryItem = player.Inventory.GetItem(x => x != null && x.DbId == dbItem.Id)
+                                                 let inventoryItem = player.Inventory.GetItem(x => x.DbId == dbItem.Id)
                                                  where !dbItem.IsDeleted && inventoryItem == null
                                                  select dbItem).ToList();
 
@@ -102,7 +105,7 @@ namespace Rhisis.World.Systems.Inventory
             // Add or update items
             foreach (Item item in player.Inventory)
             {
-                if (item == null)
+                if (item == null || item.Id == -1)
                 {
                     continue;
                 }
@@ -416,7 +419,7 @@ namespace Rhisis.World.Systems.Inventory
                 throw new ArgumentNullException(nameof(itemToUse), $"Cannot find item with unique id: '{itemUniqueId}' in {player.Object.Name} inventory.");
             }
 
-            if (part != -1)
+            if (part >= 0)
             {
                 if (part >= MaxHumanParts)
                 {

--- a/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
+++ b/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
@@ -199,6 +199,7 @@ namespace Rhisis.World.Tests.Systems
             int deleteQuantity = itemToDelete.Quantity;
 
             int deletedAmount = Service.DeleteItem(_player, itemUniqueId, deleteQuantity);
+            Item deletedItem = _player.Inventory.GetItemAtSlot(itemToDeleteSlot);
 
             Assert.Equal(deleteQuantity, deletedAmount);
             Assert.Null(_player.Inventory.GetItemAtSlot(itemToDeleteSlot));


### PR DESCRIPTION
This PR fixes issue #368 about the broken consumable items.
The item container logic has been changed to create "empty" items for each slots. An item is considered as "empty" when its ID is equal to -1. 