### PR TITLE
Feature/level command skill points reset

### DIFF
--- a/src/Rhisis.Game.Abstractions/Features/ISkillTree.cs
+++ b/src/Rhisis.Game.Abstractions/Features/ISkillTree.cs
@@ -22,6 +22,13 @@ namespace Rhisis.Game.Abstractions.Features
         void AddSkillPoints(ushort skillPointsToAdd, bool sendToPlayer = true);
 
         /// <summary>
+        /// Adds the amount of available skill points to the tree as if the player would level from (level - 1) to (level).
+        /// </summary>
+        /// <param name="level">The level to which the player just leveled.</param>
+        /// <param name="sendToPlayer">Boolean value that indicates if the system should send the update packet back to the player.</param>
+        void AddSkillPointsForLevelUp(int level, bool sendToPlayer = true);
+
+        /// <summary>
         /// Gets a skill by its id.
         /// </summary>
         /// <param name="skillId">Skill id.</param>
@@ -54,7 +61,16 @@ namespace Rhisis.Game.Abstractions.Features
         /// <summary>
         /// Resets the skill tree and redistribute the skill points.
         /// </summary>
+        /// <remarks>
+        /// - Sets all the skills of the skill tree to level 0.
+        /// - Returns all the spent skill points to the available skill points.
+        /// </remarks>
         void Reskill();
+
+        /// <summary>
+        /// Resets the available skill points to 0.
+        /// </summary>
+        void ResetAvailableSkillPoints();
 
         /// <summary>
         /// Sets a skill level.

--- a/src/Rhisis.Game/Features/Experience.cs
+++ b/src/Rhisis.Game/Features/Experience.cs
@@ -185,7 +185,7 @@ namespace Rhisis.Game.Features
 
             if (_player.Level != _player.DeathLevel)
             {
-                _player.SkillTree.AddSkillPoints((ushort)((_player.Level - 1) / 20 + 2), sendToPlayer: false);
+                _player.SkillTree.AddSkillPointsForLevelUp(_player.Level, sendToPlayer: false);
                 _player.Statistics.AvailablePoints += statPoints;
             }
 

--- a/src/Rhisis.Game/Features/SkillTree.cs
+++ b/src/Rhisis.Game/Features/SkillTree.cs
@@ -41,6 +41,12 @@ namespace Rhisis.Game.Features
             }
         }
 
+        public void AddSkillPointsForLevelUp(int level, bool sendToPlayer = true)
+        {
+            int skillPointsToAdd = (level - 1) / 20 + 2;
+            AddSkillPoints((ushort)skillPointsToAdd, sendToPlayer);
+        }
+
         public ISkill GetSkill(int skillId) => _skills.FirstOrDefault(x => x.Id == skillId);
 
         public ISkill GetSkillAtIndex(int skillIndex) => _skills.ElementAt(skillIndex);
@@ -79,6 +85,11 @@ namespace Rhisis.Game.Features
                 SkillPoints += (ushort)(skill.Level * GameConstants.SkillPointUsage[skill.Data.JobType]);
                 skill.Level = 0;
             }
+        }
+
+        public void ResetAvailableSkillPoints()
+        {
+            SkillPoints = 0;
         }
 
         public void Serialize(INetPacketStream packet)
@@ -210,6 +221,5 @@ namespace Rhisis.Game.Features
 
             return false;
         }
-
     }
 }

--- a/src/Rhisis.Game/Features/SkillTree.cs
+++ b/src/Rhisis.Game/Features/SkillTree.cs
@@ -78,8 +78,6 @@ namespace Rhisis.Game.Features
 
         public void Reskill()
         {
-            SkillPoints = 0;
-
             foreach (ISkill skill in _skills)
             {
                 SkillPoints += (ushort)(skill.Level * GameConstants.SkillPointUsage[skill.Data.JobType]);

--- a/src/Rhisis.World/Game/Chat/LevelCommand.cs
+++ b/src/Rhisis.World/Game/Chat/LevelCommand.cs
@@ -51,9 +51,15 @@ namespace Rhisis.Game.Features.Chat.Commands
             player.Experience.Reset();
             player.Statistics.Restat();
 
+            player.SkillTree.Reskill();
+            player.SkillTree.ResetAvailableSkillPoints();
+            for (int levelNr = 2; levelNr <= player.Level; levelNr++)
+            {
+                player.SkillTree.AddSkillPointsForLevelUp(levelNr, false);
+            }
+
             if (player.Job.Id != job.Id)
             {
-                player.SkillTree.Reskill();
                 player.ChangeJob(job.Id);
             }
 


### PR DESCRIPTION
- Triggering a reskill should no longer discard all unspent skill points
- Using the /level command was not giving any skill points and it was discarding available skill points, but now it should behave as expected.
    - It will first trigger a reskill so all skills are level 0
    - Then it resets all available skill points
    - Then it adds skill points for every level according to the existing formula in the code