### PR TITLE
Fix inventory issues related to slots and masks

### DIFF
--- a/Rhisis.sln
+++ b/Rhisis.sln
@@ -46,7 +46,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhisis.World.Tests", "test\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhisis.Scripting", "src\Rhisis.Scripting\Rhisis.Scripting.csproj", "{28B8CF39-9385-4794-9614-9762A02ED66D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rhisis.Testing", "test\Rhisis.Testing\Rhisis.Testing.csproj", "{D76C60D9-9859-4B92-8574-074B1EEE7FEA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rhisis.Testing", "test\Rhisis.Testing\Rhisis.Testing.csproj", "{D76C60D9-9859-4B92-8574-074B1EEE7FEA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
+++ b/src/Rhisis.Cluster/Handlers/CharacterHandler.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Rhisis.Cluster.Client;
 using Rhisis.Cluster.Packets;
+using Rhisis.Cluster.Structures;
 using Rhisis.Core.Common.Formulas;
 using Rhisis.Core.Resources;
 using Rhisis.Core.Structures;
@@ -72,13 +73,15 @@ namespace Rhisis.Cluster.Handlers
                 return;
             }
 
-            IEnumerable<DbCharacter> userCharacters = GetCharacters(dbUser.Id);
+            IEnumerable<ClusterCharacter> characters = GetCharacters(dbUser.Id);
 
-            _clusterPacketFactory.SendPlayerList(client, packet.AuthenticationKey, userCharacters);
+            _clusterPacketFactory.SendPlayerList(client, packet.AuthenticationKey, characters);
             _clusterPacketFactory.SendWorldAddress(client, selectedWorldServer.Host);
 
             if (_clusterServer.ClusterConfiguration.EnableLoginProtect)
+            {
                 _clusterPacketFactory.SendLoginNumPad(client, client.LoginProtectValue);
+            }
         }
 
         /// <summary>
@@ -163,9 +166,9 @@ namespace Rhisis.Cluster.Handlers
 
             _logger.LogInformation($"Character '{newCharacter.Name}' has been created successfully for user '{dbUser.Username}' from {client.Socket.RemoteEndPoint}.");
 
-            IEnumerable<DbCharacter> dbCharacters = GetCharacters(dbUser.Id);
+            IEnumerable<ClusterCharacter> characters = GetCharacters(dbUser.Id);
 
-            _clusterPacketFactory.SendPlayerList(client, packet.AuthenticationKey, dbCharacters);
+            _clusterPacketFactory.SendPlayerList(client, packet.AuthenticationKey, characters);
         }
 
         /// <summary>
@@ -219,7 +222,7 @@ namespace Rhisis.Cluster.Handlers
 
             _logger.LogInformation($"Character '{characterToDelete.Name}' has been deleted successfully for user '{packet.Username}' from {client.Socket.RemoteEndPoint}.");
 
-            IEnumerable<DbCharacter> dbCharacters = GetCharacters(dbUser.Id);
+            IEnumerable<ClusterCharacter> dbCharacters = GetCharacters(dbUser.Id);
 
             _clusterPacketFactory.SendPlayerList(client, packet.AuthenticationKey, dbCharacters);
         }
@@ -277,11 +280,12 @@ namespace Rhisis.Cluster.Handlers
         /// </summary>
         /// <param name="userId">User id.</param>
         /// <returns>Collection of <see cref="DbCharacter"/>.</returns>
-        private IEnumerable<DbCharacter> GetCharacters(int userId)
+        private IEnumerable<ClusterCharacter> GetCharacters(int userId)
         {
             return _database.Characters.AsNoTracking()
                 .Include(x => x.Items)
-                .Where(x => x.UserId == userId && !x.IsDeleted);
+                .Where(x => x.UserId == userId && !x.IsDeleted)
+                .Select(x => new ClusterCharacter(x));
         }
     }
 }

--- a/src/Rhisis.Cluster/Packets/ClusterPacketFactory.cs
+++ b/src/Rhisis.Cluster/Packets/ClusterPacketFactory.cs
@@ -1,10 +1,10 @@
 ﻿using Rhisis.Network.Packets;
-using Rhisis.Database.Entities;
 using System.Collections.Generic;
 using Rhisis.Network;
 using Rhisis.Core.IO;
 using System.Linq;
 using Rhisis.Cluster.Client;
+using Rhisis.Cluster.Structures;
 
 namespace Rhisis.Cluster.Packets
 {
@@ -100,7 +100,7 @@ namespace Rhisis.Cluster.Packets
         }
 
         /// <inheritdoc />
