### PR TITLE
Rides (brooms, boards) can now be unequiped.

### DIFF
--- a/src/Rhisis.Game.Common/ItemFlags.cs
+++ b/src/Rhisis.Game.Common/ItemFlags.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Rhisis.Game.Common
+{
+    [Flags]
+    public enum ItemFlags : uint
+    {
+        Expired = 0x01,
+        Binds = 0x02,
+        IsUsing = 0x04,
+    }
+}

--- a/src/Rhisis.Game/Protocol/Snapshots/DoEquipSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/DoEquipSnapshot.cs
@@ -6,15 +6,17 @@ namespace Rhisis.Network.Snapshots
 {
     public class DoEquipSnapshot : FFSnapshot
     {
-        public DoEquipSnapshot(IPlayer player, IItem item, bool equip)
+
+        /// <param name="wasEquiped">true: the given item was equiped, false: the item was unequiped</param>
+        public DoEquipSnapshot(IPlayer player, IItem item, bool wasEquiped)
             : base(SnapshotType.DOEQUIP, player.Id)
         {
             Write((byte)item.Index);
             Write(0); // Guild id
-            Write(Convert.ToByte(equip));
+            Write(Convert.ToByte(wasEquiped));
             Write(item.Id);
             Write(item.Refines);
-            Write(0); // flag
+            Write(0); // See ItemFlags enum
             Write((int)item.Data.Parts);
         }
     }


### PR DESCRIPTION
The DoEquipSnapshot class was being instantiated with "equip" on true for both unequip and equips. 
It has now been fixed to being false for unequips