### PR TITLE
Fix duplicate character weapons on character selection

### DIFF
--- a/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
+++ b/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
@@ -279,20 +279,9 @@ namespace Rhisis.Cluster.Handlers
         /// <returns>Collection of <see cref="DbCharacter"/>.</returns>
         private IEnumerable<DbCharacter> GetCharacters(int userId)
         {
-            const int EquipOffset = 42;
-            IEnumerable<DbCharacter> dbCharacters = _database.Characters.AsNoTracking().Include(x => x.Items).Where(x => x.UserId == userId && !x.IsDeleted);
-
-            for (int i = 0; i < dbCharacters.Count(); i++)
-            {
-                DbCharacter character = dbCharacters.ElementAt(i);
-
-                if (character == null)
-                    continue;
-
-                character.Items = character.Items.Where(x => x.ItemSlot > EquipOffset).ToList();
-            }
-
-            return dbCharacters;
+            return _database.Characters.AsNoTracking()
+                .Include(x => x.Items)
+                .Where(x => x.UserId == userId && !x.IsDeleted);
         }
     }
 }

--- a/src/Rhisis.Cluster/Packets/ClusterPacketFactory.cs
+++ b/src/Rhisis.Cluster/Packets/ClusterPacketFactory.cs
@@ -137,12 +137,15 @@ namespace Rhisis.Cluster.Packets
                     packet.Write(character.Intelligence);
                     packet.Write(0); // Mode ??
 
-                    IEnumerable<DbItem> equipedItems = character.Items.Where(x => x.ItemSlot > 42);
+                    const int EquipOffset = 42;
+                    IEnumerable<DbItem> equipedItems = character.Items.Where(x => x.ItemSlot > EquipOffset && !x.IsDeleted);
 
                     packet.Write(equipedItems.Count());
 
                     foreach (DbItem item in equipedItems)
+                    {
                         packet.Write(item.ItemId);
+                    }
                 }
 
                 packet.Write(0); // Messenger?


### PR DESCRIPTION
This PR fixes issue #373 where the player had 2 swords. This was due to a bad LINQ during player serialization. All items that had a slot grather than the inventory equip offset (42) were serialized. Even items marked as deleted.