-        public void SendPlayerList(IClusterClient client, int authenticationKey, IEnumerable<DbCharacter> characters)
+        public void SendPlayerList(IClusterClient client, int authenticationKey, IEnumerable<ClusterCharacter> characters)
         {
             using (var packet = new FFPacket())
             {
@@ -111,23 +111,23 @@ namespace Rhisis.Cluster.Packets
 
                 foreach (var character in characters)
                 {
-                    packet.Write((int)character.Slot);
+                    packet.Write(character.Slot);
                     packet.Write(1); // this number represents the selected character in the window
                     packet.Write(character.MapId);
-                    packet.Write(0x0B + character.Gender); // Model id
+                    packet.Write(0x0B + (byte)character.Gender); // Model id
                     packet.Write(character.Name);
-                    packet.Write(character.PosX);
-                    packet.Write(character.PosY);
-                    packet.Write(character.PosZ);
+                    packet.Write(character.PositionX);
+                    packet.Write(character.PositionY);
+                    packet.Write(character.PositionZ);
                     packet.Write(character.Id);
                     packet.Write(0); // Party id
                     packet.Write(0); // Guild id
                     packet.Write(0); // War Id
                     packet.Write(character.SkinSetId);
                     packet.Write(character.HairId);
-                    packet.Write((uint)character.HairColor);
+                    packet.Write(character.HairColor);
                     packet.Write(character.FaceId);
-                    packet.Write(character.Gender);
+                    packet.Write((byte)character.Gender);
                     packet.Write(character.JobId);
                     packet.Write(character.Level);
                     packet.Write(0); // Job Level (Maybe master or hero ?)
@@ -137,14 +137,11 @@ namespace Rhisis.Cluster.Packets
                     packet.Write(character.Intelligence);
                     packet.Write(0); // Mode ??
 
-                    const int EquipOffset = 42;
-                    IEnumerable<DbItem> equipedItems = character.Items.Where(x => x.ItemSlot > EquipOffset && !x.IsDeleted);
+                    packet.Write(character.EquipedItems.Count());
 
-                    packet.Write(equipedItems.Count());
-
-                    foreach (DbItem item in equipedItems)
+                    foreach (int equipedItemId in character.EquipedItems)
                     {
-                        packet.Write(item.ItemId);
+                        packet.Write(equipedItemId);
                     }
                 }
 

--- a/src/Rhisis.Cluster/Packets/IClusterPacketFactory.cs
+++ b/src/Rhisis.Cluster/Packets/IClusterPacketFactory.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Cluster.Client;
+using Rhisis.Cluster.Structures;
 using Rhisis.Database.Entities;
 using Rhisis.Network.Packets;
 using System.Collections.Generic;
@@ -36,7 +37,7 @@ namespace Rhisis.Cluster.Packets
         /// <param name="client">Client.</param>
         /// <param name="authenticationKey">Client authentication key.</param>
         /// <param name="characters">A list of the client's available characters.</param>
-        void SendPlayerList(IClusterClient client, int authenticationKey, IEnumerable<DbCharacter> characters);
+        void SendPlayerList(IClusterClient client, int authenticationKey, IEnumerable<ClusterCharacter> characters);
 
         /// <summary>
         /// Sends the selected world server host address.

--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
-    <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>
 

--- a/src/Rhisis.Cluster/Structures/ClusterCharacter.cs
+++ b/src/Rhisis.Cluster/Structures/ClusterCharacter.cs
@@ -1,0 +1,79 @@
+﻿using Rhisis.Core.Common;
+using Rhisis.Database.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rhisis.Cluster.Structures
+{
+    public class ClusterCharacter
+    {
+        public int Id { get; }
+
+        public string Name { get; }
+
+        public GenderType Gender { get; }
+
+        public int Level { get; }
+
+        public int Slot { get; }
+
+        public int MapId { get; }
+
+        public float PositionX { get; }
+
+        public float PositionY { get; }
+
+        public float PositionZ { get; }
+
+        public int SkinSetId { get; }
+
+        public int HairId { get; }
+
+        public uint HairColor { get; }
+
+        public int FaceId { get; }
+
+        public int JobId { get; }
+
+        public int Strength { get; }
+
+        public int Stamina { get; }
+
+        public int Intelligence { get; }
+
+        public int Dexterity { get; }
+
+        /// <summary>
+        /// Gets the character equiped items ids.
+        /// </summary>
+        public IEnumerable<int> EquipedItems { get; }
+
+        public ClusterCharacter(DbCharacter dbCharacter)
+        {
+            Id = dbCharacter.Id;
+            Name = dbCharacter.Name;
+            Gender = (GenderType)dbCharacter.Gender;
+            Level = dbCharacter.Level;
+            Slot = dbCharacter.Slot;
+            MapId = dbCharacter.MapId;
+            PositionX = dbCharacter.PosX;
+            PositionY = dbCharacter.PosY;
+            PositionZ = dbCharacter.PosZ;
+            SkinSetId = dbCharacter.SkinSetId;
+            HairId = dbCharacter.HairId;
+            HairColor = (uint)dbCharacter.HairColor;
+            FaceId = dbCharacter.FaceId;
+            JobId = dbCharacter.JobId;
+            Strength = dbCharacter.Strength;
+            Stamina = dbCharacter.Stamina;
+            Intelligence = dbCharacter.Intelligence;
+            Dexterity = dbCharacter.Dexterity;
+            EquipedItems = dbCharacter.Items.AsQueryable()
+                .Where(x => x.ItemSlot > 42 && !x.IsDeleted)
+                .OrderBy(x => x.ItemSlot)
+                .Select(x => x.ItemId);
+        }
+    }
+}

--- a/src/Rhisis.Core/Structures/Game/ItemData.cs
+++ b/src/Rhisis.Core/Structures/Game/ItemData.cs
@@ -33,6 +33,9 @@ namespace Rhisis.Core.Structures.Game
         [DataMember(Name = "dwItemKind3")]
         public ItemKind3 ItemKind3 { get; set; }
 
+        [DataMember(Name = "dwItemJob")]
+        public DefineJob.Job ItemJob { get; set; }
+
         [DataMember(Name = "dwItemSex")]
         [DefaultValue(int.MaxValue)]
         public int ItemSex { get; set; }

--- a/src/Rhisis.Core/Structures/Game/JobData.cs
+++ b/src/Rhisis.Core/Structures/Game/JobData.cs
@@ -67,5 +67,28 @@ namespace Rhisis.Core.Structures.Game
 
         [IgnoreDataMember]
         public JobData Parent { get; set; }
+
+        /// <summary>
+        /// Checks if the given job is anterior to the player's job.
+        /// </summary>
+        /// <param name="player">Current player.</param>
+        /// <param name="job">Job.</param>
+        /// <returns>True if the given job is anterior to the player's job; false otherwise.</returns>
+        public bool IsAnteriorJob(DefineJob.Job job)
+        {
+            JobData jobData = this;
+
+            while (jobData != null)
+            {
+                if (jobData.Id == job)
+                {
+                    return true;
+                }
+
+                jobData = jobData.Parent;
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
-    <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>
 

--- a/src/Rhisis.Network/Packets/World/DoUseItemPacket.cs
+++ b/src/Rhisis.Network/Packets/World/DoUseItemPacket.cs
@@ -30,7 +30,11 @@ namespace Rhisis.Network.Packets.World
             UniqueItemId = (packet.Read<int>() >> 16) & 0xFFFF;
             ObjectId = packet.Read<int>();
             Part = packet.Read<int>();
-            FlightSpeed = packet.Read<float>();
+
+            if (!packet.IsEndOfStream)
+            {
+                FlightSpeed = packet.Read<float>();
+            }
         }
     }
 }

--- a/src/Rhisis.World/Game/Chat/Commands/CreateItemCommand.cs
+++ b/src/Rhisis.World/Game/Chat/Commands/CreateItemCommand.cs
@@ -45,11 +45,6 @@ namespace Rhisis.World.Game.Chat
                 throw new ArgumentException($"Create item command must have at least one parameter.", nameof(parameters));
             }
 
