### PR TITLE
Fix projectiles and propMoverEx.inc file indent

### DIFF
--- a/bin/data/res/data/propMoverEx.inc
+++ b/bin/data/res/data/propMoverEx.inc
@@ -1,40 +1,40 @@
 /*
  06.04.07 -xuzhu-
- ÀÏ¹ÝÀûÀÎ ¾ÆÀÌÅÛ ½ÀµæÀÇ ±âº» Á¤Ã¥ º¯°æ.
- 1.ÀÏ¹ÝÀûÀÎ ¹«±â/¹æ¾î±¸ÀÇ ±âº»ÀåºñµéÀº ¸ðµç ¸ó½ºÅÍ¿¡°Ô¼­ µå¶øµÇ°Ô º¯°æµÇ¾ú´Ù.
- 2.¶³¾îÁö´Â ¹«±â/¹æ¾î±¸ÀÇ ·¹º§Àº ¸ó½ºÅÍ·¹º§º¸´Ù 2~5·¹º§ ³·Àº ¾ÆÀÌÅÛÀÌ µå¶øµÇµµ·Ï ÇÏ¿´´Ù.
- 3.À¯´ÏÅ©±ÞÀÇ ¹«±â´Â Èñ¹ÚÇÑ È®·ü·Î ¿ùµåµå¶øÀ¸·Îµµ ±¸ÇÒ ¼ö ÀÖÁö¸¸ Æ¯Á¤ ¸ó½ºÅÍ¿¡°Ô¼­ ±¸ÇÒ È®·üÀÌ ´õ ³ô°Ô ÇÑ´Ù.
- .DropKindÀÇ nMinUniq, nMaxUniqÀÇ ÆÄ¶ó¸ÞÅÍ´Â ´õÀÌ»ó »ç¿ëµÇÁö ¾Ê°Ô ¹Ù²Ù¾ú´Ù.
- .¼­¹ö¿¡¼­ ½ºÅ©¸³Æ®¸¦ ÀÐÀ»¶§ ¹«Á¶°Ç pPropMover->dwLevel - 2 ~ -5¹üÀ§·Î ¼³Á¤µÇ°Ô ¹Ù²Ù¾ú´Ù.
- .ÀÌ´Â ÀÏ¹ÝÀûÀ¸·Î ¸ó½ºÅÍµéÀÌ Àåºñ¸¦ µå¶øÇÒ¶§ ¸÷·¹º§º¸´Ù 2~5·¹º§ ³·Àº ÅÛÀÌ µå¶øµÇ°Ô ÇÏ¿©
- .³·ÀºÅÛÀ¸·Î »ç³ÉÀº °¡´ÉÇÏ°Ô ¹ß¶õ½º¸¦ ¼³Á¤ÇÏ°í, µ·ÀÌ ÀÖ´Ù¸é ´õ ÁÁÀº ¾ÆÀÌÅÛÀ» »ç¼­ »ç³ÉÇÒ ¼ö ÀÖµµ·Ï Çß´Ù.
+ ï¿½Ï¹ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½âº» ï¿½ï¿½Ã¥ ï¿½ï¿½ï¿½ï¿½.
+ 1.ï¿½Ï¹ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½î±¸ï¿½ï¿½ ï¿½âº»ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Í¿ï¿½ï¿½Ô¼ï¿½ ï¿½ï¿½ï¿½ï¿½Ç°ï¿½ ï¿½ï¿½ï¿½ï¿½Ç¾ï¿½ï¿½ï¿½.
+ 2.ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½/ï¿½ï¿½î±¸ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Í·ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 2~5ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Çµï¿½ï¿½ï¿½ ï¿½Ï¿ï¿½ï¿½ï¿½.
+ 3.ï¿½ï¿½ï¿½ï¿½Å©ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ È®ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Îµï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Æ¯ï¿½ï¿½ ï¿½ï¿½ï¿½Í¿ï¿½ï¿½Ô¼ï¿½ ï¿½ï¿½ï¿½ï¿½ È®ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Ñ´ï¿½.
+ .DropKindï¿½ï¿½ nMinUniq, nMaxUniqï¿½ï¿½ ï¿½Ä¶ï¿½ï¿½ï¿½Í´ï¿½ ï¿½ï¿½ï¿½Ì»ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ê°ï¿½ ï¿½Ù²Ù¾ï¿½ï¿½ï¿½.
+ .ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Å©ï¿½ï¿½Æ®ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ pPropMover->dwLevel - 2 ~ -5ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ç°ï¿½ ï¿½Ù²Ù¾ï¿½ï¿½ï¿½.
+ .ï¿½Ì´ï¿½ ï¿½Ï¹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Íµï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ò¶ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 2~5ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ç°ï¿½ ï¿½Ï¿ï¿½
+ .ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï°ï¿½ ï¿½ß¶ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï°ï¿½, ï¿½ï¿½ï¿½ï¿½ ï¿½Ö´Ù¸ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ç¼­ ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½Öµï¿½ï¿½ï¿½ ï¿½ß´ï¿½.
 */
 
 /*
-¾ÆÀÌÅÛ ¹ß»ý ÆÇÁ¤ O -> ¹ß»ý ÃÖ´ë °³¼ö¿¡ ÀÇÇÑ ¾ÆÀÌÅÛ ¹ß»ý, 25% µ·
-		 X -> ¾ÆÀÌÅÛ ¾øÀÌ 100% µ·
+ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ß»ï¿½ ï¿½ï¿½ï¿½ï¿½ O -> ï¿½ß»ï¿½ ï¿½Ö´ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ß»ï¿½, 25% ï¿½ï¿½
+		 X -> ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ 100% ï¿½ï¿½
 
-DropItem()ÀÇ ÃÖ´ë·®Àº 32°³ÀÌ¹Ç·Î ÇÔ¼ö¸¦ ±× ÀÌ»ó ³ÖÁö ¾Êµµ·Ï ÇÑ´Ù.
-- DropEvenitemÀº DropitemÀÇ °³¼ö¿¡ Á¾¼Ó¹ÞÀ½
-DropKind()ÀÇ ÃÖ´ë·®Àº 64°³ÀÌ¹Ç·Î ÇÔ¼ö¸¦ ±× ÀÌ»ó ³ÖÁö ¾Êµµ·Ï ÇÑ´Ù.
-DropQuestItem()ÀÇ ÃÖ´ë·®Àº 16°³ÀÓ
+DropItem()ï¿½ï¿½ ï¿½Ö´ë·®ï¿½ï¿½ 32ï¿½ï¿½ï¿½Ì¹Ç·ï¿½ ï¿½Ô¼ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½Ì»ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Êµï¿½ï¿½ï¿½ ï¿½Ñ´ï¿½.
+- DropEvenitemï¿½ï¿½ Dropitemï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Ó¹ï¿½ï¿½ï¿½
+DropKind()ï¿½ï¿½ ï¿½Ö´ë·®ï¿½ï¿½ 64ï¿½ï¿½ï¿½Ì¹Ç·ï¿½ ï¿½Ô¼ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½Ì»ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½Êµï¿½ï¿½ï¿½ ï¿½Ñ´ï¿½.
+DropQuestItem()ï¿½ï¿½ ï¿½Ö´ë·®ï¿½ï¿½ 16ï¿½ï¿½ï¿½ï¿½
 
 MVI_MONSTER
 {
-	Maxitem = ¹ß»ý ÃÖ´ë °³¼ö;
-	DropItem(Æ¯Á¤¾ÆÀÌÅÛÀÎµ¦½º, 3000000000(30¾ï)ÀÇ È®·ü, ¾ÆÀÌÅÛÃß°¡·¹º§, »ý¼º °¹¼ö);
-	»ý¼ºÈ®·üÀÌ ³·Àº °ÍÀ» Á¦ÀÏ »óÀ§·Î µÎ¾î »ý¼ºÈ®·üÀÌ ÀûÀº ¾ÆÀÌÅÛÀº ¹«Á¶°Ç ¹ß»ý°³¼ö¿¡
-	¿ì¼±ÀûÀ¸·Î Æ÷ÇÔµÇµµ·Ï ÇÑ´Ù.
+	Maxitem = ï¿½ß»ï¿½ ï¿½Ö´ï¿½ ï¿½ï¿½ï¿½ï¿½;
+	DropItem(Æ¯ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Îµï¿½ï¿½ï¿½, 3000000000(30ï¿½ï¿½)ï¿½ï¿½ È®ï¿½ï¿½, ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ß°ï¿½ï¿½ï¿½ï¿½ï¿½, ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½);
+	ï¿½ï¿½ï¿½ï¿½È®ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Î¾ï¿½ ï¿½ï¿½ï¿½ï¿½È®ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ß»ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	ï¿½ì¼±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ÔµÇµï¿½ï¿½ï¿½ ï¿½Ñ´ï¿½.
 	DropGold(Min, Max);
-	QuestItem(¾î¶² Äù½ºÆ®ÀÎ°¡, Äù½ºÆ® »óÅÂ, Äù½ºÆ®¿ëÀ¸·Î Áö±ÞµÇ´Â ¾ÆÀÌÅÛ, È®·ü, Áö±Þ°¹¼ö );
+	QuestItem(ï¿½î¶² ï¿½ï¿½ï¿½ï¿½Æ®ï¿½Î°ï¿½, ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½ï¿½ï¿½, ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ÞµÇ´ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½, È®ï¿½ï¿½, ï¿½ï¿½ï¿½Þ°ï¿½ï¿½ï¿½ );
 	
-	m_dwAttackMoveDelay = 0; // ÀÌµ¿½Ã µô·¹ÀÌ(¹Ð¸®¼¼ÄÁµå)
-	m_dwRunawayDelay = 1000; // µµ¸Á°¥ ¶§ µô·¹ÀÌ(¹Ð¸®¼¼ÄÁµå)
-	SetRunAway( HP(percent) );//, NPC Index(0ÀÌ¸é ÇÛÆÛ ¾øÀ½), °¹¼ö(0Àº ¸ù¶¥) );
-	ÇöÀç hp, ÇÛÆÛ ¸ó½ºÅÍ index, µµ¿ò ¿äÃ»ÇÒ ¸ó½ºÅÍ ¼ö(0 ÁÖº¯¿¡ °Ë»öµÇ´Â ³ð ¸ðµÎ)
-	¸¸¾à µµ¿ò ¿äÃ»ÇÒ ¸ó½ºÅÍ°¡ ÇÊ¿ä ¾ø´Ù¸é index¸¦ 0À¸·Î
-	SetCallHelper( HP(Percent), NPC(Index), °¹¼ö(0ÀÌ¸é ¸ù¶¥), bParty(TRUE,FALSE, °ø°Ý ´ë»óÀÚ¸¦ ÇØ´ç ÇÃ·¹ÀÌ¾îÀÇ ÆÄÆ¼ ¸É¹ö·Î ¼³Á¤) ); 
-	m_nAttackFirstRange = 10; // ¼±°ø ¸÷ÀÌ ¼±°øÇÏ±â À§ÇÑ ½ºÄµ ¹üÀ§. ¹ÌÅÍ ´ÜÀ§
+	m_dwAttackMoveDelay = 0; // ï¿½Ìµï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½Ð¸ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½)
+	m_dwRunawayDelay = 1000; // ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½Ð¸ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½)
+	SetRunAway( HP(percent) );//, NPC Index(0ï¿½Ì¸ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½), ï¿½ï¿½ï¿½ï¿½(0ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½) );
+	ï¿½ï¿½ï¿½ï¿½ hp, ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ index, ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ã»ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½(0 ï¿½Öºï¿½ï¿½ï¿½ ï¿½Ë»ï¿½ï¿½Ç´ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½)
+	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Ã»ï¿½ï¿½ ï¿½ï¿½ï¿½Í°ï¿½ ï¿½Ê¿ï¿½ ï¿½ï¿½ï¿½Ù¸ï¿½ indexï¿½ï¿½ 0ï¿½ï¿½ï¿½ï¿½
+	SetCallHelper( HP(Percent), NPC(Index), ï¿½ï¿½ï¿½ï¿½(0ï¿½Ì¸ï¿½ ï¿½ï¿½ï¿½ï¿½), bParty(TRUE,FALSE, ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Ú¸ï¿½ ï¿½Ø´ï¿½ ï¿½Ã·ï¿½ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½ï¿½Æ¼ ï¿½É¹ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½) ); 
+	m_nAttackFirstRange = 10; // ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï±ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Äµ ï¿½ï¿½ï¿½ï¿½. ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 }
 
 AI
@@ -42,19 +42,19 @@ AI
     Scan jon (jobNum) range (num) quest (QuestID) item (ItemID) chao (100,101) s
     Attack (%) cunning (Hi,sam,low)                B
     Recovery (%) (%) (%) (u/m/a)                   B
-    Summon (%) (num) (MoverID) B  // 20ÃÊ¸¶´Ù ÇÑ¹ø¾¿ (%)È®·ü·Î ¼ÒÈ¯½Ãµµ. MoverID¸¦ num¸¶¸® »ý¼º.
+    Summon (%) (num) (MoverID) B  // 20ï¿½Ê¸ï¿½ï¿½ï¿½ ï¿½Ñ¹ï¿½ï¿½ï¿½ (%)È®ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½È¯ï¿½Ãµï¿½. MoverIDï¿½ï¿½ numï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½.
     Rangeattack (X)                                B 
     Keeprangeattack (Range)                        B  
     Evade (%)                                      B
     Helper   (freq) (sr) (num) (mtype)             B
     Berserk  (hp) (%)                              B
-    Randomtarget  Á¦ÀÏ¸ÕÀú ¾²ÀÌ´Â °æ¿ì »ç¿ë        B 
+    Randomtarget  ï¿½ï¿½ï¿½Ï¸ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Ì´ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½        B 
     teleport (freq) (X,Y or 1~5) (mana) (batt)     M
     Loot     (d) (X,Y) (code) (?)                  M
        
 }
 
-¼ýÀÚ 		È®·ü		1°³°¡ ¶³¾îÁú¶§ ¸ó½ºÅÍ¼ö
+ï¿½ï¿½ï¿½ï¿½ 		È®ï¿½ï¿½		1ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½Í¼ï¿½
 9375		0.0003125%	320000
 18750		0.000625%	160000
 37500		0.00125%	80000
@@ -165,8 +165,8 @@ MI_AIBATT4
 	DropKind(IK3_BOOTS, 1, 6);
 	DropKind(IK3_SHIELD, 1, 6);
 	
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -293,8 +293,8 @@ MI_MUSHPANG4
 	DropKind(IK3_BOOTS, 3, 8);
 	DropKind(IK3_SHIELD, 3, 8);
 	
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -571,8 +571,8 @@ MI_PUKEPUKE4
 	DropItem(II_ARM_ARM_SHI_LIGHT, 30000000, 0, 1);
 	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 30000000, 1, 1);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -727,8 +727,8 @@ MI_PEAKYTURTLE4
 	DropKind(IK3_BOOTS, 6, 13);
 	DropKind(IK3_SHIELD, 6, 13);
 	
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1026,8 +1026,8 @@ MI_DORIDOMA4
 	DropKind(IK3_BOOTS, 9, 16);
 	DropKind(IK3_SHIELD, 9, 16);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1202,8 +1202,8 @@ MI_LAWOLF4
 	DropKind(IK3_BOW, 11, 18);
 	DropKind(IK3_YOYO, 11, 18);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1396,8 +1396,8 @@ MI_FEFERN4
 	DropItem(II_GEN_FOO_ICE_STRAWBERRYSHAKE, 600000001, 0, 1);
 	DropItem(II_GEN_FOO_ICE_STRAWBERRYSHAKE, 600000001, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1509,7 +1509,7 @@ MI_NYANGNYANG3
 {
 	Maxitem = 2;
 	DropGold(28, 41);
-//	DropItem(II_ARM_ARM_SHI_FURY, 83320, 0, 1);   // world dropÀ¸·Î ¹Ù²Þ
+//	DropItem(II_ARM_ARM_SHI_FURY, 83320, 0, 1);   // world dropï¿½ï¿½ï¿½ï¿½ ï¿½Ù²ï¿½
 	DropKind(IK3_SWD, 15, 19);
 	DropKind(IK3_AXE, 15, 19);
 	DropKind(IK3_CHEERSTICK, 15, 19);
@@ -1572,8 +1572,8 @@ MI_NYANGNYANG4
 	DropKind(IK3_BOW, 15, 22);
 	DropKind(IK3_YOYO, 15, 22);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1756,8 +1756,8 @@ MI_BANG4
 	DropKind(IK3_BOW, 17, 24);
 	DropKind(IK3_YOYO, 17, 24);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -1934,8 +1934,8 @@ MI_WAGSAAC4
 	DropKind(IK3_BOW, 19, 26);
 	DropKind(IK3_YOYO, 19, 26);
 	
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -2113,8 +2113,8 @@ MI_MIA4
 	DropKind(IK3_BOW, 21, 28);
 	DropKind(IK3_YOYO, 21, 28);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -2286,8 +2286,8 @@ MI_MRPUMPKIN4
 	DropKind(IK3_BOW, 23, 30);
 	DropKind(IK3_YOYO, 23, 30);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -2459,8 +2459,8 @@ MI_REDMANTIS4
 	DropKind(IK3_BOW, 25, 32);
 	DropKind(IK3_YOYO, 25, 32);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -2652,8 +2652,8 @@ MI_JACKTHEHAMMER4
 	DropKind(IK3_BOW, 27, 34);
 	DropKind(IK3_YOYO, 27, 34);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -2851,8 +2851,8 @@ MI_GIGGLEBOX4
 	DropKind(IK3_BOW, 29, 36);
 	DropKind(IK3_YOYO, 29, 36);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -3047,8 +3047,8 @@ MI_ROCKMUSCLE4
 	DropKind(IK3_BOW, 31, 38);
 	DropKind(IK3_YOYO, 31, 38);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -3096,141 +3096,141 @@ MI_BIGMUSCLE
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 7500000, 0, 1);
 
-	DropItem(II_GEN_GEM_GEM_TWINKLESTONE, 1800000000, 0, 1);	//	ºû³ª¼®
-	DropItem(II_GEN_GEM_GEM_FORFORM, 1800000000, 0, 1);		//	Æ÷Æû°¡·ç
-	DropItem(II_GEN_GEM_GEM_PALIN, 1800000000, 0, 1);		//	ÆÈ¸°
-	DropItem(II_GEN_GEM_GEM_CHUPIM, 1800000000, 0, 1);		//	ÃòÇË
-	DropItem(II_GEN_GEM_GEM_PEAKYRIND, 1800000000, 0, 1);		//	ÇÇÅ°¶óÀÎµå
-	DropItem(II_GEN_GEM_GEM_MOP, 1800000000, 0, 1);			//	¸ðÇÁ
-	DropItem(II_GEN_GEM_GEM_POPORAM, 1800000000, 0, 1);		//	Æ÷Æ÷¶÷
-	DropItem(II_GEN_GEM_GEM_SLAIN, 1800000000, 0, 1);		//	½½·¹ÀÎ
-	DropItem(II_GEN_GEM_GEM_TARINROOT, 1800000000, 0, 1);		//	Å¸¸°»Ñ¸®
-	DropItem(II_GEN_GEM_GEM_STARSTONE, 1800000000, 0, 1);		//	º°¼®
-	DropItem(II_GEN_GEM_GEM_GOLDENWING, 1800000000, 0, 1);		//	È²±Ý³¯°³
-	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ºí·çÇã´Ï
-	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	¹Ì¾ÆÀÇ ÀÎÇü
-	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	¿­È­¼º³É
-	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«µå¸°
-	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ÇÜ¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	±â±Û·Àµå
-	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	¿ùÀå¼®
-	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	º¸¿ì¹êµå
-	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	´ýºí¸µ
+	DropItem(II_GEN_GEM_GEM_TWINKLESTONE, 1800000000, 0, 1);	//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_FORFORM, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_PALIN, 1800000000, 0, 1);		//	ï¿½È¸ï¿½
+	DropItem(II_GEN_GEM_GEM_CHUPIM, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_PEAKYRIND, 1800000000, 0, 1);		//	ï¿½ï¿½Å°ï¿½ï¿½ï¿½Îµï¿½
+	DropItem(II_GEN_GEM_GEM_MOP, 1800000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_POPORAM, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_SLAIN, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_TARINROOT, 1800000000, 0, 1);		//	Å¸ï¿½ï¿½ï¿½Ñ¸ï¿½
+	DropItem(II_GEN_GEM_GEM_STARSTONE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENWING, 1800000000, 0, 1);		//	È²ï¿½Ý³ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	ï¿½ï¿½È­ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«ï¿½å¸°
+	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ï¿½Ü¸ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	ï¿½ï¿½Û·ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½å¼®
+	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 
 
-	DropItem(II_GEN_MAT_ELE_CANDLE, 15000000, 0, 1);		//	Äµµé Ä«µå
-	DropItem(II_GEN_MAT_ELE_RAIN, 15000000, 0, 1);			//	·¹ÀÎ Ä«µå
-	DropItem(II_GEN_MAT_ELE_BREEZE, 15000000, 0, 1);		//	ºê¸®Áî Ä«µå
-	DropItem(II_GEN_MAT_ELE_SPARK, 14500000, 0, 1);		        //	½ºÆÄÅ© Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 14500000, 0, 1);		        //	ÅäÄ¡ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 14500000, 0, 1);			//	·¹ÀÌÅ© Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 14500000, 0, 1);		//	º¼Å×ÀÌÁö Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 14500000, 0, 1);	        	//	½ºÅæ Ä«µå
+	DropItem(II_GEN_MAT_ELE_CANDLE, 15000000, 0, 1);		//	Äµï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RAIN, 15000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_BREEZE, 15000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_SPARK, 14500000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 14500000, 0, 1);		        //	ï¿½ï¿½Ä¡ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 14500000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 14500000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 14500000, 0, 1);	        	//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
 
-	DropItem(II_WEA_SWO_OUTLAW, 50000000, 0, 1);	        	//	¾Æ¿ô·Î¼Òµå
-	DropItem(II_WEA_SWO_FAIRSLENDER, 45000000, 0, 1);		//	Æä¾î½½·£´õ¼Òµå
-	DropItem(II_WEA_SWO_TAO, 35000000, 0, 1);       		//	Å¸¿À¼Òµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_WAN_EPI, 50000000, 0, 1);			//	¿¡ÇÇ¿Ïµå
-	DropItem(II_WEA_WAN_NIZ, 45000000, 0, 1);			//	´ÏÁî¿Ïµå
-	DropItem(II_WEA_WAN_KALIS, 35000000, 0, 1);		        //	Ä®¸®½º¿Ïµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_CHEE_HUEY, 50000000, 0, 1);	        	//	ÈÞÀÌ½ºÆ½
-	DropItem(II_WEA_CHEE_KUDOS, 45000000, 0, 1);			//	Å¥µµ½º½ºÆ½
-	DropItem(II_WEA_CHEE_SAINT, 35000000, 0, 1);	         	//	¼¼ÀÎÆ®½ºÆ½(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_AXE_BRONZE, 50000000, 0, 1);			//	ºê·ÐÁî¿¢½º
-	DropItem(II_WEA_AXE_GRANG, 45000000, 0, 1);			//	±×¶û¿¢½º
-	DropItem(II_WEA_AXE_PROEM, 35000000, 0, 1);	         	//      ÇÁ·Î¿¥¿¢½º(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_STA_INNER, 50000000, 0, 1);			//	ÀÎ³Ê½ºÅÂÇÁ
-	DropItem(II_WEA_STA_HERALD, 45000000, 0, 1);			//	ÇØ·²µå½ºÅÂÇÁ
-	DropItem(II_WEA_STA_SIGN, 35000000, 0, 1);			//	½ÎÀÎ½ºÅÂÇÁ(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_KNU_TWIT, 50000000, 0, 1);			//	Æ®À­³ÊÅ¬
-	DropItem(II_WEA_KNU_XENO, 45000000, 0, 1);			//	Á¦³ë³ÊÅ¬
-	DropItem(II_WEA_KNU_TALIN, 35000000, 0, 1);			//	Å»¸°³ÊÅ¬(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_YOY_CLIENT, 50000000, 0, 1);			//	Å¬¶óÀÌ¾ðÆ®
-	DropItem(II_WEA_YOY_TENSU, 45000000, 0, 1);	       		//	ÅÙ¼ö
-	DropItem(II_WEA_YOY_DICEIN, 35000000, 0, 1);			//	µð¼¼ÀÎ(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_BOW_STIENG, 50000000, 0, 1);			//	½ºÆ¼¿¨¾îº¸¿ì
-	DropItem(II_WEA_BOW_CLASEM, 45000000, 0, 1);	       		//	Å¬·¹¼¼¹ÌÆ®º¸¿ì(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_BOW_CRISTI, 35000000, 0, 1);			//	Å©¸®½ºÆ¼¾Æº¸¿ì
+	DropItem(II_WEA_SWO_OUTLAW, 50000000, 0, 1);	        	//	ï¿½Æ¿ï¿½ï¿½Î¼Òµï¿½
+	DropItem(II_WEA_SWO_FAIRSLENDER, 45000000, 0, 1);		//	ï¿½ï¿½î½½ï¿½ï¿½ï¿½ï¿½ï¿½Òµï¿½
+	DropItem(II_WEA_SWO_TAO, 35000000, 0, 1);       		//	Å¸ï¿½ï¿½ï¿½Òµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_WAN_EPI, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½Ç¿Ïµï¿½
+	DropItem(II_WEA_WAN_NIZ, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_WAN_KALIS, 35000000, 0, 1);		        //	Ä®ï¿½ï¿½ï¿½ï¿½ï¿½Ïµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_CHEE_HUEY, 50000000, 0, 1);	        	//	ï¿½ï¿½ï¿½Ì½ï¿½Æ½
+	DropItem(II_WEA_CHEE_KUDOS, 45000000, 0, 1);			//	Å¥ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ½
+	DropItem(II_WEA_CHEE_SAINT, 35000000, 0, 1);	         	//	ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½Æ½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_AXE_BRONZE, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½î¿¢ï¿½ï¿½
+	DropItem(II_WEA_AXE_GRANG, 45000000, 0, 1);			//	ï¿½×¶ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_AXE_PROEM, 35000000, 0, 1);	         	//      ï¿½ï¿½ï¿½Î¿ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_STA_INNER, 50000000, 0, 1);			//	ï¿½Î³Ê½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_HERALD, 45000000, 0, 1);			//	ï¿½Ø·ï¿½ï¿½å½ºï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_SIGN, 35000000, 0, 1);			//	ï¿½ï¿½ï¿½Î½ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_KNU_TWIT, 50000000, 0, 1);			//	Æ®ï¿½ï¿½ï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_XENO, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_TALIN, 35000000, 0, 1);			//	Å»ï¿½ï¿½ï¿½ï¿½Å¬(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_YOY_CLIENT, 50000000, 0, 1);			//	Å¬ï¿½ï¿½ï¿½Ì¾ï¿½Æ®
+	DropItem(II_WEA_YOY_TENSU, 45000000, 0, 1);	       		//	ï¿½Ù¼ï¿½
+	DropItem(II_WEA_YOY_DICEIN, 35000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_BOW_STIENG, 50000000, 0, 1);			//	ï¿½ï¿½Æ¼ï¿½ï¿½ï¿½îº¸ï¿½ï¿½
+	DropItem(II_WEA_BOW_CLASEM, 45000000, 0, 1);	       		//	Å¬ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_BOW_CRISTI, 35000000, 0, 1);			//	Å©ï¿½ï¿½ï¿½ï¿½Æ¼ï¿½Æºï¿½ï¿½ï¿½
 
-	DropItem(II_ARM_M_MER_HELMET0101, 70000000, 0, 1);		//	¹ÌÆ½ Çï¸ä
-	DropItem(II_ARM_M_MER_SUIT0101, 60000000, 0, 1);		//	¹ÌÆ½ ½´Æ®
-	DropItem(II_ARM_M_MER_GAUNTLET0101, 70000000, 0, 1);		//	¹ÌÆ½ °ÇÆ²·¿
-	DropItem(II_ARM_M_MER_BOOTS0101, 70000000, 0, 1);		//	¹ÌÆ½ ºÎÃ÷
-	DropItem(II_ARM_M_MER_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_BOOTS0201, 80000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_HELMET0101, 70000000, 0, 1);		//	½ºÀ§ÇÁÆ® Çï¸ä
-	DropItem(II_ARM_F_MER_SUIT0101, 60000000, 0, 1);		//	½ºÀ§ÇÁÆ® ½´Æ®
-	DropItem(II_ARM_F_MER_GAUNTLET0101, 80000000, 0, 1);		//	½ºÀ§ÇÁÆ® °ÇÆ²·¿
-	DropItem(II_ARM_F_MER_BOOTS0101, 70000000, 0, 1);		//	½ºÀ§ÇÁÆ® ºÎÃ÷
-	DropItem(II_ARM_F_MER_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_HELMET0101, 70000000, 0, 1);		//	´ÙÀÌ½º Çï¸ä
-	DropItem(II_ARM_M_MAG_SUIT0101, 60000000, 0, 1);		//	´ÙÀÌ½º ½´Æ®
-	DropItem(II_ARM_M_MAG_GAUNTLET0101, 70000000, 0, 1);		//	´ÙÀÌ½º °ÇÆ²·¿
-	DropItem(II_ARM_M_MAG_BOOTS0101, 70000000, 0, 1);		//	´ÙÀÌ½º ºÎÃ÷
-	DropItem(II_ARM_M_MAG_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_HELMET0101, 70000000, 0, 1);		//	·è½º Çï¸ä
-	DropItem(II_ARM_F_MAG_SUIT0101, 60000000, 0, 1);		//	·è½º ½´Æ®
-	DropItem(II_ARM_F_MAG_GAUNTLET0101, 70000000, 0, 1);		//	·è½º °ÇÆ²·¿
-	DropItem(II_ARM_F_MAG_BOOTS0101, 70000000, 0, 1);		//	·è½º ºÎÃ÷
-	DropItem(II_ARM_F_MAG_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_SUIT0101, 60000000, 0, 1);		//	ºê¸®Áî ½´Æ®
-	DropItem(II_ARM_M_ASS_GAUNTLET0101, 70000000, 0, 1);		//	ºê¸®Áî °ÇÆ²·¿
-	DropItem(II_ARM_M_ASS_BOOTS0101, 70000000, 0, 1);		//	ºê¸®Áî ºÎÃ÷
-	DropItem(II_ARM_M_ASS_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_HELMET0101, 70000000, 0, 1);		//	ÇÃ·Î¶ö Çï¸ä
-	DropItem(II_ARM_F_ASS_SUIT0101, 60000000, 0, 1);		//	ÇÃ·Î¶ö ½´Æ®
-	DropItem(II_ARM_F_ASS_GAUNTLET0101, 70000000, 0, 1);		//	ÇÃ·Î¶ö °ÇÆ²·¿
-	DropItem(II_ARM_F_ASS_BOOTS0101, 70000000, 0, 1);		//	ÇÃ·Î¶ö ºÎÃ÷
-	DropItem(II_ARM_F_ASS_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_HELMET0101, 70000000, 0, 1);		//	½Ã³Ê Çï¸ä
-	DropItem(II_ARM_M_ACR_SUIT0101, 60000000, 0, 1);		//	½Ã³Ê ½´Æ®
-	DropItem(II_ARM_M_ACR_GAUNTLET0101, 70000000, 0, 1);		//	½Ã³Ê °ÇÆ²·¿
-	DropItem(II_ARM_M_ACR_BOOTS0101, 70000000, 0, 1);		//	½Ã³Ê ºÎÃ÷
-	DropItem(II_ARM_M_ACR_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_HELMET0101, 70000000, 0, 1);		//	½Ã¾ÈÅä Çï¸ä
-	DropItem(II_ARM_F_ACR_SUIT0101, 60000000, 0, 1);		//	½Ã¾ÈÅä ½´Æ®
-	DropItem(II_ARM_F_ACR_GAUNTLET0101, 70000000, 0, 1);		//	½Ã¾ÈÅä °ÇÆ²·¿
-	DropItem(II_ARM_F_ACR_BOOTS0101, 70000000, 0, 1);		//	½Ã¾ÈÅä ºÎÃ÷
-        DropItem(II_ARM_F_ACR_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_M_MER_HELMET0101, 70000000, 0, 1);		//	ï¿½ï¿½Æ½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_SUIT0101, 60000000, 0, 1);		//	ï¿½ï¿½Æ½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MER_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½ï¿½Æ½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MER_BOOTS0101, 70000000, 0, 1);		//	ï¿½ï¿½Æ½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_BOOTS0201, 80000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_HELMET0101, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_SUIT0101, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MER_GAUNTLET0101, 80000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MER_BOOTS0101, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_HELMET0101, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_SUIT0101, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MAG_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_BOOTS0101, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_HELMET0101, 70000000, 0, 1);		//	ï¿½è½º ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_SUIT0101, 60000000, 0, 1);		//	ï¿½è½º ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MAG_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½è½º ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_BOOTS0101, 70000000, 0, 1);		//	ï¿½è½º ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_SUIT0101, 60000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_ASS_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_ASS_BOOTS0101, 70000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_ASS_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_HELMET0101, 70000000, 0, 1);		//	ï¿½Ã·Î¶ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_SUIT0101, 60000000, 0, 1);		//	ï¿½Ã·Î¶ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_ASS_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½Ã·Î¶ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_BOOTS0101, 70000000, 0, 1);		//	ï¿½Ã·Î¶ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_HELMET0101, 70000000, 0, 1);		//	ï¿½Ã³ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_ACR_SUIT0101, 60000000, 0, 1);		//	ï¿½Ã³ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_ACR_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½Ã³ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_ACR_BOOTS0101, 70000000, 0, 1);		//	ï¿½Ã³ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_ACR_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_HELMET0101, 70000000, 0, 1);		//	ï¿½Ã¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ACR_SUIT0101, 60000000, 0, 1);		//	ï¿½Ã¾ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_ACR_GAUNTLET0101, 70000000, 0, 1);		//	ï¿½Ã¾ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_ACR_BOOTS0101, 70000000, 0, 1);		//	ï¿½Ã¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+        DropItem(II_ARM_F_ACR_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 
-	DropItem(II_ARM_ARM_SHI_SPARKLE, 20000000, 0, 1);		//	½ºÆÄÅ¬ ½Çµå
-	DropItem(II_ARM_ARM_SHI_SHURAIN, 15000000, 0, 1);	        //	½´·¹ÀÎ ½Çµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_ARM_SHI_SPARKLE, 20000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Å¬ ï¿½Çµï¿½
+	DropItem(II_ARM_ARM_SHI_SHURAIN, 15000000, 0, 1);	        //	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Çµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 
-	DropItem(II_GEN_FOO_COO_BARBECUE, 3000000000, 0, 1);		//	¹Ùº£Å¥
-	DropItem(II_GEN_FOO_COO_SEAFOODPANCAKE, 3000000000, 0, 1);	//	ÇØ¹°ÆÄÀü
-	DropItem(II_GEN_FOO_ICE_PINEAPPLECONE, 3000000000, 0, 1);	//	ÆÄÀÎ¾ÖÇÃÄÜ
-	DropItem(II_GEN_FOO_ICE_BANANAJUJUBAR, 3000000000, 0, 1);	//	¹Ù³ª³ªÂÞÂÞ¹Ù
-	DropItem(II_GEN_REF_REF_SECOND, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 2±Þ
-	DropItem(II_GEN_REF_REF_THIRD, 30000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 3±Þ
-	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 4±Þ
-	DropItem(II_GEN_POT_DRI_VITAL200, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 200
-	DropItem(II_GEN_POT_DRI_VITAL300, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 300
-	DropItem(II_GEN_POT_DRI_VITAL400, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 400
-	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	Áúº´Ä¡·á¾à
-	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ÇØµ¶¾à
+	DropItem(II_GEN_FOO_COO_BARBECUE, 3000000000, 0, 1);		//	ï¿½Ùºï¿½Å¥
+	DropItem(II_GEN_FOO_COO_SEAFOODPANCAKE, 3000000000, 0, 1);	//	ï¿½Ø¹ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_FOO_ICE_PINEAPPLECONE, 3000000000, 0, 1);	//	ï¿½ï¿½ï¿½Î¾ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_FOO_ICE_BANANAJUJUBAR, 3000000000, 0, 1);	//	ï¿½Ù³ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Þ¹ï¿½
+	DropItem(II_GEN_REF_REF_SECOND, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 2ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_THIRD, 30000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 3ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 4ï¿½ï¿½
+	DropItem(II_GEN_POT_DRI_VITAL200, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 200
+	DropItem(II_GEN_POT_DRI_VITAL300, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 300
+	DropItem(II_GEN_POT_DRI_VITAL400, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 400
+	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Ä¡ï¿½ï¿½ï¿½
+	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ï¿½Øµï¿½ï¿½ï¿½
 
 
 	m_nAttackFirstRange = 10;
@@ -3411,8 +3411,8 @@ MI_HOBO4
 	DropKind(IK3_BOW, 33, 40);
 	DropKind(IK3_YOYO, 33, 40);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -3605,8 +3605,8 @@ MI_DUMBBULL4
 	DropKind(IK3_BOW, 35, 42);
 	DropKind(IK3_YOYO, 35, 42);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -3807,8 +3807,8 @@ MI_TOTEMIA4
 	DropKind(IK3_BOW, 37, 44);
 	DropKind(IK3_YOYO, 37, 44);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -3987,8 +3987,8 @@ MI_CARDPUPPET4
 	DropItem(II_GEN_JEW_RIN_STRRING, 30000000, 3, 1);
 	DropItem(II_GEN_JEW_RIN_INTRING, 30000000, 3, 1);
 	
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -4194,8 +4194,8 @@ MI_TOMBSTONEBEARER4
 	DropKind(IK3_BOW, 41, 48);
 	DropKind(IK3_YOYO, 41, 48);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -4393,8 +4393,8 @@ MI_BASQUE4
 	DropKind(IK3_BOW, 43, 50);
 	DropKind(IK3_YOYO, 43, 50);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -4581,8 +4581,8 @@ MI_PRANKSTER4
 	DropItem(II_WEA_KNU_PAIPOL, 10000000, 0, 1);
 	DropItem(II_WEA_AXE_DRAKHAN, 10000000, 0, 1);
 	
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -4797,8 +4797,8 @@ MI_WHEELEM4
 	DropKind(IK3_BOW, 47, 54);
 	DropKind(IK3_YOYO, 47, 54);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -4985,8 +4985,8 @@ MI_LEYENA4
 	DropItem(II_GEN_JEW_RIN_DEXRING, 30000000, 4, 1);
 	DropItem(II_GEN_JEW_RIN_STARING, 30000000, 4, 1);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -5196,8 +5196,8 @@ MI_STEAMWALKER4
 	DropKind(IK3_BOW, 51, 58);
 	DropKind(IK3_YOYO, 51, 58);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -5406,8 +5406,8 @@ MI_STEELKNIGHT4
 	DropKind(IK3_BOW, 53, 60);
 	DropKind(IK3_YOYO, 53, 60);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -5620,8 +5620,8 @@ MI_NUTTYWHEEL4
 	DropKind(IK3_BOW, 55, 62);
 	DropKind(IK3_YOYO, 55, 62);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -5662,7 +5662,7 @@ MI_NUTTYWHEEL4
 
 }
 
-MI_DRILLER1    // ¿©±â¼­ºÎÅÍ 59·¹º§ÀÓ.
+MI_DRILLER1    // ï¿½ï¿½ï¿½â¼­ï¿½ï¿½ï¿½ï¿½ 59ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½.
 {
 	Maxitem = 2;
 	DropGold(53, 77);
@@ -5817,8 +5817,8 @@ MI_DRILLER4
 	DropKind(IK3_BOW, 57, 64);
 	DropKind(IK3_YOYO, 57, 64);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6021,8 +6021,8 @@ MI_VOLT4
 	DropKind(IK3_BOW, 59, 66);
 	DropKind(IK3_YOYO, 59, 66);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6221,8 +6221,8 @@ MI_ELDERGUARD4
 	DropKind(IK3_BOW, 61, 68);
 	DropKind(IK3_YOYO, 61, 68);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6425,8 +6425,8 @@ MI_GARBAGEPIDER4
 	DropKind(IK3_BOW, 63, 70);
 	DropKind(IK3_YOYO, 63, 70);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6626,8 +6626,8 @@ MI_CRANEMACHINERY4
 	DropKind(IK3_BOW, 65, 72);
 	DropKind(IK3_YOYO, 65, 72);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6761,8 +6761,8 @@ MI_MOTHBEE4
 	DropItem(II_GEN_JEW_EAR_ATTEARRING, 30000000, 0, 1);
 	DropItem(II_GEN_JEW_EAR_DEFEARRING, 30000000, 0, 1);	
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -6885,8 +6885,8 @@ MI_FLBYRIGEN4
 	DropItem(II_GEN_JEW_EAR_ATTEARRING, 30000000, 2, 1);
 	DropItem(II_GEN_JEW_EAR_DEFEARRING, 30000000, 7, 1);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -7013,8 +7013,8 @@ MI_ROCKEPELLER4
 	DropItem(II_GEN_JEW_EAR_ATTEARRING, 30000000, 3, 1);
 	DropItem(II_GEN_JEW_EAR_DEFEARRING, 30000000, 9, 1);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 75000000, 0, 1); //¼Ó¼º Ä«µå3 2.5%
-	DropItem(II_GEN_MAT_ELE_FLAME, 150000000, 0, 1); //¼Ó¼º Ä«µå2 5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 75000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 2.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 150000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -7063,7 +7063,7 @@ MI_GURUCATCHER
 	Maxitem = 0;
 }
 
-//½ÃÀÏ¶óÄ«
+//ï¿½ï¿½ï¿½Ï¶ï¿½Ä«
 MI_SYLIACA1
 {
 	Maxitem = 2;
@@ -7242,8 +7242,8 @@ MI_SYLIACA4
 	DropKind(IK3_BOW, 67, 74);
 	DropKind(IK3_YOYO, 67, 74);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -7285,7 +7285,7 @@ MI_SYLIACA4
 
 }
 
-//±×¸®¸ù
+//ï¿½×¸ï¿½ï¿½ï¿½
 MI_GREEMONG1
 {
 	Maxitem = 2;
@@ -7467,8 +7467,8 @@ MI_GREEMONG4
 	DropKind(IK3_BOW, 69, 75);
 	DropKind(IK3_YOYO, 69, 75);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -7507,7 +7507,7 @@ MI_GREEMONG4
    	}               
 }
 
-//Ä³¸®¾Æº½
+//Ä³ï¿½ï¿½ï¿½Æºï¿½
 MI_CARRIERBOMB1
 {
 	Maxitem = 2;
@@ -7678,8 +7678,8 @@ MI_CARRIERBOMB4
 	DropKind(IK3_BOW, 73, 79);
 	DropKind(IK3_YOYO, 73, 79);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_GEM_GEM_BOMBTIMER, 1000000000, 0, 1);
 	DropItem(II_GEN_GEM_GEM_BOMBTIMER, 1000000000, 0, 1);
@@ -7716,7 +7716,7 @@ MI_CARRIERBOMB4
 
 }
 
-//¶óÀÌÁª
+//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 MI_RISEM1
 {
 
@@ -7883,8 +7883,8 @@ MI_RISEM4
 	DropKind(IK3_BOW, 57, 64);
 	DropKind(IK3_YOYO, 57, 64);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -7926,7 +7926,7 @@ MI_RISEM4
    	}               
 }
 
-//³«ÅÍºñÅ¬
+//ï¿½ï¿½ï¿½Íºï¿½Å¬
 MI_NUCTUVEHICLE1
 {
 	Maxitem = 2;
@@ -8100,8 +8100,8 @@ MI_NUCTUVEHICLE4
 	DropKind(IK3_BOW, 55, 62);
 	DropKind(IK3_YOYO, 55, 62);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -8146,7 +8146,7 @@ MI_NUCTUVEHICLE4
 
 }
 
-//Àáºñ°Å
+//ï¿½ï¿½ï¿½ï¿½
 MI_ZOMBIGER1
 {
 	Maxitem = 2;
@@ -8314,8 +8314,8 @@ MI_ZOMBIGER4
 	DropKind(IK3_BOW, 56, 63);
 	DropKind(IK3_YOYO, 56, 63);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -8357,7 +8357,7 @@ MI_ZOMBIGER4
    	}               
 }
 
-//±Ø´Ü »ç³É¿ë ¸ó½ºÅÍ
+//ï¿½Ø´ï¿½ ï¿½ï¿½É¿ï¿½ ï¿½ï¿½ï¿½ï¿½
 
 MI_FLYBAT1
 {
@@ -8521,8 +8521,8 @@ MI_FLYBAT4
 	DropKind(IK3_BOW, 19, 26);
 	DropKind(IK3_YOYO, 19, 26);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -8723,8 +8723,8 @@ MI_BUCROW4
 	DropKind(IK3_BOW, 31, 38);
 	DropKind(IK3_YOYO, 31, 38);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -8935,8 +8935,8 @@ MI_SCOPICON4
 	DropKind(IK3_BOW, 41, 48);
 	DropKind(IK3_YOYO, 41, 48);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -9150,8 +9150,8 @@ MI_TRANGFOMA4
 	DropKind(IK3_BOW, 49, 56);
 	DropKind(IK3_YOYO, 49, 56);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -9219,7 +9219,7 @@ MI_CLOCKWORK1
 
 	
         DropItem(II_ARM_ARM_SHI_RUKENSHIA, 300000000, 0, 1);         
-        DropItem(II_ARM_ARM_SHI_TOEFFIN, 300000000, 0, 1); //(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+        DropItem(II_ARM_ARM_SHI_TOEFFIN, 300000000, 0, 1); //(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
         DropItem(II_ARM_ARM_SHI_TOEFFIN, 300000000, 0, 1);            
         DropItem(II_ARM_ARM_SHI_CATEPO, 300000000, 0, 1); 
 
@@ -9290,9 +9290,9 @@ MI_CLOCKWORK1
 }
 
 
-// ´ÙÄÜ¼¼¼Ç3¿ë ¸ó½ºÅÍ ¾ÆÀÌÅÛ ¸®½ºÆù
+// ï¿½ï¿½ï¿½Ü¼ï¿½ï¿½ï¿½3ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 
-MI_GRRR1	// ±×¸£¸ª
+MI_GRRR1	// ï¿½×¸ï¿½ï¿½ï¿½
 {
 	Maxitem = 2;
 	DropGold(81, 118);
@@ -9461,8 +9461,8 @@ MI_GRRR4
 	DropKind(IK3_THSWD, 80, 95);
 	DropKind(IK3_THAXE, 80, 95);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -9505,6 +9505,7 @@ MI_GRRR4
 		    }	
    	}               
 }
+}
 MI_KRRR
 {
 	Maxitem = 25;
@@ -9513,148 +9514,148 @@ MI_KRRR
 	DropItem(II_GEN_MAT_ORICHALCUM01, 7500000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 28880000, 0, 1);
 
-        DropItem(II_GEN_GEM_GEM_POPORAM, 1800000000, 0, 1);		//	Æ÷Æ÷¶÷
-	DropItem(II_GEN_GEM_GEM_SLAIN, 1800000000, 0, 1);		//	½½·¹ÀÎ
-	DropItem(II_GEN_GEM_GEM_TARINROOT, 1800000000, 0, 1);		//	Å¸¸°»Ñ¸®
-	DropItem(II_GEN_GEM_GEM_STARSTONE, 1800000000, 0, 1);		//	º°¼®
-	DropItem(II_GEN_GEM_GEM_GOLDENWING, 1800000000, 0, 1);		//	È²±Ý³¯°³
-	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ºí·çÇã´Ï
-	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	¹Ì¾ÆÀÇ ÀÎÇü
-	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	¿­È­¼º³É
-	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«µå¸°
-	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ÇÜ¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	±â±Û·Àµå
-	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	¿ùÀå¼®
-	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	º¸¿ì¹êµå
-	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	´ýºí¸µ
-	DropItem(II_GEN_GEM_GEM_KALIN, 1800000000, 0, 1);		//	Ä®¸°ºê·ÎÂî
-	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 1800000000, 0, 1);		//	Å¬·°ÇÏÆ®
-	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 1800000000, 0, 1);		//	Åù¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 1800000000, 0, 1);		//	È²±ÝÁÖ¸Ô
-	DropItem(II_GEN_GEM_GEM_ORBRIN, 1800000000, 0, 1);		//	¿Àºê¸°
-	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 1800000000, 0, 1);		//	È²±ÝÄÅ
+        DropItem(II_GEN_GEM_GEM_POPORAM, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_SLAIN, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_TARINROOT, 1800000000, 0, 1);		//	Å¸ï¿½ï¿½ï¿½Ñ¸ï¿½
+	DropItem(II_GEN_GEM_GEM_STARSTONE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENWING, 1800000000, 0, 1);		//	È²ï¿½Ý³ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	ï¿½ï¿½È­ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«ï¿½å¸°
+	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ï¿½Ü¸ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	ï¿½ï¿½Û·ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½å¼®
+	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_KALIN, 1800000000, 0, 1);		//	Ä®ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 1800000000, 0, 1);		//	Å¬ï¿½ï¿½ï¿½ï¿½Æ®
+	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 1800000000, 0, 1);		//	È²ï¿½ï¿½ï¿½Ö¸ï¿½
+	DropItem(II_GEN_GEM_GEM_ORBRIN, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ê¸°
+	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 1800000000, 0, 1);		//	È²ï¿½ï¿½ï¿½ï¿½
 
-	DropItem(II_GEN_MAT_ELE_CANDLE, 14000000, 0, 1);		//	Äµµé Ä«µå
-	DropItem(II_GEN_MAT_ELE_RAIN, 14000000, 0, 1);			//	·¹ÀÎ Ä«µå
-	DropItem(II_GEN_MAT_ELE_BREEZE, 14000000, 0, 1);		//	ºê¸®Áî Ä«µå
-	DropItem(II_GEN_MAT_ELE_SPARK, 14000000, 0, 1);		        //	½ºÆÄÅ© Ä«µå
-        DropItem(II_GEN_MAT_ELE_SAND, 14000000, 0, 1);                  //      ½Úµå Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 10000000, 0, 1);		        //	ÅäÄ¡ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 10000000, 0, 1);			//	·¹ÀÌÅ© Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 10000000, 0, 1);		//	º¼Å×ÀÌÁö Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 10000000, 0, 1);		        //	½ºÅæ Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 10000000, 0, 1);			//	°ÔÀÏ Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 5000000, 0, 1);		        //	ÇÃ·¹ÀÓ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 5000000, 0, 1);		        //	¸®¹ö Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 5000000, 0, 1);		//	Á¦³Ê·¹ÀÌÅÍ Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 5000000, 0, 1);			//	µ¥ÀúÆ® Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 5000000, 0, 1);			//	½ÎÀÌÅ¬·Ð Ä«µå
+	DropItem(II_GEN_MAT_ELE_CANDLE, 14000000, 0, 1);		//	Äµï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RAIN, 14000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_BREEZE, 14000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_SPARK, 14000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+        DropItem(II_GEN_MAT_ELE_SAND, 14000000, 0, 1);                  //      ï¿½Úµï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 10000000, 0, 1);		        //	ï¿½ï¿½Ä¡ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 10000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 10000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 10000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 10000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 5000000, 0, 1);		        //	ï¿½Ã·ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 5000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 5000000, 0, 1);		//	ï¿½ï¿½ï¿½Ê·ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 5000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Æ® Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 5000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ Ä«ï¿½ï¿½
 
-	DropItem(II_WEA_SWO_CLIP, 50000000, 0, 1);			//	Å¬¸³¼Òµå
-	DropItem(II_WEA_SWO_TAO, 45000000, 0, 1);			//	Å¸¿À¼Òµå
-	DropItem(II_WEA_SWO_SEPAL, 35000000, 0, 1);			//	¼¼ÆÞ¼Òµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_WAN_RUBY, 50000000, 0, 1);			//	·çºñ¿Ïµå
-	DropItem(II_WEA_WAN_KALIS, 45000000, 0, 1);			//	Ä®¸®½º¿Ïµå
-	DropItem(II_WEA_WAN_POLY, 35000000, 0, 1);			//	Æú¸®¿Ïµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_CHEE_SAYRAM, 50000000, 0, 1);			//	¼¼ÀÌ¶÷½ºÆ½
-	DropItem(II_WEA_CHEE_SAINT, 45000000, 0, 1);			//	¼¼ÀÎÆ®½ºÆ½
-	DropItem(II_WEA_CHEE_FLURY, 35000000, 0, 1);			//	ÇÃ·¯¸®½ºÆ½(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_AXE_DRONE, 50000000, 0, 1);			//	µå·Ð¿¢½º
-	DropItem(II_WEA_AXE_PROEM, 45000000, 0, 1);			//	ÇÁ·Î¿¥¿¢½º
-	DropItem(II_WEA_AXE_CORIN, 35000000, 0, 1);			//	ÄÚ¸°¿¢½º(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_STA_ADDSELF, 50000000, 0, 1);			//	¾Öµå¼¿ÇÁ½ºÅÂÇÁ
-	DropItem(II_WEA_STA_SIGN, 45000000, 0, 1);			//	½ÎÀÎ½ºÅÂÇÁ
-	DropItem(II_WEA_STA_IGNIS, 35000000, 0, 1);			//	ÀÌ±×´Ï½º½ºÆÐÇÁ(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_KNU_SIDE, 50000000, 0, 1);			//	»çÀÌµå³ÊÅ¬
-	DropItem(II_WEA_KNU_TALIN, 45000000, 0, 1);			//	Å»¸°³ÊÅ¬
-	DropItem(II_WEA_KNU_RIGOR, 35000000, 0, 1);			//	¸®°Å³ÊÅ¬(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_YOY_EMPORE, 50000000, 0, 1);			//	¿¥Æ÷·¯
-	DropItem(II_WEA_YOY_DICEIN, 45000000, 0, 1);			//	µð¼¼ÀÎ
-	DropItem(II_WEA_YOY_MIRAGL, 35000000, 0, 1);			//      ¹Ì¶óÁñ(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_BOW_REDIAN, 50000000, 0, 1);			//	·¹µð¾Æ³Ê º¸¿ì
-        DropItem(II_WEA_BOW_CRISTI, 45000000, 0, 1);			//	Å©¸®½ºÆ¼¾Æ º¸¿ì
-	DropItem(II_WEA_BOW_IRUN  , 35000000, 0, 1);			//	¾ÆÀÌ·éº¸¿ì
+	DropItem(II_WEA_SWO_CLIP, 50000000, 0, 1);			//	Å¬ï¿½ï¿½ï¿½Òµï¿½
+	DropItem(II_WEA_SWO_TAO, 45000000, 0, 1);			//	Å¸ï¿½ï¿½ï¿½Òµï¿½
+	DropItem(II_WEA_SWO_SEPAL, 35000000, 0, 1);			//	ï¿½ï¿½ï¿½Þ¼Òµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_WAN_RUBY, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_WAN_KALIS, 45000000, 0, 1);			//	Ä®ï¿½ï¿½ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_WAN_POLY, 35000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ï¿½Ïµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_CHEE_SAYRAM, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½Ì¶ï¿½ï¿½ï¿½Æ½
+	DropItem(II_WEA_CHEE_SAINT, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½Æ½
+	DropItem(II_WEA_CHEE_FLURY, 35000000, 0, 1);			//	ï¿½Ã·ï¿½ï¿½ï¿½ï¿½ï¿½Æ½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_AXE_DRONE, 50000000, 0, 1);			//	ï¿½ï¿½Ð¿ï¿½ï¿½ï¿½
+	DropItem(II_WEA_AXE_PROEM, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½Î¿ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_AXE_CORIN, 35000000, 0, 1);			//	ï¿½Ú¸ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_STA_ADDSELF, 50000000, 0, 1);			//	ï¿½Öµå¼¿ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_SIGN, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½Î½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_IGNIS, 35000000, 0, 1);			//	ï¿½Ì±×´Ï½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_KNU_SIDE, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½Ìµï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_TALIN, 45000000, 0, 1);			//	Å»ï¿½ï¿½ï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_RIGOR, 35000000, 0, 1);			//	ï¿½ï¿½ï¿½Å³ï¿½Å¬(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_YOY_EMPORE, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_YOY_DICEIN, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_YOY_MIRAGL, 35000000, 0, 1);			//      ï¿½Ì¶ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_BOW_REDIAN, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Æ³ï¿½ ï¿½ï¿½ï¿½ï¿½
+        DropItem(II_WEA_BOW_CRISTI, 45000000, 0, 1);			//	Å©ï¿½ï¿½ï¿½ï¿½Æ¼ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_BOW_IRUN  , 35000000, 0, 1);			//	ï¿½ï¿½ï¿½Ì·éº¸ï¿½ï¿½
 
-	DropItem(II_ARM_M_MER_HELMET0201, 70000000, 0, 1);		//	Æ÷Ãó Çï¸ä
-	DropItem(II_ARM_M_MER_SUIT0201, 60000000, 0, 1);		//	Æ÷Ãó ½´Æ®
-	DropItem(II_ARM_M_MER_GAUNTLET0201, 70000000, 0, 1);		//	Æ÷Ãó °ÇÆ²·¿
-	DropItem(II_ARM_M_MER_BOOTS0201, 70000000, 0, 1);		//	Æ÷Ãó ºÎÃ÷
-	DropItem(II_ARM_M_MER_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_HELMET0201, 70000000, 0, 1);		//	Æ÷½º Çï¸ä
-	DropItem(II_ARM_F_MER_SUIT0201, 60000000, 0, 1);		//	Æ÷½º ½´Æ®
-	DropItem(II_ARM_F_MER_GAUNTLET0201, 70000000, 0, 1);		//	Æ÷½º °ÇÆ²·¿
-	DropItem(II_ARM_F_MER_BOOTS0201, 70000000, 0, 1);		//	Æ÷½º ºÎÃ÷
-	DropItem(II_ARM_F_MER_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_HELMET0201, 70000000, 0, 1);		//	°ÔÀÏ Çï¸ä
-	DropItem(II_ARM_M_ASS_SUIT0201, 60000000, 0, 1);		//	°ÔÀÏ ½´Æ®
-	DropItem(II_ARM_M_ASS_GAUNTLET0201, 70000000, 0, 1);		//	°ÔÀÏ °ÇÆ²·¿
-	DropItem(II_ARM_M_ASS_BOOTS0201, 70000000, 0, 1);		//	°ÔÀÏ ºÎÃ÷
-	DropItem(II_ARM_M_ASS_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_HELMET0201, 70000000, 0, 1);		//	¾ÆÀÌ¸®½º Çï¸ä
-	DropItem(II_ARM_F_ASS_SUIT0201, 60000000, 0, 1);		//	¾ÆÀÌ¸®½º ½´Æ®
-	DropItem(II_ARM_F_ASS_GAUNTLET0201, 70000000, 0, 1);		//	¾ÆÀÌ¸®½º °ÇÆ²·¿
-	DropItem(II_ARM_F_ASS_BOOTS0201, 70000000, 0, 1);		//	¾ÆÀÌ¸®½º ºÎÃ÷
-	DropItem(II_ARM_F_ASS_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_HELMET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_SUIT0201, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_BOOTS0201, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_HELMET0201, 70000000, 0, 1);		//	¹ÙÀÎµð¿¢ Çï¸ä
-	DropItem(II_ARM_F_ACR_SUIT0201, 60000000, 0, 1);		//	¹ÙÀÎµð¿¢ ½´Æ®
-	DropItem(II_ARM_F_ACR_GAUNTLET0201, 70000000, 0, 1);		//	¹ÙÀÎµð¿¢ °ÇÆ²·¿
-	DropItem(II_ARM_F_ACR_BOOTS0201, 70000000, 0, 1);		//	¹ÙÀÎµð¿¢ ºÎÃ÷
-	DropItem(II_ARM_F_ACR_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_HELMET0201, 70000000, 0, 1);		//	¼ÅÇÃ Çï¸ä
-	DropItem(II_ARM_M_MAG_SUIT0201, 60000000, 0, 1);		//	¼ÅÇÃ ½´Æ®
-	DropItem(II_ARM_M_MAG_GAUNTLET0201, 70000000, 0, 1);		//	¼ÅÇÃ °ÇÆ²·¿
-	DropItem(II_ARM_M_MAG_BOOTS0201, 70000000, 0, 1);		//	¼ÅÇÃ ºÎÃ÷
-	DropItem(II_ARM_M_MAG_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_HELMET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_SUIT0301, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_GAUNTLET0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_BOOTS0301, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_HELMET0201, 70000000, 0, 1);		//	Á¦ÀÌ Çï¸ä
-	DropItem(II_ARM_F_MAG_SUIT0201, 60000000, 0, 1);		//	Á¦ÀÌ ½´Æ®
-	DropItem(II_ARM_F_MAG_GAUNTLET0201, 70000000, 0, 1);		//	Á¦ÀÌ °ÇÆ²·¿
-	DropItem(II_ARM_F_MAG_BOOTS0201, 70000000, 0, 1);		//	Á¦ÀÌ ºÎÃ÷
+	DropItem(II_ARM_M_MER_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MER_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MER_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MER_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MER_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_ASS_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_ASS_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_ASS_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_ASS_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì¸ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì¸ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_ASS_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì¸ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Ì¸ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ASS_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_HELMET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_SUIT0201, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_GAUNTLET0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_BOOTS0201, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Îµï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ACR_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½Îµï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_ACR_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Îµï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_ACR_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½Îµï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_ACR_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MAG_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_HELMET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_SUIT0301, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_GAUNTLET0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_BOOTS0301, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_HELMET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_SUIT0201, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MAG_GAUNTLET0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_BOOTS0201, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 
-	DropItem(II_ARM_ARM_SHI_GYRO, 20000000, 0, 1);		        //	ÀÚÀÌ·Î ½Çµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_ARM_SHI_GYRO, 15000000, 0, 1);		        //	ÀÚÀÌ·Î ½Çµå
+	DropItem(II_ARM_ARM_SHI_GYRO, 20000000, 0, 1);		        //	ï¿½ï¿½ï¿½Ì·ï¿½ ï¿½Çµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_ARM_SHI_GYRO, 15000000, 0, 1);		        //	ï¿½ï¿½ï¿½Ì·ï¿½ ï¿½Çµï¿½
 
-	DropItem(II_GEN_FOO_INS_BREAD, 3000000000, 0, 1);		//	½Ä»§
-	DropItem(II_GEN_FOO_ICE_FRUITJUICE, 3000000000, 0, 1);		//	°úÀÏÁÖ½º
-	DropItem(II_GEN_FOO_COO_FISHSOUP, 3000000000, 0, 1);		//	»ý¼±½ºÇÁ
-	DropItem(II_GEN_FOO_COO_SAUSAGECASSEROLE, 3000000000, 0, 1);	//	¼Ò½ÃÁöÀü°ñ
-	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 4±Þ
-	DropItem(II_GEN_REF_REF_FIFTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 5±Þ
-	DropItem(II_GEN_REF_REF_SIXTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 6±Þ
-	DropItem(II_GEN_POT_DRI_VITAL400, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 400
-	DropItem(II_GEN_POT_DRI_VITAL500, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 500
-	DropItem(II_GEN_POT_DRI_VITAL600, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 600
-	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ÇØµ¶¾à
-	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	Áúº´Ä¡·á¾à
+	DropItem(II_GEN_FOO_INS_BREAD, 3000000000, 0, 1);		//	ï¿½Ä»ï¿½
+	DropItem(II_GEN_FOO_ICE_FRUITJUICE, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½Ö½ï¿½
+	DropItem(II_GEN_FOO_COO_FISHSOUP, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_FOO_COO_SAUSAGECASSEROLE, 3000000000, 0, 1);	//	ï¿½Ò½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 4ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_FIFTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 5ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_SIXTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 6ï¿½ï¿½
+	DropItem(II_GEN_POT_DRI_VITAL400, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 400
+	DropItem(II_GEN_POT_DRI_VITAL500, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 500
+	DropItem(II_GEN_POT_DRI_VITAL600, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 600
+	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ï¿½Øµï¿½ï¿½ï¿½
+	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Ä¡ï¿½ï¿½ï¿½
 
 	m_nAttackFirstRange = 10;
 	
@@ -9687,148 +9688,148 @@ MI_MUSHMOOT
 	DropItem(II_GEN_MAT_ORICHALCUM01, 7500000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 28880000, 0, 1);
 
-	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ºí·çÇã´Ï
-	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	¹Ì¾ÆÀÇ ÀÎÇü
-	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	¿­È­¼º³É
-	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«µå¸°
-	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ÇÜ¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	±â±Û·Àµå
-	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	¿ùÀå¼®
-	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	º¸¿ì¹êµå
-	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	´ýºí¸µ
-	DropItem(II_GEN_GEM_GEM_KALIN, 1800000000, 0, 1);		//	Ä®¸°ºê·ÎÂî
-	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 1800000000, 0, 1);		//	Å¬·°ÇÏÆ®
-	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 1800000000, 0, 1);		//	Åù¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 1800000000, 0, 1);		//	È²±ÝÁÖ¸Ô
-	DropItem(II_GEN_GEM_GEM_ORBRIN, 1800000000, 0, 1);		//	¿Àºê¸°
-	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 1800000000, 0, 1);		//	È²±ÝÄÅ
-	DropItem(II_GEN_GEM_GEM_TOMA, 1800000000, 0, 1);		//	Åä¸¶
-	DropItem(II_GEN_GEM_GEM_STEAMTEAR, 1800000000, 0, 1);		//	½ºÆÀÆ¼¾î
-	DropItem(II_GEN_GEM_GEM_KNIGHTLER, 1800000000, 0, 1);		//	³ªÀÌÆ²·¯
-	DropItem(II_GEN_GEM_GEM_WHEESHOE, 1800000000, 0, 1);		//	ÈÙ½´
-	DropItem(II_GEN_GEM_GEM_DROIL, 1800000000, 0, 1);		//	µå·ÎÀÏ
+	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MIADOLL, 1800000000, 0, 1);		//	ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 1800000000, 0, 1);	//	ï¿½ï¿½È­ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CARDRIN, 1800000000, 0, 1);		//	Ä«ï¿½å¸°
+	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 1800000000, 0, 1);		//	ï¿½Ü¸ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 1800000000, 0, 1);		//	ï¿½ï¿½Û·ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MOONSTONE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½å¼®
+	DropItem(II_GEN_GEM_GEM_BOBAND, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_DUMBLING, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_KALIN, 1800000000, 0, 1);		//	Ä®ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 1800000000, 0, 1);		//	Å¬ï¿½ï¿½ï¿½ï¿½Æ®
+	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 1800000000, 0, 1);		//	È²ï¿½ï¿½ï¿½Ö¸ï¿½
+	DropItem(II_GEN_GEM_GEM_ORBRIN, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ê¸°
+	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 1800000000, 0, 1);		//	È²ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_TOMA, 1800000000, 0, 1);		//	ï¿½ä¸¶
+	DropItem(II_GEN_GEM_GEM_STEAMTEAR, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Æ¼ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_KNIGHTLER, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_WHEESHOE, 1800000000, 0, 1);		//	ï¿½Ù½ï¿½
+	DropItem(II_GEN_GEM_GEM_DROIL, 1800000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½
 
-	DropItem(II_GEN_MAT_ELE_CANDLE, 15000000, 0, 1);		//	Äµµé Ä«µå
-	DropItem(II_GEN_MAT_ELE_RAIN, 15000000, 0, 1);			//	·¹ÀÎ Ä«µå
-	DropItem(II_GEN_MAT_ELE_BREEZE, 15000000, 0, 1);		//	ºê¸®Áî Ä«µå
-	DropItem(II_GEN_MAT_ELE_SPARK, 15000000, 0, 1);		        //	½ºÆÄÅ© Ä«µå
-        DropItem(II_GEN_MAT_ELE_SAND, 15000000, 0, 1);                  //      ½Úµå Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 13000000, 0, 1);		        //	ÅäÄ¡ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 13000000, 0, 1);			//	·¹ÀÌÅ© Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 13000000, 0, 1);		//	º¼Å×ÀÌÁö Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 13000000, 0, 1);		        //	½ºÅæ Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 13000000, 0, 1);			//	°ÔÀÏ Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 10000000, 0, 1);		        //	ÇÃ·¹ÀÓ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 10000000, 0, 1);		        //	¸®¹ö Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 10000000, 0, 1);		//	Á¦³Ê·¹ÀÌÅÍ Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 10000000, 0, 1);		//	µ¥ÀúÆ® Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 10000000, 0, 1);		//	½ÎÀÌÅ¬·Ð Ä«µå
+	DropItem(II_GEN_MAT_ELE_CANDLE, 15000000, 0, 1);		//	Äµï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RAIN, 15000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_BREEZE, 15000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_SPARK, 15000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+        DropItem(II_GEN_MAT_ELE_SAND, 15000000, 0, 1);                  //      ï¿½Úµï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 13000000, 0, 1);		        //	ï¿½ï¿½Ä¡ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 13000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 13000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 13000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 13000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 10000000, 0, 1);		        //	ï¿½Ã·ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 10000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 10000000, 0, 1);		//	ï¿½ï¿½ï¿½Ê·ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 10000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Æ® Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 10000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ Ä«ï¿½ï¿½
 
-	DropItem(II_WEA_SWO_CYLOS, 50000000, 0, 1);			//	½Ç·Î½º¼Òµå
-	DropItem(II_WEA_SWO_INVADER, 45000000, 0, 1);			//	ÀÎº£ÀÌ´õ¼Òµå
-	DropItem(II_WEA_SWO_STITCH, 35000000, 0, 1);		        //      ½ºÆ¼Ä¡¼Òµå
-	DropItem(II_WEA_WAN_MEKERHILL, 50000000, 0, 1);		        //	¸ÞÄ¿Èú¿Ïµå
-	DropItem(II_WEA_WAN_NAZ, 45000000, 0, 1);			//	³ªÁî¿Ïµå
-	DropItem(II_WEA_WAN_ZEREM, 35000000, 0, 1);		        //      Á¦·½¿Ïµå
-	DropItem(II_WEA_CHEE_NINEGALE, 50000000, 0, 1);	         	//	³ªÀÎ°ÔÀÏ½ºÆ½
-	DropItem(II_WEA_CHEE_MIRTH, 45000000, 0, 1);			//	¸Ó¾²½ºÆ½
-	DropItem(II_WEA_CHEE_SIZZLE, 35000000, 0, 1);		        //      ½ÃÁñ½ºÆ½
-	DropItem(II_WEA_AXE_CROW, 50000000, 0, 1);			//	Å©·Î¿ì¿¢½º
-	DropItem(II_WEA_AXE_RAPTOR, 45000000, 0, 1);			//	·¦ÅÍ¿¢½º
-	DropItem(II_WEA_AXE_BERK, 35000000, 0, 1);		        //      ¹öÅ©¿¢½º
-	DropItem(II_WEA_STA_TEBA, 50000000, 0, 1);			//	Å×¹Ù½ºÅÂÇÁ
-	DropItem(II_WEA_STA_SLINE, 45000000, 0, 1);			//	½½¶óÀÎ½ºÅÂÇÁ
-	DropItem(II_WEA_STA_STARWHEEL, 35000000, 0, 1);		        //      ½ºÅ¸ÈÙ½ºÅÂÇÁ
-	DropItem(II_WEA_KNU_RAMPART, 50000000, 0, 1);			//	·¥ÆÄÆ®³ÊÅ¬
-	DropItem(II_WEA_KNU_REVENANT, 45000000, 0, 1);			//	·¹¹ö³ÍÆ®³ÊÅ¬
-	DropItem(II_WEA_KNU_MARVEL, 35000000, 0, 1);		        //      ¸¶º§³ÊÅ¬
-	DropItem(II_WEA_YOY_RIDENE, 50000000, 0, 1);			//	¶óÀÌµ¥³Ê
-	DropItem(II_WEA_YOY_FIREE, 45000000, 0, 1);			//	ÆÄÀÌ¾î¸®
-	DropItem(II_WEA_YOY_IMMOTE, 35000000, 0, 1);		        //      ÀÌ¸ðÆ®
-	DropItem(II_WEA_BOW_REFOME, 50000000, 0, 1);			//      ·¹Æ÷¸ÞÆ¼º¸¿ì
-	DropItem(II_WEA_BOW_CURUSI, 45000000, 0, 1);			//      Å©·çÀú º¸¿ì(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_WEA_BOW_SIGGER, 35000000, 0, 1);		        //      ½ÃÀúÁîº¸¿ì
+	DropItem(II_WEA_SWO_CYLOS, 50000000, 0, 1);			//	ï¿½Ç·Î½ï¿½ï¿½Òµï¿½
+	DropItem(II_WEA_SWO_INVADER, 45000000, 0, 1);			//	ï¿½Îºï¿½ï¿½Ì´ï¿½ï¿½Òµï¿½
+	DropItem(II_WEA_SWO_STITCH, 35000000, 0, 1);		        //      ï¿½ï¿½Æ¼Ä¡ï¿½Òµï¿½
+	DropItem(II_WEA_WAN_MEKERHILL, 50000000, 0, 1);		        //	ï¿½ï¿½Ä¿ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_WAN_NAZ, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_WAN_ZEREM, 35000000, 0, 1);		        //      ï¿½ï¿½ï¿½ï¿½ï¿½Ïµï¿½
+	DropItem(II_WEA_CHEE_NINEGALE, 50000000, 0, 1);	         	//	ï¿½ï¿½ï¿½Î°ï¿½ï¿½Ï½ï¿½Æ½
+	DropItem(II_WEA_CHEE_MIRTH, 45000000, 0, 1);			//	ï¿½Ó¾ï¿½ï¿½ï¿½Æ½
+	DropItem(II_WEA_CHEE_SIZZLE, 35000000, 0, 1);		        //      ï¿½ï¿½ï¿½ï¿½Æ½
+	DropItem(II_WEA_AXE_CROW, 50000000, 0, 1);			//	Å©ï¿½Î¿ì¿¢ï¿½ï¿½
+	DropItem(II_WEA_AXE_RAPTOR, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½Í¿ï¿½ï¿½ï¿½
+	DropItem(II_WEA_AXE_BERK, 35000000, 0, 1);		        //      ï¿½ï¿½Å©ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_TEBA, 50000000, 0, 1);			//	ï¿½×¹Ù½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_SLINE, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ï¿½Î½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_STA_STARWHEEL, 35000000, 0, 1);		        //      ï¿½ï¿½Å¸ï¿½Ù½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_KNU_RAMPART, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_REVENANT, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ®ï¿½ï¿½Å¬
+	DropItem(II_WEA_KNU_MARVEL, 35000000, 0, 1);		        //      ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Å¬
+	DropItem(II_WEA_YOY_RIDENE, 50000000, 0, 1);			//	ï¿½ï¿½ï¿½Ìµï¿½ï¿½ï¿½
+	DropItem(II_WEA_YOY_FIREE, 45000000, 0, 1);			//	ï¿½ï¿½ï¿½Ì¾î¸®
+	DropItem(II_WEA_YOY_IMMOTE, 35000000, 0, 1);		        //      ï¿½Ì¸ï¿½Æ®
+	DropItem(II_WEA_BOW_REFOME, 50000000, 0, 1);			//      ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ¼ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_WEA_BOW_CURUSI, 45000000, 0, 1);			//      Å©ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_WEA_BOW_SIGGER, 35000000, 0, 1);		        //      ï¿½ï¿½ï¿½ï¿½ï¿½îº¸ï¿½ï¿½
 
-	DropItem(II_ARM_M_MER_HELMET0301, 70000000, 0, 1);		//	¹ß·¯ Çï¸ä
-	DropItem(II_ARM_M_MER_SUIT0301, 60000000, 0, 1);		//	¹ß·¯ ½´Æ®
-	DropItem(II_ARM_M_MER_GAUNTLET0301, 70000000, 0, 1);		//	¹ß·¯ °ÇÆ²·¿
-	DropItem(II_ARM_M_MER_BOOTS0301, 70000000, 0, 1);		//	¹ß·¯ ºÎÃ÷
-	DropItem(II_ARM_M_MER_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MER_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_HELMET0301, 70000000, 0, 1);		//	±×·¹ÀÌ½º Çï¸ä
-	DropItem(II_ARM_F_MER_SUIT0301, 60000000, 0, 1);		//	±×·¹ÀÌ½º ½´Æ®
-	DropItem(II_ARM_F_MER_GAUNTLET0301, 70000000, 0, 1);		//	±×·¹ÀÌ½º °ÇÆ²·¿
-	DropItem(II_ARM_F_MER_BOOTS0301, 70000000, 0, 1);		//	±×·¹ÀÌ½º ºÎÃ÷
-	DropItem(II_ARM_F_MER_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MER_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_HELMET0301, 70000000, 0, 1);		//	ÄÚ¸µ Çï¸ä
-	DropItem(II_ARM_M_MAG_SUIT0301, 60000000, 0, 1);		//	ÄÚ¸µ ½´Æ®
-	DropItem(II_ARM_M_MAG_GAUNTLET0301, 70000000, 0, 1);		//	ÄÚ¸µ °ÇÆ²·¿
-	DropItem(II_ARM_M_MAG_BOOTS0301, 70000000, 0, 1);		//	ÄÚ¸µ ºÎÃ÷
-	DropItem(II_ARM_M_MAG_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_MAG_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_HELMET0301, 70000000, 0, 1);		//	¸¶ºí Çï¸ä
-	DropItem(II_ARM_F_MAG_SUIT0301, 60000000, 0, 1);		//	¸¶ºí ½´Æ®
-	DropItem(II_ARM_F_MAG_GAUNTLET0301, 70000000, 0, 1);		//	¸¶ºí °ÇÆ²·¿
-	DropItem(II_ARM_F_MAG_BOOTS0301, 70000000, 0, 1);		//	¸¶ºí ºÎÃ÷
-	DropItem(II_ARM_F_MAG_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_MAG_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-        DropItem(II_ARM_F_MAG_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_M_MER_HELMET0301, 70000000, 0, 1);		//	ï¿½ß·ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_SUIT0301, 60000000, 0, 1);		//	ï¿½ß·ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MER_GAUNTLET0301, 70000000, 0, 1);		//	ï¿½ß·ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MER_BOOTS0301, 70000000, 0, 1);		//	ï¿½ß·ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MER_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MER_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_HELMET0301, 70000000, 0, 1);		//	ï¿½×·ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_SUIT0301, 60000000, 0, 1);		//	ï¿½×·ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MER_GAUNTLET0301, 70000000, 0, 1);		//	ï¿½×·ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MER_BOOTS0301, 70000000, 0, 1);		//	ï¿½×·ï¿½ï¿½Ì½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MER_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MER_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_HELMET0301, 70000000, 0, 1);		//	ï¿½Ú¸ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_SUIT0301, 60000000, 0, 1);		//	ï¿½Ú¸ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_M_MAG_GAUNTLET0301, 70000000, 0, 1);		//	ï¿½Ú¸ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_BOOTS0301, 70000000, 0, 1);		//	ï¿½Ú¸ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_M_MAG_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_MAG_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_HELMET0301, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_SUIT0301, 60000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ®
+	DropItem(II_ARM_F_MAG_GAUNTLET0301, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½Æ²ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_BOOTS0301, 70000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_ARM_F_MAG_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_MAG_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+        DropItem(II_ARM_F_MAG_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 	DropItem(II_ARM_M_ASS_HELMET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_M_ASS_SUIT0301, 60000000, 0, 1);		//	
 	DropItem(II_ARM_M_ASS_GAUNTLET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_M_ASS_BOOTS0301, 70000000, 0, 1);		//	
-	DropItem(II_ARM_M_ASS_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ASS_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_M_ASS_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ASS_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 	DropItem(II_ARM_F_ASS_HELMET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_F_ASS_SUIT0301, 60000000, 0, 1);		//	
 	DropItem(II_ARM_F_ASS_GAUNTLET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_F_ASS_BOOTS0301, 70000000, 0, 1);		//	
-	DropItem(II_ARM_F_ASS_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ASS_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_F_ASS_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ASS_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 	DropItem(II_ARM_M_ACR_HELMET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_M_ACR_SUIT0301, 60000000, 0, 1);		//	
 	DropItem(II_ARM_M_ACR_GAUNTLET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_M_ACR_BOOTS0301, 70000000, 0, 1);		//	
-	DropItem(II_ARM_M_ACR_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_M_ACR_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_M_ACR_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_M_ACR_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 	DropItem(II_ARM_F_ACR_HELMET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_F_ACR_SUIT0301, 60000000, 0, 1);		//	
 	DropItem(II_ARM_F_ACR_GAUNTLET0301, 70000000, 0, 1);		//	
 	DropItem(II_ARM_F_ACR_BOOTS0301, 70000000, 0, 1);		//	
-	DropItem(II_ARM_F_ACR_HELMET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_SUIT0401, 60000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_GAUNTLET0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
-	DropItem(II_ARM_F_ACR_BOOTS0401, 70000000, 0, 1);		//	(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_F_ACR_HELMET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_SUIT0401, 60000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_GAUNTLET0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
+	DropItem(II_ARM_F_ACR_BOOTS0401, 70000000, 0, 1);		//	(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 
-	DropItem(II_ARM_ARM_SHI_VORTEX, 20000000, 0, 1);	        //	º¸ÅØ½º ½Çµå
-	DropItem(II_ARM_ARM_SHI_PLUS, 15000000, 0, 1);		        //	ÇÃ·¯½º ½Çµå(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+	DropItem(II_ARM_ARM_SHI_VORTEX, 20000000, 0, 1);	        //	ï¿½ï¿½ï¿½Ø½ï¿½ ï¿½Çµï¿½
+	DropItem(II_ARM_ARM_SHI_PLUS, 15000000, 0, 1);		        //	ï¿½Ã·ï¿½ï¿½ï¿½ ï¿½Çµï¿½(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
 
-	DropItem(II_GEN_FOO_COO_FISHSTEW, 3000000000, 0, 1);		//	»ý¼±½ºÆ©
-	DropItem(II_GEN_FOO_ICE_FRUITPARFAIT, 3000000000, 0, 1);	//	°úÀÏÆÄ¸£Æä
-	DropItem(II_GEN_FOO_INS_HODDUK, 3000000000, 0, 1);		//	È£¶±
-	DropItem(II_GEN_FOO_INS_KIMBAP, 3000000000, 0, 1);		//	±è¹ä
-	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 4±Þ
-	DropItem(II_GEN_REF_REF_FIFTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 5±Þ
-	DropItem(II_GEN_REF_REF_SIXTH, 3000000000, 0, 1);		//	¸®ÇÁ·¹¼Å 6±Þ
-	DropItem(II_GEN_POT_DRI_VITAL500, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 500
-	DropItem(II_GEN_POT_DRI_VITAL600, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 600
-	DropItem(II_GEN_POT_DRI_VITAL700, 3000000000, 0, 1);		//	È°·Âµå¸µÅ© 700
-	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ÇØµ¶¾à
-	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	Áúº´Ä¡·á¾à
+	DropItem(II_GEN_FOO_COO_FISHSTEW, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Æ©
+	DropItem(II_GEN_FOO_ICE_FRUITPARFAIT, 3000000000, 0, 1);	//	ï¿½ï¿½ï¿½ï¿½ï¿½Ä¸ï¿½ï¿½ï¿½
+	DropItem(II_GEN_FOO_INS_HODDUK, 3000000000, 0, 1);		//	È£ï¿½ï¿½
+	DropItem(II_GEN_FOO_INS_KIMBAP, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_FOUTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 4ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_FIFTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 5ï¿½ï¿½
+	DropItem(II_GEN_REF_REF_SIXTH, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ 6ï¿½ï¿½
+	DropItem(II_GEN_POT_DRI_VITAL500, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 500
+	DropItem(II_GEN_POT_DRI_VITAL600, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 600
+	DropItem(II_GEN_POT_DRI_VITAL700, 3000000000, 0, 1);		//	È°ï¿½Âµå¸µÅ© 700
+	DropItem(II_GEN_POT_POT_ANTIDOTE, 3000000000, 0, 1);		//	ï¿½Øµï¿½ï¿½ï¿½
+	DropItem(II_GEN_POT_POT_CUREDISEASE, 3000000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½Ä¡ï¿½ï¿½ï¿½
 
 	m_nAttackFirstRange = 10;
 	
@@ -9878,7 +9879,7 @@ MI_SMALL_MUSHPOIE
 }
 
 
-MI_DUMP1	//´ýÇÁ
+MI_DUMP1	//ï¿½ï¿½ï¿½ï¿½
 {
 	Maxitem = 2;
 	DropGold(84, 122);
@@ -10045,8 +10046,8 @@ MI_DUMP4
 	DropKind(IK3_THSWD, 80, 95);
 	DropKind(IK3_THAXE, 80, 95);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -10259,8 +10260,8 @@ MI_NAUTREPY4
 	DropKind(IK3_THSWD, 70, 76);
 	DropKind(IK3_THAXE, 70, 76);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -10473,8 +10474,8 @@ MI_BOO4
 	DropKind(IK3_THSWD, 70, 81);
 	DropKind(IK3_THAXE, 70, 81);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -10686,8 +10687,8 @@ MI_HOPPRE4
 	DropKind(IK3_THSWD, 71, 81);
 	DropKind(IK3_THAXE, 71, 81);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -10909,8 +10910,8 @@ MI_MUSHPOIE4
 	DropItem(II_GEN_FOO_ICE_ICECREAMCAKE, 600000001, 0, 1);
 	DropItem(II_GEN_FOO_ICE_ICECREAMCAKE, 600000001, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -11106,8 +11107,8 @@ MI_IREN4
 	DropKind(IK3_THSWD, 73, 89);
 	DropKind(IK3_THAXE, 73, 89);
 	
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -11317,8 +11318,8 @@ MI_WATANGKA4
 	DropKind(IK3_THSWD, 73, 92);
 	DropKind(IK3_THAXE, 73, 92);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -11527,8 +11528,8 @@ MI_ANTIQUERY4
 	DropKind(IK3_THSWD, 80, 95);
 	DropKind(IK3_THAXE, 80, 95);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -11734,8 +11735,8 @@ MI_LUIA4
 	DropKind(IK3_THSWD, 80, 95);
 	DropKind(IK3_THAXE, 80, 95);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -11945,8 +11946,8 @@ MI_GONGURY4
 	DropKind(IK3_THSWD, 90, 101);
 	DropKind(IK3_THAXE, 90, 101);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -12154,8 +12155,8 @@ MI_SHUHAMMA4
 	DropKind(IK3_THSWD, 80, 101);
 	DropKind(IK3_THAXE, 80, 101);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -12361,8 +12362,8 @@ MI_KERN4
 	DropKind(IK3_THSWD, 90, 104);
 	DropKind(IK3_THAXE, 90, 104);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -12572,8 +12573,8 @@ MI_GLAPHAN4
 	DropKind(IK3_THSWD, 95, 104);
 	DropKind(IK3_THAXE, 95, 104);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -12615,8 +12616,8 @@ MI_GLAPHAN4
 
 }
 
-//½Å±Ô »óÀ§·¹º§ ¸ó½ºÅÍ
-MI_KIMERADON1	//Å°¸Þ¶óµ·
+//ï¿½Å±ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+MI_KIMERADON1	//Å°ï¿½Þ¶ï¿½
 {
 	Maxitem = 2;
 	DropGold(88, 128);
@@ -12811,8 +12812,8 @@ MI_KIMERADON5
 	DropKind(IK3_THSWD, 90, 101);
 	DropKind(IK3_THAXE, 90, 101);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -12848,7 +12849,7 @@ MI_KIMERADON5
    	}               
 }
 
-MI_BEARNUCKY1	// º£¾î³ÊÅ°
+MI_BEARNUCKY1	// ï¿½ï¿½ï¿½ï¿½ï¿½Å°
 {
 	Maxitem = 2;
 	DropGold(92, 134);
@@ -13043,8 +13044,8 @@ MI_BEARNUCKY5
 	DropKind(IK3_THSWD, 80, 101);
 	DropKind(IK3_THAXE, 80, 101);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -13080,7 +13081,7 @@ MI_BEARNUCKY5
    	}               
 }
 
-MI_MUFFRIN1	//¸ÓÇª¸°
+MI_MUFFRIN1	//ï¿½ï¿½Çªï¿½ï¿½
 {
 	Maxitem = 2;
 	DropGold(97, 141);
@@ -13275,8 +13276,8 @@ MI_MUFFRIN6
 	DropKind(IK3_THSWD, 90, 104);
 	DropKind(IK3_THAXE, 90, 104);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -13507,8 +13508,8 @@ MI_POPCRANK5
 	DropKind(IK3_THSWD, 95, 104);
 	DropKind(IK3_THAXE, 95, 104);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -13545,7 +13546,7 @@ MI_POPCRANK5
 }
 
 
-//´øÀü¿ë ¸ó½ºÅÍ
+//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_DUFEFERN1
 {
 	Maxitem = 2;
@@ -13564,8 +13565,8 @@ MI_DUFEFERN1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_RIVER, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 7500000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13613,8 +13614,8 @@ MI_DUFEFERN2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 7500000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13663,8 +13664,8 @@ MI_DUFEFERN3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 	
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -13718,8 +13719,8 @@ MI_DUNYANGNYANG1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13764,8 +13765,8 @@ MI_DUNYANGNYANG2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 	
-	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13814,8 +13815,8 @@ MI_DUNYANGNYANG3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -13863,8 +13864,8 @@ MI_DUBANG1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13911,8 +13912,8 @@ MI_DUBANG2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -13959,8 +13960,8 @@ MI_DUBANG3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -14013,8 +14014,8 @@ MI_WORMVEDUQUE
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 	
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -14066,8 +14067,8 @@ MI_SERUSURIEL
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -14120,8 +14121,8 @@ MI_VICEVEDUQUE
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -14152,7 +14153,7 @@ MI_VICEVEDUQUE
    	}               
 
 }
-//Äù½ºÆ® ¸ó½ºÅÍ ¼³Á¤
+//ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_GUARDMON1
 {
 
@@ -14471,7 +14472,7 @@ MI_KYNSY
    	}   
 }
 
-//ÀÏ¹Ý Äù½ºÆ® ¸ó½ºÅÍ	
+//ï¿½Ï¹ï¿½ ï¿½ï¿½ï¿½ï¿½Æ® ï¿½ï¿½ï¿½ï¿½	
 MI_RBANG1
 {
 
@@ -14616,7 +14617,7 @@ MI_CLOCKS
    	}   
 }
 
-//½Ã³ª¸®¿À Äù½ºÆ®(2Â÷) ¸ó½ºÅÍ	
+//ï¿½Ã³ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½Æ®(2ï¿½ï¿½) ï¿½ï¿½ï¿½ï¿½	
 MI_VIOLMAGICION
 {
 
@@ -14713,7 +14714,7 @@ MI_EMERALDMANTIS
    	}   
 }
 
-//ÀÏ¹Ý Äù½ºÆ®(º¸½ºMob) ¸ó½ºÅÍ	
+//ï¿½Ï¹ï¿½ ï¿½ï¿½ï¿½ï¿½Æ®(ï¿½ï¿½ï¿½ï¿½Mob) ï¿½ï¿½ï¿½ï¿½	
 MI_ORGANIGOR
 {
 
@@ -14786,7 +14787,7 @@ MI_HADESEOR
    	}   
 }
 
-//P.K °ü·Ã °æºñº´ ¹× ¸ó½ºÅÍ ¼¼ÆÃ
+//P.K ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_GUARDIAN
 {
 	
@@ -15353,7 +15354,7 @@ MI_ANTTURTLE
    	}               
 }
 
-//µ¥Ä«³×½º ´øÀü°ü·Ã ¸ó½ºÅÍ
+//ï¿½ï¿½Ä«ï¿½×½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_DU_DKKEAKOON1
 {
 
@@ -15373,8 +15374,8 @@ MI_DU_DKKEAKOON1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 	
-	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -15422,8 +15423,8 @@ MI_DU_DKKEAKOON2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3250000, 0, 1);
@@ -15474,8 +15475,8 @@ MI_DU_DKKEAKOON3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -15523,8 +15524,8 @@ MI_DU_DKKEAKOON4
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -15571,8 +15572,8 @@ MI_DU_DKKEAKOON5
 
 
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -15620,8 +15621,8 @@ MI_DU_DKKEAKOON6
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -15669,8 +15670,8 @@ MI_DU_DKKEAKOON7
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -15718,8 +15719,8 @@ MI_DU_DKKEAKOON8
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -15765,8 +15766,8 @@ MI_DU_DKKEAKOON9
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -15811,8 +15812,8 @@ MI_DU_DKKEAKOON10
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -15861,8 +15862,8 @@ MI_DU_DKKEAKOON11
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -15955,8 +15956,8 @@ MI_DU_DKROACHFL1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -16001,8 +16002,8 @@ MI_DU_DKROACHFL2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
 
@@ -16049,8 +16050,8 @@ MI_DU_DKROACHFL3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -16098,8 +16099,8 @@ MI_DU_DKROACHFL4
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -16231,8 +16232,8 @@ MI_DU_DKTRILLIPY1
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_DESERT, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -16281,8 +16282,8 @@ MI_DU_DKTRILLIPY2
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -16328,8 +16329,8 @@ MI_DU_DKTRILLIPY3
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 	
-	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -16378,8 +16379,8 @@ MI_DU_DKTRILLIPY4
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -16425,8 +16426,8 @@ MI_DU_DKTRILLIPY5
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //¼Ó¼º Ä«µå3 0.025%
-	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //¼Ó¼º Ä«µå2 0.05%
+	DropItem(II_GEN_MAT_ELE_FLAME, 2812500, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.025%
+	DropItem(II_GEN_MAT_ELE_FLAME, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.05%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3000000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 3050000, 0, 1);
@@ -16473,8 +16474,8 @@ MI_DU_DKTRILLIPY6
 	DropKind(IK3_BOW, 6, 6);
 	DropKind(IK3_YOYO, 6, 6);
 
-	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //¼Ó¼º Ä«µå3 0.25%
-	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //¼Ó¼º Ä«µå2 0.5%
+	DropItem(II_GEN_MAT_ELE_FLAME, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.25%
+	DropItem(II_GEN_MAT_ELE_FLAME, 15000000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.5%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 11262500, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 920000, 0, 1);
@@ -17033,7 +17034,7 @@ MI_DU_METEONYKER2
 		}
 	}
 }
-// ÀÌº¥Æ®¿ë ¸ó½ºÅÍ ¼¼ÆÃ
+// ï¿½Ìºï¿½Æ®ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_DEMIAN5
 {
 	Maxitem = 16;
@@ -17089,7 +17090,7 @@ MI_MUFFRIN5
 	m_nAttackFirstRange = 8;
 }
 
-// ¹Ì±¹ ÀÌº¥Æ® ¸ó½ºÅÍ
+// ï¿½Ì±ï¿½ ï¿½Ìºï¿½Æ® ï¿½ï¿½ï¿½ï¿½
 
 MI_LOADCLOCKWORK
 {
@@ -17148,7 +17149,7 @@ MI_LOADCLOCKWORK
 	DropItem(II_ARM_F_MER_SET01HELMET, 140000000, 0, 1);
 	DropItem(II_ARM_F_ASS_SET01HELMET, 140000000, 0, 1);
         DropItem(II_ARM_ARM_SHI_RUKENSHIA, 500000000, 0, 1);         
-        DropItem(II_ARM_ARM_SHI_TOEFFIN, 500000000, 0, 1);	//(¾ÆÀÌÅÛ ÅëÇÕÀ¸·Î º¯°æµÊ)
+        DropItem(II_ARM_ARM_SHI_TOEFFIN, 500000000, 0, 1);	//(ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½)
         DropItem(II_ARM_ARM_SHI_TOEFFIN, 500000000, 0, 1);            
         DropItem(II_ARM_ARM_SHI_CATEPO, 500000000, 0, 1);
 	DropItem(II_GEN_JEW_EAR_ATTEARRING, 1500000000, 12, 1);
@@ -17377,7 +17378,7 @@ MI_GLYPHAXZ
 }
 
 
-//ÀÌºí¸®½ºÀÇ »ç¿ø ¸ó½ºÅÍ
+//ï¿½Ìºï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 
 MI_IBLCRASHER
 {
@@ -17788,42 +17789,42 @@ MI_IBLBOXTER
         DropItem(II_WEA_YOY_IBLLINESS, 500000, 0, 1);
         DropItem(II_ARM_ARM_SHI_CONTRA, 500000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_CANDLE, 3000000, 0, 1);		//	Äµµé Ä«µå
-	DropItem(II_GEN_MAT_ELE_RAIN, 3000000, 0, 1);			//	·¹ÀÎ Ä«µå
-	DropItem(II_GEN_MAT_ELE_BREEZE, 3000000, 0, 1);		//	ºê¸®Áî Ä«µå
-	DropItem(II_GEN_MAT_ELE_SPARK, 3000000, 0, 1);		        //	½ºÆÄÅ© Ä«µå
-        DropItem(II_GEN_MAT_ELE_SAND, 3000000, 0, 1);                  //      ½Úµå Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 3000000, 0, 1);		        //	ÅäÄ¡ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 3000000, 0, 1);			//	·¹ÀÌÅ© Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 3000000, 0, 1);		//	º¼Å×ÀÌÁö Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 3000000, 0, 1);		        //	½ºÅæ Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3000000, 0, 1);			//	°ÔÀÏ Ä«µå
-	DropItem(II_GEN_MAT_ELE_FLAME, 2000000, 0, 1);		        //	ÇÃ·¹ÀÓ Ä«µå
-	DropItem(II_GEN_MAT_ELE_RIVER, 2000000, 0, 1);		        //	¸®¹ö Ä«µå
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 2000000, 0, 1);		//	Á¦³Ê·¹ÀÌÅÍ Ä«µå
-	DropItem(II_GEN_MAT_ELE_DESERT, 2000000, 0, 1);			//	µ¥ÀúÆ® Ä«µå
-	DropItem(II_GEN_MAT_ELE_CYCLON, 2000000, 0, 1);			//	½ÎÀÌÅ¬·Ð Ä«µå
+	DropItem(II_GEN_MAT_ELE_CANDLE, 3000000, 0, 1);		//	Äµï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RAIN, 3000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_BREEZE, 3000000, 0, 1);		//	ï¿½ê¸®ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_SPARK, 3000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+        DropItem(II_GEN_MAT_ELE_SAND, 3000000, 0, 1);                  //      ï¿½Úµï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 3000000, 0, 1);		        //	ï¿½ï¿½Ä¡ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 3000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å© Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 3000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 3000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_FLAME, 2000000, 0, 1);		        //	ï¿½Ã·ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_RIVER, 2000000, 0, 1);		        //	ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 2000000, 0, 1);		//	ï¿½ï¿½ï¿½Ê·ï¿½ï¿½ï¿½ï¿½ï¿½ Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_DESERT, 2000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Æ® Ä«ï¿½ï¿½
+	DropItem(II_GEN_MAT_ELE_CYCLON, 2000000, 0, 1);			//	ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ Ä«ï¿½ï¿½
 
-        DropItem(II_GEN_GEM_GEM_POPORAM, 100000000, 0, 1);		//	Æ÷Æ÷¶÷
-	DropItem(II_GEN_GEM_GEM_SLAIN, 100000000, 0, 1);		//	½½·¹ÀÎ
-	DropItem(II_GEN_GEM_GEM_TARINROOT, 100000000, 0, 1);		//	Å¸¸°»Ñ¸®
-	DropItem(II_GEN_GEM_GEM_STARSTONE, 100000000, 0, 1);		//	º°¼®
-	DropItem(II_GEN_GEM_GEM_GOLDENWING, 100000000, 0, 1);		//	È²±Ý³¯°³
-	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 100000000, 0, 1);		//	ºí·çÇã´Ï
-	DropItem(II_GEN_GEM_GEM_MIADOLL, 100000000, 0, 1);		//	¹Ì¾ÆÀÇ ÀÎÇü
-	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 100000000, 0, 1);	        //	¿­È­¼º³É
-	DropItem(II_GEN_GEM_GEM_CARDRIN, 100000000, 0, 1);		//	Ä«µå¸°
-	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 100000000, 0, 1);		//	ÇÜ¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 100000000, 0, 1);		//	±â±Û·Àµå
-	DropItem(II_GEN_GEM_GEM_MOONSTONE, 100000000, 0, 1);		//	¿ùÀå¼®
-	DropItem(II_GEN_GEM_GEM_BOBAND, 100000000, 0, 1);		//	º¸¿ì¹êµå
-	DropItem(II_GEN_GEM_GEM_DUMBLING, 100000000, 0, 1);		//	´ýºí¸µ
-	DropItem(II_GEN_GEM_GEM_KALIN, 100000000, 0, 1);		//	Ä®¸°ºê·ÎÂî
-	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 100000000, 0, 1);		//	Å¬·°ÇÏÆ®
-	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 100000000, 0, 1);		//	Åù¸¶ºí
-	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 100000000, 0, 1);		//	È²±ÝÁÖ¸Ô
-	DropItem(II_GEN_GEM_GEM_ORBRIN, 100000000, 0, 1);		//	¿Àºê¸°
-	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 100000000, 0, 1);		//	È²±ÝÄÅ
+        DropItem(II_GEN_GEM_GEM_POPORAM, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_SLAIN, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_TARINROOT, 100000000, 0, 1);		//	Å¸ï¿½ï¿½ï¿½Ñ¸ï¿½
+	DropItem(II_GEN_GEM_GEM_STARSTONE, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENWING, 100000000, 0, 1);		//	È²ï¿½Ý³ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_BLUEHONEY, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MIADOLL, 100000000, 0, 1);		//	ï¿½Ì¾ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_FURIOUSMATCH, 100000000, 0, 1);	        //	ï¿½ï¿½È­ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CARDRIN, 100000000, 0, 1);		//	Ä«ï¿½å¸°
+	DropItem(II_GEN_GEM_GEM_HAMMARBLE, 100000000, 0, 1);		//	ï¿½Ü¸ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GIGGLANDE, 100000000, 0, 1);		//	ï¿½ï¿½Û·ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_MOONSTONE, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½å¼®
+	DropItem(II_GEN_GEM_GEM_BOBAND, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_DUMBLING, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_KALIN, 100000000, 0, 1);		//	Ä®ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_CLOCKHEART, 100000000, 0, 1);		//	Å¬ï¿½ï¿½ï¿½ï¿½Æ®
+	DropItem(II_GEN_GEM_GEM_TOMBMARBLE, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+	DropItem(II_GEN_GEM_GEM_GOLDENFIST, 100000000, 0, 1);		//	È²ï¿½ï¿½ï¿½Ö¸ï¿½
+	DropItem(II_GEN_GEM_GEM_ORBRIN, 100000000, 0, 1);		//	ï¿½ï¿½ï¿½ê¸°
+	DropItem(II_GEN_GEM_GEM_GOLDENCUP, 100000000, 0, 1);		//	È²ï¿½ï¿½ï¿½ï¿½
 
 	m_nAttackFirstRange = 10;
 
@@ -18733,7 +18734,7 @@ MI_EVENT04
    	}               
 }
 
-//12Â÷ ¹öÀü Ãß°¡ ¸ó½ºÅÍ(ÀÓ½Ã¹öÀü)
+//12ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ ï¿½ß°ï¿½ ï¿½ï¿½ï¿½ï¿½(ï¿½Ó½Ã¹ï¿½ï¿½ï¿½)
 MI_CAITSITH01
 {
 	Maxitem = 2;
@@ -18830,8 +18831,8 @@ MI_CAITSITH04
 	DropKind(IK3_BOW, 61, 68);
 	DropKind(IK3_YOYO, 61, 68);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19019,8 +19020,8 @@ MI_HARPY04
 	DropKind(IK3_THSWD, 70, 76);
 	DropKind(IK3_THAXE, 70, 76);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19209,8 +19210,8 @@ MI_POLEVIK04
 	DropKind(IK3_THSWD, 71, 81);
 	DropKind(IK3_THAXE, 71, 81);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19399,8 +19400,8 @@ MI_ABRAXAS04
 	DropKind(IK3_THSWD, 73, 89);
 	DropKind(IK3_THAXE, 73, 89);
 	
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19589,8 +19590,8 @@ MI_HAG04
 	DropKind(IK3_THSWD, 80, 95);
 	DropKind(IK3_THAXE, 80, 95);
 
-	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_RIVER, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_RIVER, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19779,8 +19780,8 @@ MI_THOTH04
 	DropKind(IK3_THSWD, 90, 101);
 	DropKind(IK3_THAXE, 90, 101);
 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_CYCLON, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -19971,8 +19972,8 @@ MI_KHNEMU04
 	DropKind(IK3_THSWD, 90, 104);
 	DropKind(IK3_THAXE, 90, 104);
 
-	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //¼Ó¼º Ä«µå3 0.125%
-	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //¼Ó¼º Ä«µå2 0.25%
+	DropItem(II_GEN_MAT_ELE_DESERT, 3750000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 0.125%
+	DropItem(II_GEN_MAT_ELE_DESERT, 7500000, 0, 1); //ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2 0.25%
 
 	DropItem(II_GEN_MAT_ORICHALCUM01, 3006250, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1560000, 0, 1);
@@ -20161,30 +20162,30 @@ MI_DANTALIAN04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 0, -1, 5, 18); //°í¾î³×Å¬¸®½º+1
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 0, -1, 5, 18); //¸àÅ»³×Å¬¸®½º+1
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 1, -1, 5, 18); //ÆäÀÌ¼Ç³×Å¬¸®½º+1
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 1, -1, 19, 26); //°í¾î³×Å¬¸®½º+2
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 3, -1, 19, 26); //¸àÅ»³×Å¬¸®½º+2
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 4, -1, 19, 26); //ÆäÀÌ¼Ç³×Å¬¸®½º+2
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 3, -1, 27, 36); //°í¾î³×Å¬¸®½º+3
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 7, -1, 27, 36); //¸àÅ»³×Å¬¸®½º+3
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 7, -1, 19, 26); //ÆäÀÌ¼Ç³×Å¬¸®½º+3
-	DropItem(II_GEN_JEW_RIN_DEXRING, 3000000, 3, 1); // ¾î·º¸µ+3
-	DropItem(II_GEN_JEW_RIN_STARING, 3000000, 3, 1); // ½ºÅÆ¸µ+3
-	DropItem(II_GEN_JEW_RIN_DEXRING, 2500000, 4, 1); // ¾î·º¸µ+4
-	DropItem(II_GEN_JEW_RIN_STARING, 2500000, 4, 1); // ½ºÅÆ¸µ+4
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 0, -1, 5, 18); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+1
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 0, -1, 5, 18); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+1
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 1, -1, 5, 18); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+1
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 1, -1, 19, 26); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+2
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 3, -1, 19, 26); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+2
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 4, -1, 19, 26); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+2
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1500000, 3, -1, 27, 36); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+3
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1500000, 7, -1, 27, 36); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+3
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1500000, 7, -1, 19, 26); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+3
+	DropItem(II_GEN_JEW_RIN_DEXRING, 3000000, 3, 1); // ï¿½î·ºï¿½ï¿½+3
+	DropItem(II_GEN_JEW_RIN_STARING, 3000000, 3, 1); // ï¿½ï¿½ï¿½Æ¸ï¿½+3
+	DropItem(II_GEN_JEW_RIN_DEXRING, 2500000, 4, 1); // ï¿½î·ºï¿½ï¿½+4
+	DropItem(II_GEN_JEW_RIN_STARING, 2500000, 4, 1); // ï¿½ï¿½ï¿½Æ¸ï¿½+4
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_POT_DRI_VITAL800,  110000000, 0, 1);
 	DropItem(II_GEN_REF_REF_EIGHTH, 420000000, 0, 1);
@@ -20369,24 +20370,24 @@ MI_GANESA04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 3000000, 4, -1, 19, 26); //°í¾î³×Å¬¸®½º+4
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 3000000, 11, -1, 19, 26); //¸àÅ»³×Å¬¸®½º+4
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 3000000, 11, -1, 19, 26); //ÆäÀÌ¼Ç³×Å¬¸®½º+4
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1000000, 5, -1, 19, 26); //°í¾î³×Å¬¸®½º+5
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1000000, 15, -1, 19, 26); //¸àÅ»³×Å¬¸®½º+5
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1000000, 14, -1, 19, 26); //ÆäÀÌ¼Ç³×Å¬¸®½º+5
-	DropItem(II_GEN_JEW_NEC_HPNECKLACE,  500000, 6, -1, 19, 26); //°í¾î³×Å¬¸®½º+6
-	DropItem(II_GEN_JEW_NEC_MPNECKLACE,  500000, 15, -1, 19, 26); //¸àÅ»³×Å¬¸®½º+6
-	DropItem(II_GEN_JEW_NEC_FPNECKLACE,  500000, 19, -1, 19, 26); //ÆäÀÌ¼Ç³×Å¬¸®½º+6
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 3000000, 4, -1, 19, 26); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+4
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 3000000, 11, -1, 19, 26); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+4
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 3000000, 11, -1, 19, 26); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+4
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE, 1000000, 5, -1, 19, 26); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+5
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE, 1000000, 15, -1, 19, 26); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+5
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE, 1000000, 14, -1, 19, 26); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+5
+	DropItem(II_GEN_JEW_NEC_HPNECKLACE,  500000, 6, -1, 19, 26); //ï¿½ï¿½ï¿½ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+6
+	DropItem(II_GEN_JEW_NEC_MPNECKLACE,  500000, 15, -1, 19, 26); //ï¿½ï¿½Å»ï¿½ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+6
+	DropItem(II_GEN_JEW_NEC_FPNECKLACE,  500000, 19, -1, 19, 26); //ï¿½ï¿½ï¿½Ì¼Ç³ï¿½Å¬ï¿½ï¿½ï¿½ï¿½+6
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -20589,25 +20590,25 @@ MI_ASURA04
 	DropItem(II_GEN_JEW_RIN_DEXRING,  500000, 6, 1);
 	DropItem(II_GEN_JEW_RIN_STARING,  500000, 6, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -22353,25 +22354,25 @@ MI_Crohell04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -22569,25 +22570,25 @@ MI_Frinker04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -22785,16 +22786,16 @@ MI_Toadrin04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_POT_DRI_VITAL800,  110000000, 0, 1);
 	DropItem(II_GEN_REF_REF_EIGHTH, 420000000, 0, 1);
@@ -22995,10 +22996,10 @@ MI_Hatsalra04
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -23197,16 +23198,16 @@ MI_Berken04
 	DropItem(II_GEN_MAT_ORICHALCUM01, 2455000, 0, 1);
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_POT_DRI_VITAL800,  110000000, 0, 1);
 	DropItem(II_GEN_REF_REF_EIGHTH, 420000000, 0, 1);
@@ -23405,25 +23406,25 @@ MI_PRICKANT04
 	DropItem(II_GEN_GEM_GEM_ANTEGG, 200000000, 0, 1);
 	
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -23621,25 +23622,25 @@ MI_CRIPESCENTIPEDE04
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 	DropItem(II_GEN_GEM_GEM_OILLEG, 200000000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -23837,25 +23838,25 @@ MI_MAULMOUSE04
 	DropItem(II_GEN_MAT_MOONSTONE, 1256000, 0, 1);
 	DropItem(II_GEN_GEM_GEM_NICECHEESE, 200000000, 0, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -24230,25 +24231,25 @@ MI_PRICKANT04_1
 	DropItem(II_GEN_JEW_RIN_DEXRING,  500000, 6, 1);
 	DropItem(II_GEN_JEW_RIN_STARING,  500000, 6, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -24461,25 +24462,25 @@ MI_CRIPESCENTIPEDE04_1
 	DropItem(II_GEN_JEW_RIN_DEXRING,  500000, 6, 1);
 	DropItem(II_GEN_JEW_RIN_STARING,  500000, 6, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -24693,25 +24694,25 @@ MI_MAULMOUSE04_1
 	DropItem(II_GEN_JEW_RIN_DEXRING,  500000, 6, 1);
 	DropItem(II_GEN_JEW_RIN_STARING,  500000, 6, 1);
 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå3 
-	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
-	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//¼Ó¼º Ä«µå2
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_FLAME, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_RIVER, 		2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_CYCLON, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_DESERT, 	2000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½3 
+	DropItem(II_GEN_MAT_ELE_GENERATOR, 	5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_RIVER, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_FLAME, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_CYCLON, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
+	DropItem(II_GEN_MAT_ELE_DESERT, 		5000000, 0, -1, 20, 130 ); 	//ï¿½Ó¼ï¿½ Ä«ï¿½ï¿½2
 
 	DropItem(II_GEN_MAT_ELE_CANDLE,		 200000, 0, -1, 20, 49 ); 	//HP2% 
 	DropItem(II_GEN_MAT_ELE_MAGMA,		 100000, 0, -1, 50, 79 ); 	//HP4% 
 	DropItem(II_GEN_MAT_ELE_RAIN,		 200000, 0, -1, 20, 49 ); 	//MP2%
 	DropItem(II_GEN_MAT_ELE_FLOOD,		 100000, 0, -1, 50, 79 ); 	//MP4%
-	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//°ø°Ý·Â2%
-	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//°ø°Ý·Â4%
-	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//¹æ¾î·Â2%
-	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//¹æ¾î·Â4%
+	DropItem(II_GEN_MAT_ELE_SPARK,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½2%
+	DropItem(II_GEN_MAT_ELE_THUNDER,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½Ý·ï¿½4%
+	DropItem(II_GEN_MAT_ELE_SAND,		 200000, 0, -1, 20, 49 ); 	//ï¿½ï¿½ï¿½ï¿½2%
+	DropItem(II_GEN_MAT_ELE_MOUNTAIN,	 100000, 0, -1, 50, 79 ); 	//ï¿½ï¿½ï¿½ï¿½4%
 	DropItem(II_GEN_MAT_ELE_BREEZE,		 200000, 0, -1, 20, 49 ); 	//FP2%
 	DropItem(II_GEN_MAT_ELE_STORM,		 100000, 0, -1, 50, 79 ); 	//FP4%
 
@@ -24953,7 +24954,7 @@ MI_MOCOMOCHI1
    	}                
 }
 
-//15Â÷ ¸ó½ºÅÍ
+//15ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 MI_SKELWOLF
 {
 	Maxitem = 2;
@@ -26528,7 +26529,7 @@ MI_BESIBIGFOOT02
 }
 
 
-//ÀÌ ÀÌÇÏ´Â »ç¿ëÇÏÁö ¾ÊÀ½. Ãß°¡ ÀÛ¾÷Àº ¹Ù·Î À§¿¡¼­ ºÎÅÍ..
+//ï¿½ï¿½ ï¿½ï¿½ï¿½Ï´ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½. ï¿½ß°ï¿½ ï¿½Û¾ï¿½ï¿½ï¿½ ï¿½Ù·ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½..
 MI_PUKEPUKE5
 {
 	Maxitem = 2;

--- a/src/Rhisis.World/Handlers/BattleHandler.cs
+++ b/src/Rhisis.World/Handlers/BattleHandler.cs
@@ -82,7 +82,7 @@ namespace Rhisis.World.Handlers
                 return;
             }
 
-            _battleSystem.MagicAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.MagicPower), packet.ProjectileId);
+            _battleSystem.MagicAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.MagicPower), packet.ProjectileId + 1);
         }
 
         /// <summary>

--- a/src/Rhisis.World/Handlers/BattleHandler.cs
+++ b/src/Rhisis.World/Handlers/BattleHandler.cs
@@ -76,7 +76,13 @@ namespace Rhisis.World.Handlers
                 _logger.LogWarning($"Magic attack power cannot be less than 0.");
             }
 
-            _battleSystem.MagicAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.MagicPower));
+            if (packet.ProjectileId < 0)
+            {
+                _logger.LogError($"{client.Player} Invalid projectile id.");
+                return;
+            }
+
+            _battleSystem.MagicAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.MagicPower), packet.ProjectileId);
         }
 
         /// <summary>
@@ -100,7 +106,13 @@ namespace Rhisis.World.Handlers
                 _logger.LogWarning($"Range attack power cannot be less than 0.");
             }
 
-            _battleSystem.RangeAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.Power));
+            if (packet.ProjectileId < 0)
+            {
+                _logger.LogError($"{client.Player} Invalid projectile id.");
+                return;
+            }
+
+            _battleSystem.RangeAttack(client.Player, target, packet.AttackMessage, Math.Max(0, packet.Power), packet.ProjectileId + 1);
         }
     }
 }

--- a/src/Rhisis.World/Systems/Battle/BattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/BattleSystem.cs
@@ -115,7 +115,7 @@ namespace Rhisis.World.Systems.Battle
         }
 
         /// <inheritdoc />
-        public void MagicAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int magicAttackPower)
+        public void MagicAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int magicAttackPower, int projectileId)
         {
             var projectile = new MagicProjectileInfo(attacker, defender, magicAttackPower, onArrived: () =>
             {
@@ -123,13 +123,13 @@ namespace Rhisis.World.Systems.Battle
 
                 DamageTarget(attacker, defender, magicAttackArbiter, ObjectMessageType.OBJMSG_ATK_MAGIC1);
             });
-            int projectileId = _projectileSystem.CreateProjectile(projectile);
 
+            _projectileSystem.CreateProjectile(projectileId, projectile);
             _battlePacketFactory.SendMagicAttack(attacker, ObjectMessageType.OBJMSG_ATK_MAGIC1, defender.Id, magicAttackPower, projectileId);
         }
 
         /// <inheritdoc />
-        public void RangeAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int power)
+        public void RangeAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int power, int projectileId)
         {
             if (attacker is IPlayerEntity player)
             {
@@ -156,8 +156,8 @@ namespace Rhisis.World.Systems.Battle
                 
                 DamageTarget(attacker, defender, attackArbiter, attackType);
             });
-            int projectileId = _projectileSystem.CreateProjectile(projectile);
 
+            _projectileSystem.CreateProjectile(projectileId, projectile);
             _battlePacketFactory.SendRangeAttack(attacker, ObjectMessageType.OBJMSG_ATK_RANGE1, defender.Id, power, projectileId);
         }
 

--- a/src/Rhisis.World/Systems/Battle/IBattleSystem.cs
+++ b/src/Rhisis.World/Systems/Battle/IBattleSystem.cs
@@ -34,7 +34,8 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="defender">Defender.</param>
         /// <param name="attackType">Attack type.</param>
         /// <param name="magicAttackPower">Magic attack power.</param>
-        void MagicAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int magicAttackPower);
+        /// <param name="projectileId">Magic projectile id.</param>
+        void MagicAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int magicAttackPower, int projectileId);
 
         /// <summary>
         /// Process a range attack on an ennemy.
@@ -43,6 +44,7 @@ namespace Rhisis.World.Systems.Battle
         /// <param name="defender">Defender.</param>
         /// <param name="attackType">Attack type.</param>
         /// <param name="power">Range attack power.</param>
-        void RangeAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int power);
+        /// <param name="projectileId">Projectile id.</param>
+        void RangeAttack(ILivingEntity attacker, ILivingEntity defender, ObjectMessageType attackType, int power, int projectileId);
     }
 }

--- a/src/Rhisis.World/Systems/Follow/FollowSystem.cs
+++ b/src/Rhisis.World/Systems/Follow/FollowSystem.cs
@@ -24,6 +24,7 @@ namespace Rhisis.World.Systems.Follow
         public void Follow(ILivingEntity livingEntity, IWorldEntity targetEntity, float distance = 1f)
         {
             livingEntity.Follow.Target = targetEntity;
+            livingEntity.Follow.FollowDistance = distance;
             livingEntity.Moves.DestinationPosition.Copy(targetEntity.Object.Position);
             livingEntity.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;
             livingEntity.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;

--- a/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
+++ b/src/Rhisis.World/Systems/Mobility/MobilitySystem.cs
@@ -5,6 +5,7 @@ using Rhisis.Core.Structures;
 using Rhisis.World.Game.Entities;
 using Rhisis.World.Game.Maps;
 using Rhisis.World.Packets;
+using Rhisis.World.Systems.Follow;
 using System;
 
 namespace Rhisis.World.Systems.Mobility
@@ -14,10 +15,12 @@ namespace Rhisis.World.Systems.Mobility
     {
         private const float ArrivalRangeRadius = 1f;
         private readonly float _updateRate = MapInstance.UpdateRate / MapInstance.FrameRate;
+        private readonly IFollowSystem _followSystem;
         private readonly IMoverPacketFactory _moverPacketFactory;
 
-        public MobilitySystem(IMoverPacketFactory moverPacketFactory)
+        public MobilitySystem(IFollowSystem followSystem, IMoverPacketFactory moverPacketFactory)
         {
+            _followSystem = followSystem;
             _moverPacketFactory = moverPacketFactory;
         }
 
@@ -45,9 +48,7 @@ namespace Rhisis.World.Systems.Mobility
                 }
                 else
                 {
-                    entity.Moves.DestinationPosition.Copy(entity.Follow.Target.Object.Position);
-                    entity.Object.MovingFlags &= ~ObjectState.OBJSTA_STAND;
-                    entity.Object.MovingFlags |= ObjectState.OBJSTA_FMOVE;
+                    _followSystem.Follow(entity, entity.Follow.Target, entity.Follow.FollowDistance);
                 }
             }
 

--- a/src/Rhisis.World/Systems/Projectile/IProjectileSystem.cs
+++ b/src/Rhisis.World/Systems/Projectile/IProjectileSystem.cs
@@ -11,9 +11,10 @@ namespace Rhisis.World.Systems.Projectile
         /// <summary>
         /// Creates a new projectile.
         /// </summary>
+        /// <param name="projectileId">Projectile id.</param>
         /// <param name="projectile">Projectile information.</param>
         /// <returns>Projectile id.</returns>
-        int CreateProjectile(ProjectileInfo projectile);
+        int CreateProjectile(int projectileId, ProjectileInfo projectile);
 
         /// <summary>
         /// Removes a projectile from the given living entity projectile's collection.

--- a/src/Rhisis.World/Systems/Projectile/ProjectileSystem.cs
+++ b/src/Rhisis.World/Systems/Projectile/ProjectileSystem.cs
@@ -8,10 +8,9 @@ namespace Rhisis.World.Systems.Projectile
     public class ProjectileSystem : IProjectileSystem
     {
         /// <inheritdoc />
-        public int CreateProjectile(ProjectileInfo projectile)
+        public int CreateProjectile(int projectileId, ProjectileInfo projectile)
         {
             ILivingEntity livingEntity = projectile.Owner;
-            int projectileId = livingEntity.Battle.LastProjectileId++;
 
             livingEntity.Battle.Projectiles.Add(projectileId, projectile);
 

--- a/src/Rhisis.World/Systems/Skills/SkillSystem.cs
+++ b/src/Rhisis.World/Systems/Skills/SkillSystem.cs
@@ -517,7 +517,7 @@ namespace Rhisis.World.Systems.Skills
                 ExecuteSkill(caster, target, skill, reduceCasterPoints: false);
             });
 
-            _projectileSystem.CreateProjectile(projectile);
+            //_projectileSystem.CreateProjectile(projectile);
             _skillPacketFactory.SendUseSkill(caster, target, skill, skillCastingTime, skillUseType);
 
             caster.Delayer.DelayAction(TimeSpan.FromMilliseconds(skill.LevelData.CastingTime), () =>


### PR DESCRIPTION
This PR fixes issue #419.

The problem was located in the way we handle projectiles. In fact, the client sends a projectile id and we should use this id instead of generating one on server side.

Also, the monster drops were broken due to a missing  closing bracket (`}`) on the `propMoverEx.inc` file.