### PR TITLE
Support ONEKILL_MODE in the battle system feature

### DIFF
--- a/src/Rhisis.Game/Features/AttackArbiters/MeleeAttackArbiter.cs
+++ b/src/Rhisis.Game/Features/AttackArbiters/MeleeAttackArbiter.cs
@@ -88,11 +88,6 @@ namespace Rhisis.Game.Features.AttackArbiters
         /// <returns></returns>
         private AttackFlags GetAttackFlags()
         {
-            if (Attacker is IPlayer player && player.Mode.HasFlag(ModeType.ONEKILL_MODE))
-            {
-                return AttackFlags.AF_GENERIC;
-            }
-
             int hitRate;
             var hitRating = GetHitRating(Attacker);
             var escapeRating = GetEspaceRating(Defender);

--- a/src/Rhisis.Game/Features/Battle.cs
+++ b/src/Rhisis.Game/Features/Battle.cs
@@ -147,6 +147,8 @@ namespace Rhisis.Game.Features
 
         private void InflictDamages(IMover attacker, IMover target, AttackResult attackResult, ObjectMessageType objectMessageType)
         {
+            OverrideDamagesIfOneHitKillMode(attackResult, target);
+
             Target = target;
             target.Health.SufferDamages(attacker, Math.Max(0, attackResult.Damages), attackResult.Flags, objectMessageType);
 
@@ -163,6 +165,15 @@ namespace Rhisis.Game.Features
                     monster.Follow(_mover);
                     monster.Battle.Target = _mover;
                 }
+            }
+        }
+
+        private void OverrideDamagesIfOneHitKillMode(AttackResult attackResult, IMover target)
+        {
+            if (_mover is IPlayer player && player.Mode.HasFlag(ModeType.ONEKILL_MODE))
+            {
+                attackResult.Damages = target.Health.Hp;
+                attackResult.Flags = AttackFlags.AF_GENERIC;
             }
         }
     }


### PR DESCRIPTION
All damage caused by the Battle systems (spells, melee attacks) should be impacted.
I didn't check if official FlyFF also worked like this or if it only triggered on melee attacks, but I think it makes sense like this.