-            if (!player.Inventory.HasAvailableSlots())
-            {
-                _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
-                return;
-            }
             int quantity = parameters.Length >= 2 ? Convert.ToInt32(parameters[1]) : 1;
             byte refine = parameters.Length >= 3 ? Convert.ToByte(parameters[2]) : (byte)0;
             ElementType element = parameters.Length >= 4 ? (ElementType)Enum.Parse(typeof(ElementType), parameters[3].ToString(), true) : default;
@@ -66,8 +61,16 @@ namespace Rhisis.World.Game.Chat
                 itemToCreate = _itemFactory.CreateItem(itemId, refine, element, elementRefine, player.PlayerData.Id);
             }
 
-            if(itemToCreate != null)
+            if (!player.Inventory.CanStoreItem(itemToCreate))
+            {
+                _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
+                return;
+            }
+
+            if (itemToCreate != null)
+            {
                 _inventorySystem.CreateItem(player, itemToCreate, quantity, player.PlayerData.Id);
+            }
         }
     }
 }

--- a/src/Rhisis.World/Game/Components/InventoryContainerComponent.cs
+++ b/src/Rhisis.World/Game/Components/InventoryContainerComponent.cs
@@ -58,6 +58,53 @@ namespace Rhisis.World.Game.Components
         }
 
         /// <summary>
