### PR TITLE
Fix item drop from player inventory

### DIFF
--- a/src/Rhisis.World/Systems/Drop/DropSystem.cs
+++ b/src/Rhisis.World/Systems/Drop/DropSystem.cs
@@ -49,7 +49,7 @@ namespace Rhisis.World.Systems.Drop
                 newItem.Drop.DespawnTime = Time.TimeInSeconds() + _worldServerConfiguration.Drops.DespawnTime;
             }
 
-            owner.Object.CurrentLayer.AddEntity(newItem);
+            entity.Object.CurrentLayer.AddEntity(newItem);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR fixes issue #387 where the dropped item was still in the inventory and not dropped on the floor. This was due to a `NullReferenceException` on the `DropSystem` when dropping the item on the current map layer.