### PR TITLE
Fix monster gold drop

### DIFF
--- a/src/Rhisis.World/Game/Structures/Item.cs
+++ b/src/Rhisis.World/Game/Structures/Item.cs
@@ -60,12 +60,11 @@ namespace Rhisis.World.Game.Structures
         }
 
         /// <summary>
-        /// Create an <see cref="Item"/> with an id and a quantity.
+        /// Creates a <see cref="Item"/> instance with an id.
         /// </summary>
-        /// <param name="id">Item id</param>
-        /// <param name="quantity">Item quantity</param>
-        public Item(int id, int quantity)
-            : this(id, quantity, -1, -1, -1)
+        /// <param name="id">Item Id.</param>
+        public Item(int id)
+            : this(id, -1, -1, -1, -1)
         {
         }
 

--- a/src/Rhisis.World/Systems/Drop/DropSystem.cs
+++ b/src/Rhisis.World/Systems/Drop/DropSystem.cs
@@ -68,7 +68,7 @@ namespace Rhisis.World.Systems.Drop
             else if (gold > (DropGoldLimit3 * _worldServerConfiguration.Rates.Gold))
                 goldItemId = DefineItem.II_GOLD_SEED4;
 
-            DropItem(entity, new Item(goldItemId, gold), owner);
+            DropItem(entity, new Item(goldItemId), owner, gold);
         }
     }
 }


### PR DESCRIPTION
This PR fixes issue #391. Now monsters drop more than 1 penya when they die.