### PR TITLE
Add defense calculation during battle

### DIFF
--- a/src/Rhisis.Cluster/Client/ClusterClient.cs
+++ b/src/Rhisis.Cluster/Client/ClusterClient.cs
@@ -96,9 +96,18 @@ namespace Rhisis.Cluster.Client
             catch (ArgumentNullException)
             {
                 if (Enum.IsDefined(typeof(PacketType), packetHeaderNumber))
-                    _logger.LogWarning("Received an unimplemented Cluster packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(PacketType), packetHeaderNumber), packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
+                {
+                    _logger.LogTrace("Received an unimplemented Cluster packet {0} (0x{1}) from {2}.", 
+                        Enum.GetName(typeof(PacketType), packetHeaderNumber), 
+                        packetHeaderNumber.ToString("X4"), 
+                        Socket.RemoteEndPoint);
+                }
                 else
-                    _logger.LogWarning("[SECURITY] Received an unknown Cluster packet 0x{0} from {1}.", packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
+                {
+                    _logger.LogTrace("[SECURITY] Received an unknown Cluster packet 0x{0} from {1}.", 
+                        packetHeaderNumber.ToString("X4"), 
+                        Socket.RemoteEndPoint);
+                }
             }
             catch (Exception exception)
             {

--- a/src/Rhisis.Login/Client/LoginClient.cs
+++ b/src/Rhisis.Login/Client/LoginClient.cs
@@ -95,14 +95,14 @@ namespace Rhisis.Login.Client
             {
                 if (Enum.IsDefined(typeof(PacketType), packetHeaderNumber))
                 {
-                    _logger.LogWarning("Received an unimplemented Login packet {0} (0x{1}) from {2}.",
+                    _logger.LogTrace("Received an unimplemented Login packet {0} (0x{1}) from {2}.",
                         Enum.GetName(typeof(PacketType), packetHeaderNumber),
                         packetHeaderNumber.ToString("X2"),
                         Socket.RemoteEndPoint);
                 }
                 else
                 {
-                    _logger.LogWarning("Received an unknown Login packet 0x{0} from {1}.", 
+                    _logger.LogTrace("Received an unknown Login packet 0x{0} from {1}.", 
                         packetHeaderNumber.ToString("X2"), 
                         Socket.RemoteEndPoint);
                 }

--- a/src/Rhisis.World/Client/WorldClient.cs
+++ b/src/Rhisis.World/Client/WorldClient.cs
@@ -71,11 +71,11 @@ namespace Rhisis.World.Client
             {
                 if (Enum.IsDefined(typeof(PacketType), packetHeaderNumber))
                 {
-                    _logger.LogWarning("Received an unimplemented World packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(PacketType), packetHeaderNumber), packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
+                    _logger.LogTrace("Received an unimplemented World packet {0} (0x{1}) from {2}.", Enum.GetName(typeof(PacketType), packetHeaderNumber), packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
                 }
                 else
                 {
-                    _logger.LogWarning("Received an unknown World packet 0x{0} from {1}.", packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
+                    _logger.LogTrace("Received an unknown World packet 0x{0} from {1}.", packetHeaderNumber.ToString("X4"), Socket.RemoteEndPoint);
                 }
             }
             catch (Exception exception)

--- a/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
+++ b/src/Rhisis.World/Game/Components/PlayerDataComponent.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Core.Common;
 using Rhisis.Core.Data;
+using Rhisis.Core.Helpers;
 using Rhisis.Core.Structures.Game;
 using System;
 
@@ -77,5 +78,28 @@ namespace Rhisis.World.Game.Components
         /// Gets or sets the player level when it dies.
         /// </summary>
         public int DeathLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's minimal defense.
+        /// </summary>
+        public int DefenseMin { get; set; }
+
+        /// <summary>
+        /// Gets or sets the player's maximum defense.
+        /// </summary>
+        public int DefenseMax { get; set; }
+
+        /// <summary>
+        /// Gets the player's defense.
+        /// </summary>
+        public int Defense
+        {
+            get
+            {
+                int defenseDelta = DefenseMax - DefenseMin;
+
+                return DefenseMin + (defenseDelta > 0 ? RandomHelper.Random(0, defenseDelta) : 0);
+            }
+        }
     }
 }

--- a/src/Rhisis.World/Handlers/InventoryHandler.cs
+++ b/src/Rhisis.World/Handlers/InventoryHandler.cs
@@ -3,6 +3,7 @@ using Rhisis.Network.Packets;
 using Rhisis.Network.Packets.World;
 using Rhisis.World.Client;
 using Rhisis.World.Systems.Inventory;
+using Rhisis.World.Systems.PlayerData;
 using Sylver.HandlerInvoker.Attributes;
 
 namespace Rhisis.World.Handlers
@@ -15,16 +16,19 @@ namespace Rhisis.World.Handlers
     {
         private readonly ILogger<InventoryHandler> _logger;
         private readonly IInventorySystem _inventorySystem;
+        private readonly IPlayerDataSystem _playerDataSystem;
 
         /// <summary>
         /// Creates a new <see cref="InventoryHandler"/> instance.
         /// </summary>
         /// <param name="logger">Logger.</param>
         /// <param name="inventorySystem">Inventory System.</param>
-        public InventoryHandler(ILogger<InventoryHandler> logger, IInventorySystem inventorySystem)
+        /// <param name="playerDataSystem">Player data system.</param>
+        public InventoryHandler(ILogger<InventoryHandler> logger, IInventorySystem inventorySystem, IPlayerDataSystem playerDataSystem)
         {
             _logger = logger;
             _inventorySystem = inventorySystem;
+            _playerDataSystem = playerDataSystem;
         }
 
         /// <summary>
@@ -47,6 +51,7 @@ namespace Rhisis.World.Handlers
         public void OnDoEquip(IWorldClient client, EquipItemPacket packet)
         {
             _inventorySystem.EquipItem(client.Player, packet.UniqueId, packet.Part);
+            _playerDataSystem.CalculateDefense(client.Player);
         }
 
         /// <summary>
@@ -86,6 +91,7 @@ namespace Rhisis.World.Handlers
             }
 
             _inventorySystem.UseItem(client.Player, packet.UniqueItemId, packet.Part);
+            _playerDataSystem.CalculateDefense(client.Player);
         }
     }
 }

--- a/src/Rhisis.World/Systems/PlayerData/IPlayerDataSystem.cs
+++ b/src/Rhisis.World/Systems/PlayerData/IPlayerDataSystem.cs
@@ -19,5 +19,11 @@ namespace Rhisis.World.Systems.PlayerData
         /// <param name="goldAmount">Gold amount to decrease.</param>
         /// <returns>Returns true if the gold has been decreased; false otherwhise.</returns>
         bool DecreaseGold(IPlayerEntity player, int goldAmount);
+        
+        /// <summary>
+        /// Calculates the player defense based on the equiped items.
+        /// </summary>
+        /// <param name="player">Current player.</param>
+        void CalculateDefense(IPlayerEntity player);
     }
 }

--- a/src/Rhisis.World/Systems/Statistics/StatisticsSystem.cs
+++ b/src/Rhisis.World/Systems/Statistics/StatisticsSystem.cs
@@ -4,6 +4,7 @@ using Rhisis.Core.DependencyInjection;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Helpers;
 using Rhisis.World.Packets;
+using Rhisis.World.Systems.PlayerData;
 
 namespace Rhisis.World.Systems.Statistics
 {
@@ -11,22 +12,24 @@ namespace Rhisis.World.Systems.Statistics
     public sealed class StatisticsSystem : IStatisticsSystem
     {
         private readonly ILogger<StatisticsSystem> _logger;
+        private readonly IPlayerDataSystem _playerDataSystem;
         private readonly IPlayerPacketFactory _playerPacketFactory;
 
         /// <summary>
         /// Creates a new <see cref="StatisticsSystem"/> instance.
         /// </summary>
         /// <param name="logger">Logger.</param>
-        public StatisticsSystem(ILogger<StatisticsSystem> logger, IPlayerPacketFactory playerPacketFactory)
+        /// <param name="playerDataSystem">Player data system.</param>
+        /// <param name="playerPacketFactory">Player packet factory.</param>
+        public StatisticsSystem(ILogger<StatisticsSystem> logger, IPlayerDataSystem playerDataSystem, IPlayerPacketFactory playerPacketFactory)
         {
             _logger = logger;
+            _playerDataSystem = playerDataSystem;
             _playerPacketFactory = playerPacketFactory;
         }
 
         public void UpdateStatistics(IPlayerEntity player, ushort strength, ushort stamina, ushort dexterity, ushort intelligence)
         {
-            _logger.LogDebug("Modify sttus");
-
             var total = strength + stamina + dexterity + intelligence;
 
             var statsPoints = player.Statistics.StatPoints;
@@ -52,6 +55,7 @@ namespace Rhisis.World.Systems.Statistics
             player.Statistics.StatPoints -= (ushort)total;
 
             _playerPacketFactory.SendPlayerUpdateState(player);
+            _playerDataSystem.CalculateDefense(player);
         }
 
         public void Restat(IPlayerEntity player)
@@ -69,6 +73,7 @@ namespace Rhisis.World.Systems.Statistics
             player.Statistics.StatPoints = (ushort)((player.Object.Level - 1) * 2);
 
             _playerPacketFactory.SendPlayerUpdateState(player);
+            _playerDataSystem.CalculateDefense(player);
         }
     }
 }


### PR DESCRIPTION
This PR covers issue #423 and adds the the player defense calculation based on the equiped items.

Each items have a min and max defense rate. We just sum all the mins and maxs together:
```csharp
foreach (var equipedItem in equipedItems)
{
     player.PlayerData.DefenseMin += equipedItem.Data.AbilityMin;
     player.PlayerData.DefenseMax += equipedItem.Data.AbilityMax;
}
```
then when we calculate the real defense, we will do a random between the `DefenseMin` and `DefenseMax` values to obtain the real player defense.