+        /// Equips an item to the given destination part.
+        /// </summary>
+        /// <param name="itemToEquip">Item to equip.</param>
+        /// <param name="destinationPart">Destination part.</param>
+        /// <returns>True if the item has been equiped; false otherwise.</returns>
+        public bool Equip(Item itemToEquip, ItemPartType destinationPart)
+        {
+            int sourceSlot = itemToEquip.Slot;
+            int destinationSlot = MaxStorageCapacity + (int)destinationPart;
+
+            if (itemToEquip.Slot == destinationSlot || itemToEquip.Slot >= MaxCapacity || destinationSlot >= MaxCapacity)
+            {
+                return false;
+            }
+
+            Swap(sourceSlot, destinationSlot);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unequip an item.
+        /// </summary>
+        /// <param name="itemToUnequip">Item to unequip.</param>
+        /// <returns>True if the item has been unequiped; false otherwise.</returns>
+        public bool Unequip(Item itemToUnequip)
+        {
+            int slot = itemToUnequip.Slot;
+
+            if (slot >= MaxCapacity)
+            {
+                return false;
+            }
+
+            int availableSlot = GetAvailableSlot();
+
+            if (availableSlot != Empty)
+            {
+                Swap(slot, availableSlot);
+                
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Checks if the given item is equiped.
         /// </summary>
         /// <param name="item">Item to check.</param>

--- a/src/Rhisis.World/Game/Factories/Internal/NpcFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/NpcFactory.cs
@@ -13,6 +13,8 @@ using Rhisis.World.Game.Entities.Internal;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Game.Structures;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Rhisis.World.Game.Factories.Internal
@@ -76,23 +78,25 @@ namespace Rhisis.World.Game.Factories.Internal
 
             if (npc.NpcData != null && npc.NpcData.HasShop)
             {
+                const int NpcShopItemsPerTab = 100;
                 ShopData npcShopData = npc.NpcData.Shop;
                 npc.Shop = new ItemContainerComponent[npcShopData.Items.Length];
 
                 for (var i = 0; i < npcShopData.Items.Length; i++)
                 {
-                    npc.Shop[i] = new ItemContainerComponent(100);
+                    npc.Shop[i] = new ItemContainerComponent(NpcShopItemsPerTab);
 
-                    for (var j = 0; j < npcShopData.Items[i].Count && j < npc.Shop[i].MaxCapacity; j++)
+                    IEnumerable<Item> shopTabItems = npcShopData.Items[i].Select((item, index) =>
                     {
-                        ItemDescriptor item = npcShopData.Items[i][j];
                         Item shopItem = _itemFactory.CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine);
 
-                        shopItem.Slot = j;
+                        shopItem.Slot = index;
                         shopItem.Quantity = shopItem.Data.PackMax;
 
-                        npc.Shop[i].SetItemAtIndex(shopItem, j);
-                    }
+                        return shopItem;
+                    });
+
+                    npc.Shop[i].Initialize(shopTabItems.Take(NpcShopItemsPerTab));
                 }
             }
 

--- a/src/Rhisis.World/Game/Structures/Item.cs
+++ b/src/Rhisis.World/Game/Structures/Item.cs
@@ -2,9 +2,7 @@
 using Rhisis.Core.Extensions;
 using Rhisis.Core.Structures.Game;
 using Rhisis.Database.Entities;
-using Rhisis.World.Systems.Inventory;
 using Sylver.Network.Data;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -16,17 +14,18 @@ namespace Rhisis.World.Game.Structures
     [DebuggerDisplay("({Quantity}) {Data?.Name ?? \"Empty\"} +{Refine} ({Element}+{ElementRefine})")]
     public class Item : ItemDescriptor
     {
+        public const int Empty = -1;
         public const int RefineMax = 10;
 
         /// <summary>
         /// Flyff item refine table.
         /// </summary>
-        public static readonly IReadOnlyCollection<int> RefineTable = new[] {0, 2, 4, 6, 8, 10, 13, 16, 19, 21, 24};
+        public static readonly IReadOnlyCollection<int> RefineTable = new[] { 0, 2, 4, 6, 8, 10, 13, 16, 19, 21, 24 };
 
         /// <summary>
         /// Gets the item unique Id.
         /// </summary>
-        public int UniqueId { get; set; }
+        public int Index { get; set; }
 
         /// <summary>
         /// Gets the creator id of the item.
@@ -52,10 +51,10 @@ namespace Rhisis.World.Game.Structures
         /// Creates an empty <see cref="Item"/>.
         /// </summary>
         /// <remarks>
-        /// All values set to -1.
+        /// All values set to <see cref="Empty"/>.
         /// </remarks>
         public Item()
-            : this(-1, -1, -1, -1, -1)
+            : this(Empty, Empty, Empty, Empty, Empty)
         {
         }
 
@@ -64,7 +63,7 @@ namespace Rhisis.World.Game.Structures
         /// </summary>
         /// <param name="id">Item Id.</param>
         public Item(int id)
-            : this(id, -1, -1, -1, -1)
+            : this(id, Empty, Empty, Empty, Empty)
         {
         }
 
@@ -76,7 +75,7 @@ namespace Rhisis.World.Game.Structures
         /// <param name="creatorId">Id of the character that created the object (for GM)</param>
         /// <param name="slot">Item slot</param>
         public Item(int id, int quantity, int creatorId, int slot)
-            : this(id, quantity, creatorId, slot, -1)
+            : this(id, quantity, creatorId, slot, Empty)
         {
         }
 
@@ -92,7 +91,7 @@ namespace Rhisis.World.Game.Structures
             : this(id, quantity, creatorId, slot, uniqueId, 0)
         {
         }
-        
+
         /// <summary>
         /// Create an <see cref="Item"/> with an id, quantity, creator id, destination slot and refine.
         /// </summary>
@@ -157,7 +156,7 @@ namespace Rhisis.World.Game.Structures
             Quantity = quantity;
             CreatorId = creatorId;
             Slot = slot;
-            UniqueId = uniqueId;
+            Index = uniqueId;
             Refine = refine;
             Element = element;
             ElementRefine = elementRefine;
@@ -201,18 +200,18 @@ namespace Rhisis.World.Game.Structures
         /// Serialize the item into the packet.
         /// </summary>
         /// <param name="packet"></param>
-        public void Serialize(INetPacketStream packet)
+        public void Serialize(INetPacketStream packet, int itemIndex)
         {
-            packet.Write(UniqueId);
+            packet.Write(itemIndex);
             packet.Write(Id);
             packet.Write(0); // Serial number
             packet.Write(Data?.Name.TakeCharacters(31) ?? "[undefined]");
-            packet.Write((short) Quantity);
+            packet.Write((short)Quantity);
             packet.Write<byte>(0); // Repair number
             packet.Write(0); // Hp
             packet.Write(0); // Repair
             packet.Write<byte>(0); // flag ?
-            packet.Write((int) Refine);
+            packet.Write((int)Refine);
             packet.Write(0); // guild id (cloaks?)
             packet.Write((byte)Element);
             packet.Write((int)ElementRefine);
@@ -226,7 +225,7 @@ namespace Rhisis.World.Game.Structures
             packet.Write<byte>(0); // pet
             packet.Write(0); // m_bTranformVisPet
         }
-        
+
         /// <summary>
         /// Clones this <see cref="Item"/>.
         /// </summary>
@@ -237,9 +236,20 @@ namespace Rhisis.World.Game.Structures
             {
                 ExtraUsed = ExtraUsed,
                 Slot = Slot,
-                UniqueId = UniqueId,
+                Index = Index,
                 Quantity = Quantity
             };
+        }
+
+        public void CopyFrom(Item itemToCopy)
+        {
+            Id = itemToCopy.Id;
+            CreatorId = itemToCopy.CreatorId;
+            Refine = itemToCopy.Refine;
+            Element = itemToCopy.Element;
+            ElementRefine = itemToCopy.ElementRefine;
+            Quantity = itemToCopy.Quantity;
+            Data = itemToCopy.Data;
         }
 
         /// <summary>
@@ -247,15 +257,15 @@ namespace Rhisis.World.Game.Structures
         /// </summary>
         public void Reset()
         {
-            Id = -1;
+            Id = Empty;
             DbId = -1;
             Quantity = 0;
-            CreatorId = -1;
+            CreatorId = Empty;
             Refine = 0;
             Element = 0;
             ElementRefine = 0;
             ExtraUsed = 0;
-            Slot = -1;
+            Slot = Empty;
             Data = null;
         }
 

--- a/src/Rhisis.World/Game/Structures/ItemCreationResult.cs
+++ b/src/Rhisis.World/Game/Structures/ItemCreationResult.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Rhisis.World.Game.Structures
+{
+    public struct ItemCreationResult
+    {
+        public ItemCreationActionType ActionType { get; }
+
+        public Item Item { get; }
+
+        public ItemCreationResult(ItemCreationActionType actionType, Item item)
+        {
+            ActionType = actionType;
+            Item = item;
+        }
+    }
+
+    public enum ItemCreationActionType
+    {
+        Add,
+        Update,
+        Delete
+    }
+}

--- a/src/Rhisis.World/Packets/Internal/InventoryPacketFactory.cs
+++ b/src/Rhisis.World/Packets/Internal/InventoryPacketFactory.cs
@@ -31,8 +31,8 @@ namespace Rhisis.World.Packets.Internal
             using var packet = new FFPacket();
             
             packet.StartNewMergedPacket(entity.Id, SnapshotType.DOEQUIP);
-            packet.Write(item.UniqueId);
-            packet.Write((byte)0); // Guild id
+            packet.Write((byte)item.Index);
+            packet.Write(0); // Guild id
             packet.Write(Convert.ToByte(equip));
             packet.Write(item.Id);
             packet.Write(item.Refines);
@@ -49,9 +49,9 @@ namespace Rhisis.World.Packets.Internal
             
             packet.StartNewMergedPacket(entity.Id, SnapshotType.CREATEITEM);
             packet.Write<byte>(0);
-            item.Serialize(packet);
+            item.Serialize(packet, -1);
             packet.Write<byte>(1);
-            packet.Write((byte)item.UniqueId);
+            packet.Write((byte)item.Index);
             packet.Write((short)item.Quantity);
 
             SendToPlayer(entity, packet);

--- a/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
+++ b/src/Rhisis.World/Packets/Internal/WorldSpawnPacketFactory.cs
@@ -368,14 +368,13 @@ namespace Rhisis.World.Packets.Internal
             }
             else if (entityToSpawn.Type == WorldEntityType.Drop)
             {
-                var dropItemEntity = entityToSpawn as IItemEntity;
-                if (dropItemEntity is null)
+                if (!(entityToSpawn is IItemEntity dropItemEntity))
                 {
                     packet.Dispose();
                     return;
                 }
 
-                dropItemEntity.Drop.Item.Serialize(packet);
+                dropItemEntity.Drop.Item.Serialize(packet, -1);
             }
 
             SendToPlayer(player, packet);

