### PR TITLE
Refactor Battle feature to no longer be linked with the object messag…

### DIFF
--- a/src/Rhisis.Game.Abstractions/Features/Battle/AttackType.cs
+++ b/src/Rhisis.Game.Abstractions/Features/Battle/AttackType.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Text;
+
+namespace Rhisis.Game.Abstractions.Features.Battle
+{
+    public enum AttackType
+    {
+        // TODO could there be a single MeleeAttack type with a sub type somehow?
+        MeleeAttack1 = 0,
+        MeleeAttack2 = 1,
+        MeleeAttack3 = 2,
+        MeleeAttack4 = 3,
+        RangeBowAttack = 4,
+        RangeWandAttack = 5,
+        SkillMeleeAttack = 6,
+        SkillMagicAttack = 7
+    }
+}

--- a/src/Rhisis.Game.Abstractions/Features/Battle/IBattle.cs
+++ b/src/Rhisis.Game.Abstractions/Features/Battle/IBattle.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 
 namespace Rhisis.Game.Abstractions.Features
@@ -19,33 +20,29 @@ namespace Rhisis.Game.Abstractions.Features
         IMover Target { get; set; }
 
         /// <summary>
-        /// Checks if the current mover can attack the given mover.
-        /// </summary>
-        /// <param name="target">Target to attack.</param>
-        /// <returns>True if the current mover can attack the mover; false otherwise.</returns>
-        bool CanAttack(IMover target);
-
-        /// <summary>
-        /// Attacks the given target.
+        /// Attacks the given target if the target is valid.
         /// </summary>
         /// <param name="target"></param>
-        /// <param name="objectMessageType">Attack type.</param>
-        void MeleeAttack(IMover target, ObjectMessageType objectMessageType);
+        /// <param name="attackType">Attack type.</param>
+        /// <returns>true is the target was valid and the attack happened</returns>
+        bool TryMeleeAttack(IMover target, AttackType attackType);
 
         /// <summary>
-        /// Process a range attack of the given type (range or magic) on a given target.
+        /// Process a range attack of the given type (range or magic) on a given target if the target is valid.
         /// </summary>
         /// <param name="target">Target to attack.</param>
         /// <param name="power">Range attack power.</param>
-        /// <param name="objectMessageType">Range attack type.</param>
-        void RangeAttack(IMover target, int power, ObjectMessageType objectMessageType);
+        /// <param name="rangeAttackType">Range attack type.</param>
+        /// <returns>true is the target was valid and the attack happened</returns>
+        bool TryRangeAttack(IMover target, int power, AttackType rangeAttackType);
 
         /// <summary>
-        /// Process a skill attack on a given target.
+        /// Process a skill attack on a given target if the target is valid.
         /// </summary>
         /// <param name="target">Target to attack.</param>
         /// <param name="skill">Skill to execute.</param>
-        void SkillAttack(IMover target, ISkill skill);
+        /// <returns>true is the target was valid and the attack happened</returns>
+        bool TrySkillAttack(IMover target, ISkill skill);
 
         /// <summary>
         /// Clears the battle target.

