### PR TITLE
Update player cache

### DIFF
--- a/src/Rhisis.Game.Abstractions/Entities/IPlayer.cs
+++ b/src/Rhisis.Game.Abstractions/Entities/IPlayer.cs
@@ -131,5 +131,10 @@ namespace Rhisis.Game.Abstractions.Entities
         /// </summary>
         /// <param name="newJob">New job.</param>
         void ChangeJob(DefineJob.Job newJob);
+
+        /// <summary>
+        /// Updates the player cache information.
+        /// </summary>
+        void UpdateCache();
     }
 }

--- a/src/Rhisis.Game/Features/Experience.cs
+++ b/src/Rhisis.Game/Features/Experience.cs
@@ -49,6 +49,7 @@ namespace Rhisis.Game.Features
 
             if (hasLevelUp)
             {
+                _player.UpdateCache();
                 _player.Health.RegenerateAll();
                 SendLevelUpPackets();
             }

--- a/src/Rhisis.Game/Protocol/Messages/PlayerCacheUpdate.cs
+++ b/src/Rhisis.Game/Protocol/Messages/PlayerCacheUpdate.cs
@@ -1,0 +1,29 @@
+﻿namespace Rhisis.Game.Protocol.Messages
+{
+    /// <summary>
+    /// Provides a data structure that notifies when a player cache has been updated.
+    /// </summary>
+    public class PlayerCacheUpdate
+    {
+        /// <summary>
+        /// Gets or sets the player id that represents the player cache that has been updated.
+        /// </summary>
+        public int PlayerId { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="PlayerCacheUpdate"/> instance.
+        /// </summary>
+        public PlayerCacheUpdate()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="PlayerCacheUpdate"/> instance.
+        /// </summary>
+        /// <param name="playerId">Player id</param>
+        public PlayerCacheUpdate(int playerId)
+        {
+            PlayerId = playerId;
+        }
+    }
+}

--- a/src/Rhisis.Game/Systems/JobSystem.cs
+++ b/src/Rhisis.Game/Systems/JobSystem.cs
@@ -55,6 +55,7 @@ namespace Rhisis.Game.Systems
                 new CreateSfxObjectSnapshot(player, DefineSpecialEffects.XI_GEN_LEVEL_UP01));
 
             SendPacketToVisible(player, snapshots, sendToPlayer: true);
+            player.UpdateCache();
         }
 
         public int GetJobMinLevel(DefineJob.Job job)

--- a/src/Rhisis.WorldServer/Game/Chat/LevelCommand.cs
+++ b/src/Rhisis.WorldServer/Game/Chat/LevelCommand.cs
@@ -63,6 +63,8 @@ namespace Rhisis.Game.Features.Chat.Commands
                 player.ChangeJob(job.Id);
             }
 
+            player.UpdateCache();
+
             using var snapshot = new SetExperienceSnapshot(player);
             player.Send(snapshot);
             player.SendToVisible(snapshot);

--- a/src/Rhisis.WorldServer/Handlers/Messages/PlayerCacheUpdateMessageHandler.cs
+++ b/src/Rhisis.WorldServer/Handlers/Messages/PlayerCacheUpdateMessageHandler.cs
@@ -1,0 +1,36 @@
+﻿using Rhisis.Game.Abstractions.Caching;
+using Rhisis.Game.Protocol.Messages;
+using Rhisis.Network.Snapshots;
+using Sylver.HandlerInvoker.Attributes;
+using System;
+
+namespace Rhisis.WorldServer.Handlers.Messages
+{
+    [Handler]
+    public class PlayerCacheUpdateMessageHandler
+    {
+        private readonly IWorldServer _worldServer;
+        private readonly IPlayerCache _playerCache;
+
+        public PlayerCacheUpdateMessageHandler(IWorldServer worldServer, IPlayerCache playerCache)
+        {
+            _worldServer = worldServer;
+            _playerCache = playerCache;
+        }
+
+        [HandlerAction(typeof(PlayerCacheUpdate))]
+        public void OnExecute(PlayerCacheUpdate message)
+        {
+            CachedPlayer cachedPlayer = _playerCache.GetCachedPlayer(message.PlayerId);
+
+            if (cachedPlayer is null)
+            {
+                throw new InvalidOperationException($"Failed to retrieve cached player with id: '{message.PlayerId}'.");
+            }
+
+            using var playerDataSnapshot = new QueryPlayerDataSnapshot(cachedPlayer);
+
+            _worldServer.SendToAll(playerDataSnapshot);
+        }
+    }
+}

--- a/src/Rhisis.WorldServer/WorldServer.cs
+++ b/src/Rhisis.WorldServer/WorldServer.cs
@@ -104,6 +104,7 @@ namespace Rhisis.WorldServer
             _messaging.Subscribe<PlayerMessengerRemoveFriend>(OnPlayerMessengerRemoveFriendMessage);
             _messaging.Subscribe<PlayerMessengerBlockFriend>(OnPlayerMessengerBlockFriendMessage);
             _messaging.Subscribe<PlayerMessengerMessage>(OnPlayerMessengerMessage);
+            _messaging.Subscribe<PlayerCacheUpdate>(OnPlayerCacheUpdateMessage);
         }
 
         /// <inheritdoc />
@@ -196,6 +197,11 @@ namespace Rhisis.WorldServer
         private void OnPlayerMessengerMessage(PlayerMessengerMessage message)
         {
             _handlerInvoker.Invoke(typeof(PlayerMessengerMessage), message);
+        }
+
+        private void OnPlayerCacheUpdateMessage(PlayerCacheUpdate message)
+        {
+            _handlerInvoker.Invoke(typeof(PlayerCacheUpdate), message);
         }
     }
 }


### PR DESCRIPTION
This PR covers issue #493 and updates the player cache when the player level up or change job. Also, the new player state is broadcast to every player connected on the cluster using the Redis messaging.

Closes #493