--- a/src/Rhisis.World/Rhisis.World.csproj
+++ b/src/Rhisis.World/Rhisis.World.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
-    <PackageReference Include="Sylver.HandlerInvoker" Version="1.0.0" />
+    <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />
   </ItemGroup>
 

--- a/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventoryItemUsage.cs
@@ -208,7 +208,7 @@ namespace Rhisis.World.Systems.Inventory
                 item.Quantity--;
             }
 
-            _inventoryPacketFactory.SendItemUpdate(player, itemUpdateType, item.UniqueId, item.Quantity);
+            _inventoryPacketFactory.SendItemUpdate(player, itemUpdateType, item.Index, item.Quantity);
 
             if (item.Data.SfxObject3 != 0)
             {

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -140,6 +140,8 @@ namespace Rhisis.World.Systems.Inventory
         public int CreateItem(IPlayerEntity player, ItemDescriptor item, int quantity, int creatorId = -1, bool sendToPlayer = true)
         {
             Item itemToCreate = _itemFactory.CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine, creatorId);
+            itemToCreate.Quantity = quantity;
+
             IEnumerable<ItemCreationResult> creationResult = player.Inventory.AddItem(itemToCreate);
 
             if (creationResult.Any())

--- a/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
+++ b/src/Rhisis.World/Systems/Inventory/InventorySystem.cs
@@ -6,7 +6,6 @@ using Rhisis.Core.DependencyInjection;
 using Rhisis.Core.Structures.Game;
 using Rhisis.Database;
 using Rhisis.Database.Entities;
-using Rhisis.World.Game.Components;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Factories;
 using Rhisis.World.Game.Structures;
@@ -70,20 +69,12 @@ namespace Rhisis.World.Systems.Inventory
         /// <inheritdoc />
         public void Initialize(IPlayerEntity player)
         {
-            IEnumerable<DbItem> items = _database.Items.Where(x => x.CharacterId == player.PlayerData.Id && !x.IsDeleted);
-            
-            if (items != null)
-            {
-                foreach (DbItem databaseItem in items)
-                {
-                    Item item = _itemFactory.CreateItem(databaseItem);
+            IEnumerable<Item> items = _database.Items
+                .Where(x => x.CharacterId == player.PlayerData.Id && !x.IsDeleted)
+                .OrderBy(x => x.ItemSlot)
+                .Select(x => _itemFactory.CreateItem(x));
 
-                    if (item != null)
-                    {
-                        player.Inventory.SetItemAtIndex(item, item.Slot);
-                    }
-                }
-            }
+            player.Inventory.Initialize(items);
         }
 
         /// <inheritdoc />
@@ -105,7 +96,7 @@ namespace Rhisis.World.Systems.Inventory
             // Add or update items
             foreach (Item item in player.Inventory)
             {
-                if (item == null || item.Id == -1)
+                if (item == null || item.Id == Item.Empty)
                 {
                     continue;
                 }
@@ -148,104 +139,32 @@ namespace Rhisis.World.Systems.Inventory
         /// <inheritdoc />
         public int CreateItem(IPlayerEntity player, ItemDescriptor item, int quantity, int creatorId = -1, bool sendToPlayer = true)
         {
-            int createdAmount = 0;
+            Item itemToCreate = _itemFactory.CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine, creatorId);
+            IEnumerable<ItemCreationResult> creationResult = player.Inventory.AddItem(itemToCreate);
 
-            if (item.Data.IsStackable)
+            if (creationResult.Any())
             {
-                for (var i = 0; i < InventoryContainerComponent.InventorySize; i++)
+                if (sendToPlayer)
                 {
-                    Item inventoryItem = player.Inventory.GetItemAtIndex(i);
-
-                    if (inventoryItem?.Id == item.Id)
+                    foreach (ItemCreationResult itemResult in creationResult)
                     {
-                        if (inventoryItem.Quantity + quantity > item.Data.PackMax)
+                        if (itemResult.ActionType == ItemCreationActionType.Add)
                         {
-                            int boughtQuantity = inventoryItem.Data.PackMax - inventoryItem.Quantity;
-
-                            createdAmount = boughtQuantity;
-                            quantity -= boughtQuantity;
-                            inventoryItem.Quantity = inventoryItem.Data.PackMax;
+                            _inventoryPacketFactory.SendItemCreation(player, itemResult.Item);
                         }
-                        else
+                        else if (itemResult.ActionType == ItemCreationActionType.Update)
                         {
-                            createdAmount = quantity;
-                            inventoryItem.Quantity += quantity;
-                            quantity = 0;
+                            _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, itemResult.Item.Index, itemResult.Item.Quantity);
                         }
-
-                        if (sendToPlayer)
-                        {
-                            _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, inventoryItem.UniqueId, inventoryItem.Quantity);
-                        }
-                    }
-                }
-
-                if (quantity > 0)
-                {
-                    int availableSlot = player.Inventory.GetAvailableSlot();
-
-                    if (availableSlot == -1)
-                    {
-                        _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
-                    }
-                    else
-                    {
-                        Item newItem = _itemFactory.CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine, creatorId);
-
-                        if (newItem == null)
-                        {
-                            throw new ArgumentNullException(nameof(newItem));
-                        }
-
-                        newItem.Quantity = quantity;
-                        newItem.Slot = availableSlot;
-
-                        player.Inventory.SetItemAtSlot(newItem, availableSlot);
-
-                        if (sendToPlayer)
-                        {
-                            _inventoryPacketFactory.SendItemCreation(player, newItem);
-                        }
-
-                        createdAmount += quantity;
                     }
                 }
             }
             else
             {
-                while (quantity > 0)
-                {
-                    int availableSlot = player.Inventory.GetAvailableSlot();
-
-                    if (availableSlot == -1)
-                    {
-                        _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
-                        break;
-                    }
-
-                    Item newItem = _itemFactory.CreateItem(item.Id, item.Refine, item.Element, item.ElementRefine, creatorId);
-
-                    if (newItem == null)
-                    {
-                        throw new ArgumentNullException(nameof(newItem));
-                    }
-
-                    newItem.Quantity = 1;
-                    newItem.Slot = availableSlot;
-
-                    player.Inventory.SetItemAtSlot(newItem, availableSlot);
-
-                    if (sendToPlayer)
-                    {
-                        _inventoryPacketFactory.SendItemCreation(player, newItem);
-                    }
-
-                    createdAmount++;
-                    quantity--;
-                }
+                _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
             }
 