--- a/src/Rhisis.Game.Abstractions/Features/Battle/RangeAttackTypeExtensions.cs
+++ b/src/Rhisis.Game.Abstractions/Features/Battle/RangeAttackTypeExtensions.cs
@@ -5,6 +5,13 @@ namespace Rhisis.Game.Abstractions.Features.Battle
 {
     public static class RangeAttackTypeExtensions
     {
+        /// <summary>
+        /// The client uses the <see cref="ObjectMessageType"/> enum to indicate the attack type.
+        /// This method will convert the <see cref="AttackType"/> known at the server to the attack type known by the client (<see cref="ObjectMessageType"/>).
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
+        /// <exception cref="NotImplementedException">The given attack type does not have a matching <see cref="ObjectMessageType"/>.</exception>
+        /// <returns>The attack type as object message type.</returns>
         public static ObjectMessageType ToObjectMessageType(this AttackType attackType)
         {
             return attackType switch
@@ -21,6 +28,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type causes a melee attack in combat or not.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool IsMeleeAttack(this AttackType attackType)
         {
             return attackType switch
@@ -33,6 +44,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type causes a ranged attack in combat or not.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool IsRangeAttack(this AttackType attackType)
         {
             return attackType switch
@@ -43,6 +58,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type causes a skill attack in combat or not.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool IsSkillAttack(this AttackType attackType)
         {
             return attackType switch
@@ -51,9 +70,12 @@ namespace Rhisis.Game.Abstractions.Features.Battle
                 AttackType.SkillMagicAttack => true,
                 _ => false
             };
-
         }
 
+        /// <summary>
+        /// Checks if the given attack type should cause a arrow projectile to be launched during combat.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool CausesArrowProjectile(this AttackType attackType)
         {
             return attackType switch
@@ -63,6 +85,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type should cause a magic projectile to be launched during combat.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool CausesMagicProjectile(this AttackType attackType)
         {
             return attackType switch
@@ -72,6 +98,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type should cause a melee skill to be cast during combat.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool CausesMeleeSkill(this AttackType attackType)
         {
             return attackType switch
@@ -81,6 +111,10 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Checks if the given attack type should cause a magic skill to be cast during combat.
+        /// </summary>
+        /// <param name="attackType">The attack type.</param>
         public static bool CausesMagicSkill(this AttackType attackType)
         {
             return attackType switch
@@ -90,6 +124,12 @@ namespace Rhisis.Game.Abstractions.Features.Battle
             };
         }
 
+        /// <summary>
+        /// Decides which type of attack should be used when a skill of the given type is used in combat.
+        /// </summary>
+        /// <param name="skillType">The skill type.</param>
+        /// <exception cref="NotImplementedException">The given skill type does not have a matching attack type.</exception>
+        /// <returns>An attack type that matches the given skill type.</returns>
         public static AttackType ToAttackType(this SkillType skillType)
         {
             return skillType switch

--- a/src/Rhisis.Game.Abstractions/Features/Battle/RangeAttackTypeExtensions.cs
+++ b/src/Rhisis.Game.Abstractions/Features/Battle/RangeAttackTypeExtensions.cs
@@ -1,0 +1,103 @@
+﻿using Rhisis.Game.Common;
+using System;
+
+namespace Rhisis.Game.Abstractions.Features.Battle
+{
+    public static class RangeAttackTypeExtensions
+    {
+        public static ObjectMessageType ToObjectMessageType(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.MeleeAttack1 => ObjectMessageType.OBJMSG_ATK1,
+                AttackType.MeleeAttack2 => ObjectMessageType.OBJMSG_ATK2,
+                AttackType.MeleeAttack3 => ObjectMessageType.OBJMSG_ATK3,
+                AttackType.MeleeAttack4 => ObjectMessageType.OBJMSG_ATK4,
+                AttackType.RangeBowAttack => ObjectMessageType.OBJMSG_ATK_RANGE1,
+                AttackType.RangeWandAttack => ObjectMessageType.OBJMSG_ATK_MAGIC1,
+                AttackType.SkillMeleeAttack => ObjectMessageType.OBJMSG_MELEESKILL,
+                AttackType.SkillMagicAttack => ObjectMessageType.OBJMSG_MAGICSKILL,
+                _ => throw new NotImplementedException($"the attack type of {attackType} can not be mapped to a object message type")
+            };
+        }
+
+        public static bool IsMeleeAttack(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.MeleeAttack1 => true,
+                AttackType.MeleeAttack2 => true,
+                AttackType.MeleeAttack3 => true,
+                AttackType.MeleeAttack4 => true,
+                _ => false
+            };
+        }
+
+        public static bool IsRangeAttack(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.RangeBowAttack => true,
+                AttackType.RangeWandAttack => true,
+                _ => false
+            };
+        }
+
+        public static bool IsSkillAttack(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.SkillMeleeAttack => true,
+                AttackType.SkillMagicAttack => true,
+                _ => false
+            };
+
+        }
+
+        public static bool CausesArrowProjectile(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.RangeBowAttack => true,
+                _ => false
+            };
+        }
+
+        public static bool CausesMagicProjectile(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.RangeWandAttack => true,
+                _ => false
+            };
+        }
+
+        public static bool CausesMeleeSkill(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.SkillMeleeAttack => true,
+                _ => false
+            };
+        }
+
+        public static bool CausesMagicSkill(this AttackType attackType)
+        {
+            return attackType switch
+            {
+                AttackType.SkillMagicAttack => true,
+                _ => false
+            };
+        }
+
+        public static AttackType ToAttackType(this SkillType skillType)
+        {
+            return skillType switch
+            {
+                SkillType.Magic => AttackType.SkillMagicAttack,
+                SkillType.Skill => AttackType.SkillMeleeAttack,
+                _ => throw new NotImplementedException($"there is no attack type for skill type {skillType}")
+            };
+        }
+    }
+}

