### PR TITLE
#438 Add monster return to begin position when following player far away

### DIFF
--- a/src/Rhisis.Core/Helpers/RandomHelper.cs
+++ b/src/Rhisis.Core/Helpers/RandomHelper.cs
@@ -23,6 +23,12 @@ namespace Rhisis.Core.Helpers
         }
 
         /// <summary>
+        /// Gets a random floating number.
+        /// </summary>
+        /// <returns></returns>
+        public static float FloatRandom() => (float)MersenneTwister.NextDouble();
+
+        /// <summary>
         /// Do a random between floats
         /// </summary>
         /// <param name="f1"></param>

--- a/src/Rhisis.Core/Structures/Vector3.cs
+++ b/src/Rhisis.Core/Structures/Vector3.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Core.Helpers;
 using System;
+using System.Numerics;
 
 namespace Rhisis.Core.Structures
 {
@@ -96,6 +97,24 @@ namespace Rhisis.Core.Structures
         public bool IsInCircle(Vector3 otherPosition, float circleRadius)
         {
             return Math.Pow(otherPosition.X - X, 2) + Math.Pow(otherPosition.Z - Z, 2) < Math.Pow(circleRadius, 2);
+        }
+
+        /// <summary>
+        /// Checks if the current position is in a given range.
+        /// </summary>
+        /// <param name="range"></param>
+        /// <returns></returns>
+        public bool IsInRange(Vector3 otherPosition, float range)
+        {
+            Vector3 distance = this - otherPosition;
+            distance.Y = 0;
+
+            if (distance.SquaredLength > range * range)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/src/Rhisis.Core/Structures/Vector3.cs
+++ b/src/Rhisis.Core/Structures/Vector3.cs
@@ -1,6 +1,5 @@
 ﻿using Rhisis.Core.Helpers;
 using System;
-using System.Numerics;
 
 namespace Rhisis.Core.Structures
 {

--- a/src/Rhisis.World/Game/Behaviors/Default/DefaultMonsterBehavior.cs
+++ b/src/Rhisis.World/Game/Behaviors/Default/DefaultMonsterBehavior.cs
@@ -70,7 +70,7 @@ namespace Rhisis.World.Game.Behaviors
             }
             else
             {
-                ProcessMonsterMovements(_monster);
+                ProcessMonsterMovements();
             }
 
             _mobilitySystem.CalculatePosition(_monster);
@@ -90,14 +90,12 @@ namespace Rhisis.World.Game.Behaviors
 
                 if (_monster.Moves.ReturningToOriginalPosition)
                 {
-                    Console.WriteLine($"{_monster} arrived from return to begin");
                     _monster.Moves.ReturningToOriginalPosition = false;
                     _monster.Attributes[DefineAttributes.HP] = _monster.Data.AddHp;
                     _moverPacketFactory.SendUpdateAttributes(_monster, DefineAttributes.HP, _monster.Attributes[DefineAttributes.HP]);
                 }
                 if (_monster.Moves.SpeedFactor >= 2f)
                 {
-                    Console.WriteLine($"{_monster} resets speed factor");
                     SetSpeedFactor(1f);
                 }
             }
@@ -171,9 +169,9 @@ namespace Rhisis.World.Game.Behaviors
         /// Update monster moves.
         /// </summary>
         /// <param name="monster"></param>
-        private void ProcessMonsterMovements(IMonsterEntity monster)
+        private void ProcessMonsterMovements()
         {
-            if (monster.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_STAND) && monster.Timers.NextMoveTime < Time.TimeInSeconds())
+            if (_monster.Object.MovingFlags.HasFlag(ObjectState.OBJSTA_STAND) && _monster.Timers.NextMoveTime < Time.TimeInSeconds())
             {
                 MoveToRandomPosition();
             }
@@ -218,6 +216,9 @@ namespace Rhisis.World.Game.Behaviors
             }
         }
 
+        /// <summary>
+        /// Makes the monster return to its begin position.
+        /// </summary>
         private void ReturnToBeginPosition()
         {
             _monster.Moves.ReturningToOriginalPosition = true;
@@ -227,17 +228,28 @@ namespace Rhisis.World.Game.Behaviors
             MoveToPosition(_monster.Object.BeginPosition);
         }
 
+        /// <summary>
+        /// Sets the monster speed factor.
+        /// </summary>
+        /// <param name="speedFactor"></param>
         private void SetSpeedFactor(float speedFactor)
         {
             _monster.Moves.SpeedFactor = speedFactor;
             _moverPacketFactory.SendSpeedFactor(_monster, _monster.Moves.SpeedFactor);
         }
 
+        /// <summary>
+        /// Makes the monster move to a random position inside its region.
+        /// </summary>
         private void MoveToRandomPosition()
         {
             MoveToPosition(_monster.Region.GetRandomPosition());
         }
 
+        /// <summary>
+        /// Movaes the monster to a given position.
+        /// </summary>
+        /// <param name="destinationPosition"></param>
         private void MoveToPosition(Vector3 destinationPosition)
         {
             _monster.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;

--- a/src/Rhisis.World/Game/Components/ObjectComponent.cs
+++ b/src/Rhisis.World/Game/Components/ObjectComponent.cs
@@ -37,6 +37,11 @@ namespace Rhisis.World.Game.Components
         public Vector3 Position { get; set; }
 
         /// <summary>
+        /// Gets or sets the monster begin position.
+        /// </summary>
+        public Vector3 BeginPosition { get; set; }
+
+        /// <summary>
         /// Gets or sets the object orientation angle.
         /// </summary>
         public float Angle { get; set; }

--- a/src/Rhisis.World/Game/Entities/IMonsterEntity.cs
+++ b/src/Rhisis.World/Game/Entities/IMonsterEntity.cs
@@ -1,5 +1,4 @@
-﻿using Rhisis.Core.Structures.Game;
-using Rhisis.World.Game.Maps.Regions;
+﻿using Rhisis.World.Game.Maps.Regions;
 
 namespace Rhisis.World.Game.Entities
 {

--- a/src/Rhisis.World/Game/Entities/Internal/MonsterEntity.cs
+++ b/src/Rhisis.World/Game/Entities/Internal/MonsterEntity.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Core.Common;
 using Rhisis.Core.Data;
+using Rhisis.Core.Structures;
 using Rhisis.Core.Structures.Game;
 using Rhisis.World.Game.Behaviors;
 using Rhisis.World.Game.Components;

--- a/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
+++ b/src/Rhisis.World/Game/Factories/Internal/MonsterFactory.cs
@@ -66,6 +66,7 @@ namespace Rhisis.World.Game.Factories.Internal
                 Speed = moverData.Speed
             };
 
+            monster.Object.BeginPosition = monster.Object.Position.Clone();
             monster.Data = moverData;
             monster.Region = region;
             monster.Attributes[DefineAttributes.HP] = moverData.AddHp;

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -71,6 +71,12 @@ namespace Rhisis.World.Systems.Battle
                 attackResult = attackArbiter.CalculateDamages();
             }
 
+            if (defender is IMonsterEntity monster && monster.Moves.ReturningToOriginalPosition)
+            {
+                attackResult.Damages = 0;
+                attackResult.Flags = AttackFlags.AF_MISS;
+            }
+
             if (attackResult.Flags.HasFlag(AttackFlags.AF_MISS) || attackResult.Damages <= 0)
             {
                 _battlePacketFactory.SendAddDamage(defender, attacker, attackResult.Flags, attackResult.Damages);


### PR DESCRIPTION
This PR covers issue #438. It makes the monsters return to their original positions when they are chasing a player during battle and when they come out of a given range. 