-            return createdAmount;
+            return creationResult.Sum(x => x.Item.Quantity);
         }
 
         /// <inheritdoc />
@@ -275,13 +194,12 @@ namespace Rhisis.World.Systems.Inventory
 
             if (sendToPlayer)
             {
-                _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, itemToDelete.UniqueId, itemToDelete.Quantity);
+                _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, itemToDelete.Index, itemToDelete.Quantity);
             }
 
             if (itemToDelete.Quantity <= 0)
             {
                 itemToDelete.Reset();
-                //player.Inventory.SetItemAtSlot(null, itemToDelete.Slot);
             }
 
             return quantityToDelete;
@@ -323,25 +241,18 @@ namespace Rhisis.World.Systems.Inventory
                     destinationItem.Quantity = destinationItem.Data.PackMax;
                     sourceItem.Quantity = newQuantity - sourceItem.Data.PackMax;
 
-                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, sourceItem.UniqueId, sourceItem.Quantity);
-                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, destinationItem.UniqueId, destinationItem.Quantity);
+                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, sourceItem.Index, sourceItem.Quantity);
+                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, destinationItem.Index, destinationItem.Quantity);
                 }
                 else
                 {
                     destinationItem.Quantity = newQuantity;
-                    DeleteItem(player, sourceItem.UniqueId, sourceItem.Quantity);
-                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, destinationItem.UniqueId, destinationItem.Quantity);
+                    DeleteItem(player, sourceItem.Index, sourceItem.Quantity);
+                    _inventoryPacketFactory.SendItemUpdate(player, UpdateItemType.UI_NUM, destinationItem.Index, destinationItem.Quantity);
                 }
             }
             else
             {
-                sourceItem.Slot = destinationSlot;
-
-                if (destinationItem != null && destinationItem.Slot != -1)
-                {
-                    destinationItem.Slot = sourceSlot;
-                }
-
                 player.Inventory.Swap(sourceSlot, destinationSlot);
 
                 if (sendToPlayer)
@@ -365,18 +276,12 @@ namespace Rhisis.World.Systems.Inventory
 
             if (isItemEquiped)
             {
-                int availableSlot = player.Inventory.GetAvailableSlot();
-
-                if (availableSlot == -1)
+                if (player.Inventory.Unequip(itemToEquip))
                 {
-                    _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_LACKSPACE);
-                    return false;
+                    _inventoryPacketFactory.SendItemEquip(player, itemToEquip, (int)itemToEquip.Data.Parts, false);
+
+                    _logger.LogDebug($"Unequip {itemToEquip} to slot {itemToEquip.Slot}");
                 }
-
-                MoveItem(player, (byte)itemToEquip.Slot, (byte)availableSlot, sendToPlayer: false);
-                _inventoryPacketFactory.SendItemEquip(player, itemToEquip, (int)itemToEquip.Data.Parts, false);
-
-                _logger.LogDebug($"Unequip {itemToEquip} to slot {itemToEquip.Slot}");
             }
             else
             {
@@ -391,20 +296,21 @@ namespace Rhisis.World.Systems.Inventory
                 {
                     _logger.LogDebug($"Unequip {equipedItem} and equip {itemToEquip}");
 
-                    if (!EquipItem(player, equipedItem.UniqueId, (int)equipedItem.Data.Parts))
+                    if (player.Inventory.Unequip(equipedItem))
                     {
-                        _logger.LogWarning($"Failed to unequip {equipedItem} to equip {itemToEquip}");
-                        return false;
+                        _logger.LogDebug($"Unequip {equipedItem} to slot {equipedItem.Slot}");
                     }
-
                 }
 
-                int equipIndex = (int)itemToEquip.Data.Parts + InventoryContainerComponent.EquipOffset;
+                ItemPartType destinationPart = itemToEquip.Data.Parts;
+                // TODO: check dual weapon
 
-                MoveItem(player, (byte)itemToEquip.Slot, (byte)equipIndex, sendToPlayer: false);
-                _inventoryPacketFactory.SendItemEquip(player, itemToEquip, (int)itemToEquip.Data.Parts, true);
+                if (player.Inventory.Equip(itemToEquip, destinationPart))
+                {
+                    _inventoryPacketFactory.SendItemEquip(player, itemToEquip, (int)itemToEquip.Data.Parts, true);
 
-                _logger.LogDebug($"Equip {itemToEquip}");
+                    _logger.LogDebug($"Equip {itemToEquip}");
+                }
             }
 
             return true;