--- a/src/Rhisis.Game.Abstractions/Features/IHealth.cs
+++ b/src/Rhisis.Game.Abstractions/Features/IHealth.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 
 namespace Rhisis.Game.Abstractions.Features
@@ -51,16 +52,16 @@ namespace Rhisis.Game.Abstractions.Features
         /// <param name="killer">Mover that killed the current mover.</param>
         /// <param name="objectMessageType">Object message type.</param>
         /// <param name="sendHitPoints">Boolean value that indiciates if the system should send the current hit points.</param>
-        void Die(IMover killer, ObjectMessageType objectMessageType = ObjectMessageType.OBJMSG_ATK1, bool sendHitPoints = false);
+        void Die(IMover killer, AttackType attackType, bool sendHitPoints = false);
 
         /// <summary>
         /// Inflict a given amount of damages to the current mover.
         /// </summary>
         /// <param name="attacker">Mover that attacked the current mover.</param>
         /// <param name="damages">Amount of damages to inflict.</param>
+        /// <param name="attackType">Attack type that causes the damages</param>
         /// <param name="attackFlags">Attack flags.</param>
-        /// <param name="objectMessageType">Attack message type.</param>
-        void SufferDamages(IMover attacker, int damages, AttackFlags attackFlags = AttackFlags.AF_GENERIC, ObjectMessageType objectMessageType = ObjectMessageType.OBJMSG_ATK1);
+        void SufferDamages(IMover attacker, int damages, AttackType attackType, AttackFlags attackFlags = AttackFlags.AF_GENERIC);
 
         /// <summary>
         /// Regenerates a small amount of the current mover health.

--- a/src/Rhisis.Game.Abstractions/Features/IHealth.cs
+++ b/src/Rhisis.Game.Abstractions/Features/IHealth.cs
@@ -50,7 +50,7 @@ namespace Rhisis.Game.Abstractions.Features
         /// Kills the current mover and makes it die.
         /// </summary>
         /// <param name="killer">Mover that killed the current mover.</param>
-        /// <param name="objectMessageType">Object message type.</param>
+        /// <param name="attackType">The type of attack that caused the death.</param>
         /// <param name="sendHitPoints">Boolean value that indiciates if the system should send the current hit points.</param>
         void Die(IMover killer, AttackType attackType, bool sendHitPoints = false);
 

--- a/src/Rhisis.Game/Behavior/Default/MonsterBehavior.cs
+++ b/src/Rhisis.Game/Behavior/Default/MonsterBehavior.cs
@@ -7,6 +7,7 @@ using Rhisis.Game.Abstractions;
 using Rhisis.Game.Abstractions.Behavior;
 using Rhisis.Game.Abstractions.Entities;
 using Rhisis.Game.Abstractions.Factories;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Abstractions.Resources;
 using Rhisis.Game.Common;
 using Rhisis.Game.Common.Resources;
@@ -88,7 +89,7 @@ namespace Rhisis.Game.Behavior.Default
                     {
                         if (_monster.Timers.NextAttackTime < Time.TimeInMilliseconds())
                         {
-                            _monster.Battle.MeleeAttack(_monster.Battle.Target, ObjectMessageType.OBJMSG_ATK1);
+                            _monster.Battle.TryMeleeAttack(_monster.Battle.Target, AttackType.MeleeAttack1);
                             _monster.Timers.NextAttackTime = (long)(Time.TimeInMilliseconds() + _monster.Data.ReAttackDelay);
                         }
                     }

--- a/src/Rhisis.Game/Features/Health.cs
+++ b/src/Rhisis.Game/Features/Health.cs
@@ -2,6 +2,7 @@
 using Rhisis.Core.IO;
 using Rhisis.Game.Abstractions.Entities;
 using Rhisis.Game.Abstractions.Features;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Abstractions.Resources;
 using Rhisis.Game.Abstractions.Systems;
 using Rhisis.Game.Common;
@@ -94,7 +95,7 @@ namespace Rhisis.Game.Abstractions.Components
             SendHealth();
         }
 
