### PR TITLE
Add database configuration for public key mysql settings

### DIFF
--- a/src/Rhisis.Core/Structures/Configuration/DatabaseConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/DatabaseConfiguration.cs
@@ -67,6 +67,28 @@ namespace Rhisis.Core.Structures.Configuration
         public string EncryptionKey { get; set; }
 
         /// <summary>
+        /// (optional) Get or sets if the public key may be retrieved by the mysql connector.
+        /// </summary>
+        /// <remarks>
+        /// Check the mysql connector documentation for details: https://mysqlconnector.net/connection-options/
+        /// </remarks>
+        [DataMember(Name = "allowPublicKeyRetrieval")]
+        [DefaultValue(false)]
+        [Display(Name = "Allow public key retrieval", Order = 6)]
+        public bool AllowPublicKeyRetrieval { get; set; }
+
+        /// <summary>
+        /// (optional) Get or sets the RSA public key file to be used by the mysql connector.
+        /// </summary>
+        /// <remarks>
+        /// Check the mysql connector documentation for details: https://mysqlconnector.net/connection-options/
+        /// </remarks>
+        [DataMember(Name = "serverRSAPublicKeyFile")]
+        [DefaultValue(null)]
+        [Display(Name = "Server RSA public key file", Order = 6)]
+        public string ServerRSAPublicKeyFile { get; set; }
+
+        /// <summary>
         /// Gets or sets the valid state of the configuration.
         /// </summary>
         [IgnoreDataMember]

--- a/src/Rhisis.Core/Structures/Configuration/DatabaseConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/DatabaseConfiguration.cs
@@ -85,7 +85,7 @@ namespace Rhisis.Core.Structures.Configuration
         /// </remarks>
         [DataMember(Name = "serverRSAPublicKeyFile")]
         [DefaultValue(null)]
-        [Display(Name = "Server RSA public key file", Order = 6)]
+        [Display(Name = "Server RSA public key file", Order = 7)]
         public string ServerRSAPublicKeyFile { get; set; }
 
         /// <summary>

--- a/src/Rhisis.Database/DatabaseFactory.cs
+++ b/src/Rhisis.Database/DatabaseFactory.cs
@@ -59,7 +59,9 @@ namespace Rhisis.Database
                 Password = databaseConfiguration.Password,
                 Port = (uint)databaseConfiguration.Port,
                 Database = databaseConfiguration.Database,
-                SslMode = MySqlSslMode.None
+                SslMode = MySqlSslMode.None,
+                AllowPublicKeyRetrieval = databaseConfiguration.AllowPublicKeyRetrieval,
+                ServerRsaPublicKeyFile = databaseConfiguration.ServerRSAPublicKeyFile
             };
 
             return sqlConnectionStringBuilder.ToString();


### PR DESCRIPTION
Added two new configuration settings to the database configuration which are passed to the MySQL connector:
![image](https://user-images.githubusercontent.com/74213082/98598224-6c4afa00-22da-11eb-953a-470800e4ded6.png)
![image](https://user-images.githubusercontent.com/74213082/98598264-7e2c9d00-22da-11eb-958a-0927a46f31a0.png)
Source: https://mysqlconnector.net/connection-options/