@@ -570,15 +476,30 @@ namespace Rhisis.World.Systems.Inventory
         {
             if (item.Data.ItemSex != int.MaxValue && item.Data.ItemSex != player.VisualAppearance.Gender)
             {
-                _logger.LogDebug("Wrong sex for armor");
+                _logger.LogTrace("Wrong sex for armor");
                 _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_WRONGSEX, item.Data.Name);
                 return false;
             }
 
             if (player.Object.Level < item.Data.LimitLevel)
             {
-                _logger.LogDebug("Player level to low");
+                _logger.LogTrace("Player level to low");
                 _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_REQLEVEL, item.Data.LimitLevel.ToString());
+                return false;
+            }
+
+            if (!player.PlayerData.JobData.IsAnteriorJob(item.Data.ItemJob))
+            {
+                _logger.LogTrace($"Player {player} tried to equip '{item.Data.Name}', but doesn't have the required job: '{item.Data.ItemJob}'.");
+                _textPacketFactory.SendDefinedText(player, DefineText.TID_GAME_WRONGJOB);
+                return false;
+            }
+
+            Item equipedItem = player.Inventory.GetEquipedItem(ItemPartType.RightWeapon);
+
+            if (item.Data.ItemKind3 == ItemKind3.ARROW && (equipedItem == null || equipedItem.Data.ItemKind3 != ItemKind3.BOW))
+            {
+                _logger.LogTrace($"Player {player} tried to equip arrows without having a bow equiped.");
                 return false;
             }
 

--- a/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
+++ b/src/Rhisis.World/Systems/Taskbar/TaskbarSystem.cs
@@ -57,7 +57,7 @@ namespace Rhisis.World.Systems.Taskbar
                     if (item is null)
                         return;
 