-        public void Die(IMover killer, ObjectMessageType objectMessageType = ObjectMessageType.OBJMSG_ATK1, bool sendHitPoints = false)
+        public void Die(IMover killer, AttackType attackType, bool sendHitPoints = false)
         {
             Hp = 0;
 
@@ -105,7 +106,7 @@ namespace Rhisis.Game.Abstractions.Components
             else
             {
                 using var moverDeathSnapshot = new FFSnapshot();
-                moverDeathSnapshot.Merge(new MoverDeathSnapshot(_mover, killer, objectMessageType));
+                moverDeathSnapshot.Merge(new MoverDeathSnapshot(_mover, killer, attackType));
 
                 if (sendHitPoints)
                 {
@@ -119,7 +120,7 @@ namespace Rhisis.Game.Abstractions.Components
             killer.Behavior.OnTargetKilled(_mover);
         }
 
-        public void SufferDamages(IMover attacker, int damages, AttackFlags attackFlags = AttackFlags.AF_GENERIC, ObjectMessageType objectMessageType = ObjectMessageType.OBJMSG_ATK1)
+        public void SufferDamages(IMover attacker, int damages, AttackType attackType, AttackFlags attackFlags = AttackFlags.AF_GENERIC)
         {
             int damagesToInflict = Math.Min(Hp, damages);
 
@@ -137,7 +138,7 @@ namespace Rhisis.Game.Abstractions.Components
 
             if (IsDead)
             {
-                Die(attacker, objectMessageType, sendHitPoints: true);
+                Die(attacker, attackType, sendHitPoints: true);
             }
         }
 

--- a/src/Rhisis.Game/Protocol/Snapshots/Battle/MeleeAttackSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/Battle/MeleeAttackSnapshot.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 
@@ -6,10 +7,11 @@ namespace Rhisis.Game.Protocol.Snapshots.Battle
 {
     public class MeleeAttackSnapshot : FFSnapshot
     {
-        public MeleeAttackSnapshot(IMover attacker, IMover target, ObjectMessageType motion, AttackFlags attackFlags)
+        public MeleeAttackSnapshot(IMover attacker, IMover target, AttackType attackType, AttackFlags attackFlags)
             : base(SnapshotType.MELEE_ATTACK, attacker.Id)
         {
-            Write((int)motion);
+            int motion = (int)attackType.ToObjectMessageType();
+            Write(motion);
             Write(target.Id);
             Write(0);
             Write((int)attackFlags);

--- a/src/Rhisis.Game/Protocol/Snapshots/Battle/RangeAttackSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/Battle/RangeAttackSnapshot.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 
@@ -6,10 +7,12 @@ namespace Rhisis.Game.Protocol.Snapshots.Battle
 {
     public class RangeAttackSnapshot : FFSnapshot
     {
-        public RangeAttackSnapshot(IMover attacker, ObjectMessageType motion, uint targetId, int power, int projectileId)
+        public RangeAttackSnapshot(IMover attacker, AttackType rangeAttackType, uint targetId, int power, int projectileId)
             : base(SnapshotType.RANGE_ATTACK, attacker.Id)
         {
-            WriteInt32((int)motion);
+            int motion = (int)rangeAttackType.ToObjectMessageType();
+
+            WriteInt32(motion);
             WriteUInt32(targetId);
             WriteInt32(power);
             WriteInt32(0); // unused parameter, always 0

--- a/src/Rhisis.Game/Protocol/Snapshots/MoverDeathSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/MoverDeathSnapshot.cs
@@ -1,14 +1,16 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 
 namespace Rhisis.Network.Snapshots
 {
     public class MoverDeathSnapshot : FFSnapshot
     {
-        public MoverDeathSnapshot(IMover mover, IMover killer, ObjectMessageType objectMessageType)
+        public MoverDeathSnapshot(IMover mover, IMover killer, AttackType attackType)
             : base(SnapshotType.MOVERDEATH, mover.Id)
         {
-            Write((int)objectMessageType);
+            var objMsgType = (int)attackType.ToObjectMessageType();
+            Write(objMsgType);
             Write(killer.Id);
         }
     }

--- a/src/Rhisis.Game/Systems/SkillSystem.cs
+++ b/src/Rhisis.Game/Systems/SkillSystem.cs
@@ -246,12 +246,14 @@ namespace Rhisis.Game.Systems
                 throw new InvalidOperationException("Only a player or monster can cast a skill.");
             }
 
-            battle.TrySkillAttack(target, skill);
-            skill.SetCoolTime(skill.LevelData.CooldownTime);
-
-            if (reduceCasterPoints)
+            if (battle.TrySkillAttack(target, skill))
             {
-                ReduceCasterPoints(caster, skill);
+                skill.SetCoolTime(skill.LevelData.CooldownTime);
+
+                if (reduceCasterPoints)
+                {
+                    ReduceCasterPoints(caster, skill);
+                }
             }
         }
 

--- a/src/Rhisis.Game/Systems/SkillSystem.cs
+++ b/src/Rhisis.Game/Systems/SkillSystem.cs
@@ -246,7 +246,7 @@ namespace Rhisis.Game.Systems
                 throw new InvalidOperationException("Only a player or monster can cast a skill.");
             }
 
-            battle.SkillAttack(target, skill);
+            battle.TrySkillAttack(target, skill);
             skill.SetCoolTime(skill.LevelData.CooldownTime);
 
             if (reduceCasterPoints)

--- a/src/Rhisis.World/Handlers/Battle/MagicAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/MagicAttackHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 using Rhisis.Network.Packets.World;
@@ -31,7 +32,7 @@ namespace Rhisis.World.Handlers.Battle
                 throw new InvalidOperationException($"Invalid projectile id.");
             }
 
-            player.Battle.RangeAttack(target, Math.Max(0, packet.MagicPower), ObjectMessageType.OBJMSG_ATK_MAGIC1);
+            player.Battle.TryRangeAttack(target, Math.Max(0, packet.MagicPower), AttackType.RangeWandAttack);
         }
     }
 }

--- a/src/Rhisis.World/Handlers/Battle/MeleeAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/MeleeAttackHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Game.Abstractions;
 using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 using Rhisis.Network.Packets.World;
@@ -35,10 +36,17 @@ namespace Rhisis.World.Handlers.Battle
                 throw new InvalidOperationException($"Player '{player}' has a different weapon speed that the server.");
             }
 
-            if (player.Battle.CanAttack(monster))
+            var attackType = packet.AttackMessage switch
             {
-                player.Battle.MeleeAttack(monster, packet.AttackMessage);
-            }
+                ObjectMessageType.OBJMSG_ATK1 => AttackType.MeleeAttack1,
+                ObjectMessageType.OBJMSG_ATK2 => AttackType.MeleeAttack2,
+                ObjectMessageType.OBJMSG_ATK3 => AttackType.MeleeAttack3,
+                ObjectMessageType.OBJMSG_ATK4 => AttackType.MeleeAttack4,
+                _ => throw new InvalidOperationException($"the object message type {packet.AttackMessage} can not be used during a melee attack packet")
+            };
+
+
+            player.Battle.TryMeleeAttack(monster, attackType);            
         }
     }
 }

