### PR TITLE
Add magic skill projectile

### DIFF
--- a/src/Rhisis.Game.Abstractions/Features/IBattle.cs
+++ b/src/Rhisis.Game.Abstractions/Features/IBattle.cs
@@ -38,8 +38,7 @@ namespace Rhisis.Game.Abstractions.Features
         /// <param name="target">Target to attack.</param>
         /// <param name="power">Range attack power.</param>
         /// <param name="objectMessageType">Range attack type.</param>
-        /// <param name="projectileId">Projectile id.</param>
-        void RangeAttack(IMover target, int power, ObjectMessageType objectMessageType, int projectileId);
+        void RangeAttack(IMover target, int power, ObjectMessageType objectMessageType);
 
         /// <summary>
         /// Process a skill attack on a given target.

--- a/src/Rhisis.Game.Abstractions/Features/IProjectiles.cs
+++ b/src/Rhisis.Game.Abstractions/Features/IProjectiles.cs
@@ -10,14 +10,19 @@ namespace Rhisis.Game.Abstractions.Features
         /// <summary>
         /// Adds a new projectile.
         /// </summary>
-        /// <param name="projectileId">Projectile id.</param>
         /// <param name="projectile">Projectile to add.</param>
-        void Add(int projectileId, IProjectile projectile);
+        /// <returns>The projectile id.</returns>
+        int Add(IProjectile projectile);
 
         /// <summary>
         /// Removes a projectile by its id.
         /// </summary>
         /// <param name="projectileId">Projectile id.</param>
         void Remove(int projectileId);
+
+        /// <summary>
+        /// Resets the mover's projectiles.
+        /// </summary>
+        void Reset();
     }
 }

--- a/src/Rhisis.Game/Features/Battle.cs
+++ b/src/Rhisis.Game/Features/Battle.cs
@@ -69,7 +69,7 @@ namespace Rhisis.Game.Features
             SendPacketToVisible(_mover, meleeAttackSnapshot);
         }
 
-        public void RangeAttack(IMover target, int power, ObjectMessageType objectMessageType, int projectileId)
+        public void RangeAttack(IMover target, int power, ObjectMessageType objectMessageType)
         {
             IProjectile projectile = null;
 
@@ -102,7 +102,7 @@ namespace Rhisis.Game.Features
 
             if (projectile != null)
             {
-                _mover.Projectiles.Add(projectileId, projectile);
+                int projectileId = _mover.Projectiles.Add(projectile);
 
                 using var snapshot = new RangeAttackSnapshot(_mover, objectMessageType, target.Id, power, projectileId);
                 SendPacketToVisible(_mover, snapshot);

--- a/src/Rhisis.Game/Features/Projectiles.cs
+++ b/src/Rhisis.Game/Features/Projectiles.cs
@@ -8,7 +8,10 @@ namespace Rhisis.Game.Features
 {
     public class Projectiles : GameFeature, IProjectiles
     {
+        private const int DefaultProjectileId = 1;
         private readonly IDictionary<int, IProjectile> _projectiles;
+
+        private int _projectileCounter;
 
         public IProjectile this[int key] => _projectiles[key];
 
@@ -21,16 +24,27 @@ namespace Rhisis.Game.Features
         public Projectiles()
         {
             _projectiles = new Dictionary<int, IProjectile>();
+            _projectileCounter = DefaultProjectileId;
         }
 
-        public void Add(int projectileId, IProjectile projectile)
+        public int Add(IProjectile projectile)
         {
+            int projectileId = _projectileCounter++;
+
             _projectiles.Add(projectileId, projectile);
+
+            return projectileId;
         }
 
         public void Remove(int projectileId)
         {
             _projectiles.Remove(projectileId);
+        }
+
+        public void Reset()
+        {
+            _projectiles.Clear();
+            _projectileCounter = DefaultProjectileId;
         }
 
         public bool ContainsKey(int key) => _projectiles.ContainsKey(key);

--- a/src/Rhisis.Game/Systems/SkillSystem.cs
+++ b/src/Rhisis.Game/Systems/SkillSystem.cs
@@ -210,17 +210,19 @@ namespace Rhisis.Game.Systems
         private void CastMagicAttackShot(IMover caster, IMover target, ISkill skill, SkillUseType skillUseType)
         {
             int skillCastingTime = skill.GetCastingTime();
-            //var projectile = new MagicSkillProjectileInfo(caster, target, skill, () =>
-            //{
-            //    ExecuteSkill(caster, target, skill, reduceCasterPoints: false);
-            //});
+            var projectile = new MagicSkillProjectile(caster, target, skill, () =>
+            {
+                ExecuteSkill(caster, target, skill, reduceCasterPoints: false);
+            });
+            caster.Projectiles.Add(projectile);
 
-            //_skillPacketFactory.SendUseSkill(caster, target, skill, skillCastingTime, skillUseType);
+            using var snapshot = new UseSkillSnapshot(caster, target, skill, skillCastingTime, skillUseType);
+            SendPacketToVisible(caster, snapshot, sendToPlayer: true);
 
-            //caster.Delayer.DelayAction(TimeSpan.FromMilliseconds(skill.LevelData.CastingTime), () =>
-            //{
-            //    ReduceCasterPoints(caster, skill);
-            //});
+            caster.Delayer.DelayAction(TimeSpan.FromMilliseconds(skill.LevelData.CastingTime), () =>
+            {
+                ReduceCasterPoints(caster, skill);
+            });
         }
 
         /// <summary>

--- a/src/Rhisis.Game/Systems/TeleportSystem.cs
+++ b/src/Rhisis.Game/Systems/TeleportSystem.cs
@@ -74,6 +74,7 @@ namespace Rhisis.Game.Systems
             }
 
             player.Spawned = true;
+            player.Projectiles.Reset();
         }
 
         private void SetPlayerPosition(IPlayer player, Vector3 position)

--- a/src/Rhisis.World/Handlers/Battle/MagicAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/MagicAttackHandler.cs
@@ -31,7 +31,7 @@ namespace Rhisis.World.Handlers.Battle
                 throw new InvalidOperationException($"Invalid projectile id.");
             }
 
-            player.Battle.RangeAttack(target, Math.Max(0, packet.MagicPower), ObjectMessageType.OBJMSG_ATK_MAGIC1, packet.ProjectileId + 1);
+            player.Battle.RangeAttack(target, Math.Max(0, packet.MagicPower), ObjectMessageType.OBJMSG_ATK_MAGIC1);
         }
     }
 }

--- a/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
@@ -47,7 +47,7 @@ namespace Rhisis.World.Handlers.Battle
             }
 
             player.Inventory.DeleteItem(bulletItem, 1);
-            player.Battle.RangeAttack(target, Math.Max(0, packet.Power), ObjectMessageType.OBJMSG_ATK_RANGE1, packet.ProjectileId + 1);
+            player.Battle.RangeAttack(target, Math.Max(0, packet.Power), ObjectMessageType.OBJMSG_ATK_RANGE1);
         }
     }
 }


### PR DESCRIPTION
This PR adds the magic skill projectiles support and improves the projectile system.

Before, we used the projectile id coming from the client. This is a security issue. Now each movers that can send projectiles keep a track of their projectile id. Also, when  a player is teleported to another map, the projectile id is restored to its default value : 1.