-                    shortcut = new Shortcut(dbShortcut.SlotIndex, dbShortcut.Type, (uint)item.UniqueId, dbShortcut.ObjectType, dbShortcut.ObjectIndex, dbShortcut.UserId, dbShortcut.ObjectData, dbShortcut.Text);
+                    shortcut = new Shortcut(dbShortcut.SlotIndex, dbShortcut.Type, (uint)item.Index, dbShortcut.ObjectType, dbShortcut.ObjectIndex, dbShortcut.UserId, dbShortcut.ObjectData, dbShortcut.Text);
                 }
                 else
                 {

--- a/src/Rhisis.World/Systems/Trade/TradeSystem.cs
+++ b/src/Rhisis.World/Systems/Trade/TradeSystem.cs
@@ -166,8 +166,8 @@ namespace Rhisis.World.Systems.Trade
             player.Trade.Items.SetItemAtIndex(inventoryItem.Clone(), destinationSlot);
             player.Trade.ItemCount++;
 
-            _tradePacketFactory.SendTradePut(player, trader: player, (byte)destinationSlot, (byte)itemType, (byte)inventoryItem.UniqueId, (short)tradingQuantity);
-            _tradePacketFactory.SendTradePut(target, trader: player, (byte)destinationSlot, (byte)itemType, (byte)inventoryItem.UniqueId, (short)tradingQuantity);
+            _tradePacketFactory.SendTradePut(player, trader: player, (byte)destinationSlot, (byte)itemType, (byte)inventoryItem.Index, (short)tradingQuantity);
+            _tradePacketFactory.SendTradePut(target, trader: player, (byte)destinationSlot, (byte)itemType, (byte)inventoryItem.Index, (short)tradingQuantity);
         }
 
         /// <inheritdoc />
@@ -451,7 +451,7 @@ namespace Rhisis.World.Systems.Trade
 
                 if (futureQuantity <= 0)
                 {
-                    _inventorySystem.DeleteItem(player, item.UniqueId, item.ExtraUsed, sendToPlayer: false);
+                    _inventorySystem.DeleteItem(player, item.Index, item.ExtraUsed, sendToPlayer: false);
                 }
 
                 _inventorySystem.CreateItem(target, newItem, tradeQuantity, sendToPlayer: false);

--- a/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
+++ b/test/Rhisis.World.Tests/Systems/InventorySystemTest.cs
@@ -142,14 +142,14 @@ namespace Rhisis.World.Tests.Systems
                 Assert.Null(_player.Inventory.GetItemAtSlot(sourceSlot));
                 Assert.NotNull(destinationItem);
                 Assert.Equal(sourceItemQuantity + destinationItemQuantity, destinationItem.Quantity);
-                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, destinationItem.UniqueId, destinationItem.Quantity), Times.Once());
+                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, destinationItem.Index, destinationItem.Quantity), Times.Once());
             }
             else
             {
                 Assert.Equal(destinationItemQuantity - sourceItemQuantity, sourceItem.Quantity);
                 Assert.Equal(itemPackMax, destinationItem.Quantity);
-                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, sourceItem.UniqueId, sourceItem.Quantity), Times.Once());
-                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, destinationItem.UniqueId, destinationItem.Quantity), Times.Once());
+                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, sourceItem.Index, sourceItem.Quantity), Times.Once());
+                _inventoryPacketFactoryMock.Verify(x => x.SendItemUpdate(_player, UpdateItemType.UI_NUM, destinationItem.Index, destinationItem.Quantity), Times.Once());
             }
         }
 
@@ -195,7 +195,7 @@ namespace Rhisis.World.Tests.Systems
 
             int itemToDeleteSlot = GetRandomSlotInUse();
             Item itemToDelete = _player.Inventory.GetItemAtSlot(itemToDeleteSlot);
-            int itemUniqueId = itemToDelete.UniqueId;
+            int itemUniqueId = itemToDelete.Index;
             int deleteQuantity = itemToDelete.Quantity;
 
             int deletedAmount = Service.DeleteItem(_player, itemUniqueId, deleteQuantity);
@@ -214,7 +214,7 @@ namespace Rhisis.World.Tests.Systems
 
             int itemToDeleteSlot = GetRandomSlotInUse();
             Item itemToDelete = _player.Inventory.GetItemAtSlot(itemToDeleteSlot);
-            int itemUniqueId = itemToDelete.UniqueId;
+            int itemUniqueId = itemToDelete.Index;
             int itemInitialQuantity = itemToDelete.Quantity;
             int deleteQuantity = itemInitialQuantity / 2;
 
@@ -244,7 +244,7 @@ namespace Rhisis.World.Tests.Systems
             int itemToDeleteSlot = GetRandomSlotInUse();
             Item itemToDelete = _player.Inventory.GetItemAtSlot(itemToDeleteSlot);
 
-            int deletedAmount = Service.DeleteItem(_player, itemToDelete.UniqueId, 0);
+            int deletedAmount = Service.DeleteItem(_player, itemToDelete.Index, 0);
 
             Assert.Equal(0, deletedAmount);
         }


### PR DESCRIPTION
This PR fixes some issues related to the inventory and the item container. (#386 and #417)
It also covers the issue #415 about arrow equipement. You can only equip arrows if you have a job that is acrobat or upper (ranger or jester) and if you have a bow already equiped.

Also, this updates the `Sylver.HandlerInvoker` library to v 1.1.0.

Some improvements have been made to the Cluster Server during characters list request. Instead of requesting all character items information, we only query the items that have a slot > 42 (Equip Offset) and we project the items only to the `ItemId` so EF Core will generate a smaller request like:
```sql
SELECT Id From Items
WHERE CharacterId = XX AND ItemSlot > 42 AND IsDeleted = 0
ORDER BY ItemSlot
```