--- a/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Rhisis.Game.Abstractions;
 using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Features.Battle;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 using Rhisis.Network.Packets.World;
@@ -47,7 +48,7 @@ namespace Rhisis.World.Handlers.Battle
             }
 
             player.Inventory.DeleteItem(bulletItem, 1);
-            player.Battle.RangeAttack(target, Math.Max(0, packet.Power), ObjectMessageType.OBJMSG_ATK_RANGE1);
+            player.Battle.TryRangeAttack(target, Math.Max(0, packet.Power), AttackType.RangeBowAttack);
         }
     }
 }

--- a/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
+++ b/src/Rhisis.World/Handlers/Battle/RangeAttackHandler.cs
@@ -47,8 +47,10 @@ namespace Rhisis.World.Handlers.Battle
                 return;
             }
 
-            player.Inventory.DeleteItem(bulletItem, 1);
-            player.Battle.TryRangeAttack(target, Math.Max(0, packet.Power), AttackType.RangeBowAttack);
+            if(player.Battle.TryRangeAttack(target, Math.Max(0, packet.Power), AttackType.RangeBowAttack))
+            {
+                player.Inventory.DeleteItem(bulletItem, 1);
+            }
         }
     }
 }


### PR DESCRIPTION
…e type bloat

I refactored the Battle feature a little bit so the ObjectMessageType is no longer used directly.
Using the ObjectMessageType in the domain logic makes the code a lot less readable as you don't know what is in there.
Now there is a dedicated enum type AttackType, and the ObjectMessageType is now only used in the packets and snapshots.

There is also a extension class for the AttackType enum which links certain behavior with the types of the enum indirectly, to make the code checking on the enum more readable and more robust for the future.

An alternative for this AttackType + Extensions could be to create a "Enum style class" which would then have properties to replace the extension methods, but I chose to keep it more simple for now.