### PR TITLE
Add GELF package for graylog logging

### DIFF
--- a/src/Rhisis.Cluster/Rhisis.Cluster.csproj
+++ b/src/Rhisis.Cluster/Rhisis.Cluster.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="NLog.GelfLayout" Version="1.2.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />

--- a/src/Rhisis.Login/Rhisis.Login.csproj
+++ b/src/Rhisis.Login/Rhisis.Login.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="NLog.GelfLayout" Version="1.2.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.0" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />

--- a/src/Rhisis.World/Rhisis.World.csproj
+++ b/src/Rhisis.World/Rhisis.World.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.3" />
     <PackageReference Include="NLog" Version="4.7.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.2" />
+    <PackageReference Include="NLog.GelfLayout" Version="1.2.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
     <PackageReference Include="Sylver.HandlerInvoker" Version="1.1.2" />
     <PackageReference Include="Sylver.Network" Version="1.2.1" />


### PR DESCRIPTION
This PR adds the Nlog.GelfLayout package to transfer logs to a graylog service.

For privacy reasons, nlog.config files are not updated with the graylog configuration.