### PR TITLE
Add buff pang system

### DIFF
--- a/bin/config/world.json
+++ b/bin/config/world.json
@@ -37,6 +37,83 @@
     },
     "messenger": {
       "maximumFriends": 200
+    },
+    "npcBuff": {
+      "default": {
+        "min": 1,
+        "max": 20,
+        "buffs": [
+          {
+            "skillId": "SI_ASS_HEAL_PATIENCE",
+            "level": 7,
+            "time": 3600
+          },
+          {
+            "skillId": "SI_ASS_CHEER_HEAPUP",
+            "level": 7,
+            "time": 3600
+          }
+        ]
+      },
+      "additionnal": [
+        {
+          "name": "MaFl_Helper_ver12",
+          "min": 1,
+          "max": 60,
+          "buffs": [
+            {
+              "skillId": "SI_ASS_HEAL_PATIENCE",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_QUICKSTEP",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_HASTE",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_CATSREFLEX",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_CANNONBALL",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_MENTALSIGN",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_HEAPUP",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_BEEFUP",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_ASS_CHEER_ACCURACY",
+              "level": 7,
+              "time": 3600
+            },
+            {
+              "skillId": "SI_RIN_SUP_PROTECT",
+              "level": 3,
+              "time": 360
+            }
+          ]
+        }
+      ]
     }
   },
   "coreServer": {

--- a/src/Rhisis.Core/Structures/Configuration/World/NpcBuffConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/World/NpcBuffConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace Rhisis.Core.Structures.Configuration.World
+{
+    public class NpcBuffConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the buffing NPC name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum player level that the NPC can buff.
+        /// </summary>
+        public int Min { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maxmimum player levle that the NPC can buff.
+        /// </summary>
+        public int Max { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates if the current NPC buff configuration is the default one.
+        /// </summary>
+        public bool IsDefault => string.IsNullOrWhiteSpace(Name);
+
+        /// <summary>
+        /// Gets or sets a collection of the buffs to apply.
+        /// </summary>
+        public IEnumerable<NpcBuffDescriptor> Buffs { get; set; }
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/World/NpcBuffConfigurationSection.cs
+++ b/src/Rhisis.Core/Structures/Configuration/World/NpcBuffConfigurationSection.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.Core.Structures.Configuration.World
+{
+    /// <summary>
+    /// Provides a data structure for configuring the buff pang system.
+    /// </summary>
+    public class NpcBuffConfigurationSection
+    {
+        /// <summary>
+        /// Gets or sets the default npc buff configuration.
+        /// </summary>
+        public NpcBuffConfiguration Default { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additionnal npc buff configuration.
+        /// </summary>
+        public IEnumerable<NpcBuffConfiguration> Additionnal { get; set; }
+
+        /// <summary>
+        /// Gets the npc buff configuration based on the given name.
+        /// </summary>
+        /// <param name="name">NPC name key.</param>
+        /// <returns>Buff configuration or default configuration.</returns>
+        public NpcBuffConfiguration Get(string name) 
+            => Additionnal.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase)) ?? Default;
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/World/NpcBuffDescriptor.cs
+++ b/src/Rhisis.Core/Structures/Configuration/World/NpcBuffDescriptor.cs
@@ -1,0 +1,23 @@
+﻿namespace Rhisis.Core.Structures.Configuration.World
+{
+    public class NpcBuffDescriptor
+    {
+        /// <summary>
+        /// Gets or sets the buff skill id.
+        /// </summary>
+        /// <remarks>
+        /// This field can either be the defined skill string like "SI_ASS_CHEER_HEAPUP" or its numerical id.
+        /// </remarks>
+        public string SkillId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the buff skill level.
+        /// </summary>
+        public int Level { get; set; }
+
+        /// <summary>
+        /// Gets or sets the buff time in seconds.
+        /// </summary>
+        public int Time { get; set; }
+    }
+}

--- a/src/Rhisis.Core/Structures/Configuration/World/WorldConfiguration.cs
+++ b/src/Rhisis.Core/Structures/Configuration/World/WorldConfiguration.cs
@@ -119,6 +119,12 @@ namespace Rhisis.Core.Structures.Configuration.World
         public MessengerConfiguration Messenger { get; set; } = new MessengerConfiguration();
 
         /// <summary>
+        /// Gets or sets the NPC buff configuration settings.
+        /// </summary>
+        [DataMember(Name = "npcBuff")]
+        public NpcBuffConfigurationSection NpcBuff { get; set; } = new NpcBuffConfigurationSection();
+
+        /// <summary>
         /// Creates a new <see cref="WorldConfiguration"/> instance.
         /// </summary>
         public WorldConfiguration()

--- a/src/Rhisis.Game.Abstractions/Entities/INpc.cs
+++ b/src/Rhisis.Game.Abstractions/Entities/INpc.cs
@@ -47,6 +47,11 @@ namespace Rhisis.Game.Abstractions.Entities
         bool HasDialog => Dialog != null;
 
         /// <summary>
+        /// Gets a value that indicates if the NPC can buff.
+        /// </summary>
+        bool CanBuff => Data?.CanBuff ?? false;
+
+        /// <summary>
         /// Gets the NPC quests.
         /// </summary>
         IEnumerable<IQuestScript> Quests { get; }

--- a/src/Rhisis.Game.Abstractions/IBuffSkill.cs
+++ b/src/Rhisis.Game.Abstractions/IBuffSkill.cs
@@ -1,4 +1,6 @@
-﻿namespace Rhisis.Game.Abstractions
+﻿using Rhisis.Game.Common.Resources;
+
+namespace Rhisis.Game.Abstractions
 {
     public interface IBuffSkill : IBuff
     {
@@ -21,5 +23,15 @@
         /// Gets the buff skill level.
         /// </summary>
         int SkillLevel { get; }
+
+        /// <summary>
+        /// Gets the buff skill data.
+        /// </summary>
+        SkillData SkillData { get; }
+
+        /// <summary>
+        /// Gets the buff skill level data.
+        /// </summary>
+        SkillLevelData SkillLevelData { get; }
     }
 }

--- a/src/Rhisis.Game.Abstractions/Systems/ISkillSystem.cs
+++ b/src/Rhisis.Game.Abstractions/Systems/ISkillSystem.cs
@@ -25,5 +25,12 @@ namespace Rhisis.Game.Abstractions.Systems
         /// <param name="skill">Skill to use.</param>
         /// <returns>True if the player can use the skill; false otherwise.</returns>
         bool CanUseSkill(IPlayer player, IMover target, ISkill skill);
+
+        /// <summary>
+        /// Applies a buff to the given target.
+        /// </summary>
+        /// <param name="target">Target to apply the buff.</param>
+        /// <param name="buff">Buff to apply.</param>
+        void ApplyBuff(IMover target, IBuff buff);
     }
 }

--- a/src/Rhisis.Game.Common/Resources/NpcData.cs
+++ b/src/Rhisis.Game.Common/Resources/NpcData.cs
@@ -61,6 +61,11 @@ namespace Rhisis.Game.Common.Resources
         public bool HasDialog => Dialog != null;
 
         /// <summary>
+        /// Gets or sets a value that indicates if the NPC can buff.
+        /// </summary>
+        public bool CanBuff { get; set; }
+
+        /// <summary>
         /// Creates a new <see cref="NpcData"/> instance.
         /// </summary>
         /// <param name="id">Npc id</param>

--- a/src/Rhisis.Game/BuffSkill.cs
+++ b/src/Rhisis.Game/BuffSkill.cs
@@ -11,22 +11,24 @@ namespace Rhisis.Game
     [DebuggerDisplay("Buff '{SkillName}' Lv.{SkillLevel}")]
     public class BuffSkill : Buff, IBuffSkill
     {
-        private readonly SkillData _skillData;
-
         public override BuffType Type => BuffType.Skill;
 
         public int? DatabaseId { get; }
 
-        public int SkillId => _skillData.Id;
+        public int SkillId => SkillData.Id;
 
-        public string SkillName => _skillData.Name;
+        public string SkillName => SkillData.Name;
 
         public int SkillLevel { get; }
+
+        public SkillData SkillData { get; }
+
+        public SkillLevelData SkillLevelData => SkillData.SkillLevels[SkillLevel];
 
         public BuffSkill(IMover owner, IDictionary<DefineAttributes, int> attributes, SkillData skillData, int skillLevel, int? databaseId = null) 
             : base(owner, attributes)
         {
-            _skillData = skillData;
+            SkillData = skillData;
             SkillLevel = skillLevel;
             DatabaseId = databaseId;
         }

--- a/src/Rhisis.Game/Features/Buffs.cs
+++ b/src/Rhisis.Game/Features/Buffs.cs
@@ -53,6 +53,11 @@ namespace Rhisis.Game.Features
             }
 
             _buffs.Add(buff);
+
+            foreach (KeyValuePair<DefineAttributes, int> attribute in buff.Attributes)
+            {
+                Owner.Attributes.Increase(attribute.Key, attribute.Value);
+            }
             
             return BuffResultType.Added;
         }

--- a/src/Rhisis.Game/Protocol/Snapshots/Skills/DoApplyUseSkillSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/Skills/DoApplyUseSkillSnapshot.cs
@@ -1,0 +1,16 @@
+﻿using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Network;
+
+namespace Rhisis.Game.Protocol.Snapshots.Skills
+{
+    public class DoApplyUseSkillSnapshot : FFSnapshot
+    {
+        public DoApplyUseSkillSnapshot(IMover mover, uint targetId, int skillId, int skillLevel)
+            : base(SnapshotType.DOAPPLYUSESKILL, mover.Id)
+        {
+            WriteUInt32(targetId);
+            WriteInt32(skillId);
+            WriteInt32(skillLevel);
+        }
+    }
+}

--- a/src/Rhisis.Game/Protocol/Snapshots/Skills/SetSkillStateSnapshot.cs
+++ b/src/Rhisis.Game/Protocol/Snapshots/Skills/SetSkillStateSnapshot.cs
@@ -1,5 +1,4 @@
-﻿using Rhisis.Game.Abstractions;
-using Rhisis.Game.Abstractions.Entities;
+﻿using Rhisis.Game.Abstractions.Entities;
 using Rhisis.Game.Common;
 using Rhisis.Network;
 
@@ -7,14 +6,14 @@ namespace Rhisis.Game.Protocol.Snapshots.Skills
 {
     public class SetSkillStateSnapshot : FFSnapshot
     {
-        public SetSkillStateSnapshot(IMover mover, ISkill skill, int time)
+        public SetSkillStateSnapshot(IMover mover, int skillId, int skillLevel, int time)
             : base(SnapshotType.SETSKILLSTATE, mover.Id)
         {
-            Write(mover.Id);
-            Write((short)BuffType.Skill);
-            Write((short)skill.Id);
-            Write(skill.Level);
-            Write(time);
+            WriteUInt32(mover.Id);
+            WriteInt16((short)BuffType.Skill);
+            WriteInt16((short)skillId);
+            WriteInt32(skillLevel);
+            WriteInt32(time);
         }
     }
 }

--- a/src/Rhisis.Game/Resources/Loaders/NpcLoader.cs
+++ b/src/Rhisis.Game/Resources/Loaders/NpcLoader.cs
@@ -57,14 +57,19 @@ namespace Rhisis.Game.Resources.Loaders
 
                         var npcId = npcStatement.Name;
                         var npcName = npcId;
+                        var canBuff = false;
 
                         foreach (IStatement npcInfoStatement in npcBlock.Statements)
                         {
-                            if (npcInfoStatement is Instruction instruction && npcInfoStatement.Name == "SetName")
+                            if (npcInfoStatement is Instruction instruction)
                             {
-                                if (instruction.Parameters.Count > 0)
+                                if (npcInfoStatement.Name == "SetName" && instruction.Parameters.Count > 0)
                                 {
                                     npcName = _texts[instruction.Parameters.First().ToString()];
+                                }
+                                if (npcInfoStatement.Name == "AddMenu")
+                                {
+                                    canBuff = instruction.Parameters.FirstOrDefault() == "MMI_NPC_BUFF";
                                 }
                             }
                         }
@@ -79,7 +84,10 @@ namespace Rhisis.Game.Resources.Loaders
                             dialogSet.TryGetValue(npcId, out dialogData);
                         }
 
-                        var npc = new NpcData(npcId, npcName, shop, dialogData);
+                        var npc = new NpcData(npcId, npcName, shop, dialogData)
+                        {
+                            CanBuff = canBuff
+                        };
 
                         if (npcData.ContainsKey(npc.Id))
                         {

--- a/src/Rhisis.Network/Packets/World/NpcBuffPacket.cs
+++ b/src/Rhisis.Network/Packets/World/NpcBuffPacket.cs
@@ -1,0 +1,19 @@
+﻿using Rhisis.Game.Abstractions.Protocol;
+using Sylver.Network.Data;
+
+namespace Rhisis.Network.Packets.World
+{
+    public class NpcBuffPacket : IPacketDeserializer
+    {
+        /// <summary>
+        /// Gets the buffing NPC key.
+        /// </summary>
+        public string NpcKey { get; private set; }
+
+        /// <inheritdoc />
+        public void Deserialize(INetPacketStream packet)
+        {
+            NpcKey = packet.ReadString();
+        }
+    }
+}

--- a/src/Rhisis.WorldServer/Handlers/BuffPangHandler.cs
+++ b/src/Rhisis.WorldServer/Handlers/BuffPangHandler.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Rhisis.Core.Structures.Configuration.World;
+using Rhisis.Game;
+using Rhisis.Game.Abstractions.Entities;
+using Rhisis.Game.Abstractions.Resources;
+using Rhisis.Game.Abstractions.Systems;
+using Rhisis.Game.Common;
+using Rhisis.Game.Common.Resources;
+using Rhisis.Game.Protocol.Snapshots.Skills;
+using Rhisis.Network;
+using Rhisis.Network.Packets.World;
+using Rhisis.Network.Snapshots;
+using Sylver.HandlerInvoker.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Rhisis.WorldServer.Handlers
+{
+    [Handler]
+    public class BuffPangHandler
+    {
+        private readonly ILogger<BuffPangHandler> _logger;
+        private readonly IOptions<WorldConfiguration> _worldConfiguration;
+        private readonly IGameResources _gameResources;
+        private readonly ISkillSystem _skillSystem;
+
+        public BuffPangHandler(ILogger<BuffPangHandler> logger, IOptions<WorldConfiguration> worldConfiguration, IGameResources gameResources, ISkillSystem skillSystem)
+        {
+            _logger = logger;
+            _worldConfiguration = worldConfiguration;
+            _gameResources = gameResources;
+            _skillSystem = skillSystem;
+        }
+
+        [HandlerAction(PacketType.NPC_BUFF)]
+        public void OnNpcBuff(IPlayer player, NpcBuffPacket packet)
+        {
+            NpcBuffConfiguration buffConfiguration = _worldConfiguration.Value.NpcBuff.Get(packet.NpcKey);
+
+            if (buffConfiguration is null)
+            {
+                _logger.LogWarning($"Failed to find npc buff configuration with key '{packet.NpcKey}' or default.");
+                return;
+            }
+
+            if (player.Level < buffConfiguration.Min || player.Level > buffConfiguration.Max)
+            {
+                using var defineTextSnapshot = new DefinedTextSnapshot(player, DefineText.TID_GAME_NPCBUFF_LEVELLIMIT,
+                    $"{buffConfiguration.Min}", $"{buffConfiguration.Max}", $"\"\"");
+                player.Send(defineTextSnapshot);
+                return;
+            }
+
+            INpc buffer = player.VisibleObjects.OfType<INpc>().FirstOrDefault(x => x.Name == packet.NpcKey);
+            
+            if (buffer is null)
+            {
+                throw new InvalidOperationException($"Failed to find NPC buffer with name: '{packet.NpcKey}'.");
+            }
+
+            foreach (var buff in buffConfiguration.Buffs)
+            {
+                SkillData skillData = GetSkillData(buff.SkillId);
+
+                if (skillData is null)
+                {
+                    continue;
+                }
+
+                int buffLevel = Math.Clamp(buff.Level, 1, skillData.MaxLevel);
+                SkillLevelData skillLevelData = skillData.SkillLevels.GetValueOrDefault(buffLevel);
+
+                if (skillLevelData is null)
+                {
+                    _logger.LogWarning($"Cannot find skill level data for skill: {skillData.Name} and level {buffLevel}");
+                    continue;
+                }
+
+                var attributes = new Dictionary<DefineAttributes, int>();
+
+                if (skillLevelData.DestParam1 > 0)
+                {
+                    attributes.Add(skillLevelData.DestParam1, skillLevelData.DestParam1Value);
+                }
+                if (skillLevelData.DestParam2 > 0)
+                {
+                    attributes.Add(skillLevelData.DestParam2, skillLevelData.DestParam2Value);
+                }
+
+                var buffSkill = new BuffSkill(player, attributes, skillData, buffLevel)
+                {
+                    RemainingTime = buff.Time * 1000
+                };
+
+                _skillSystem.ApplyBuff(player, buffSkill);
+
+                using var snapshot = new DoApplyUseSkillSnapshot(player, player.Id, skillData.Id, buffLevel);
+                player.Send(snapshot);
+                player.SendToVisible(snapshot);
+            }
+        }
+
+        private SkillData GetSkillData(string nameOrId)
+        {
+            if (!int.TryParse(nameOrId, out int skillId))
+            {
+                if (!_gameResources.Defines.TryGetValue(nameOrId, out skillId))
+                {
+                    _logger.LogWarning($"Failed to find skill with name: '{nameOrId}'.");
+                    return null;
+                }
+            }
+
+            if (!_gameResources.Skills.TryGetValue(skillId, out SkillData skill))
+            {
+                _logger.LogWarning($"Cannot find skill with id: '{skillId}'.");
+                return null;
+            }
+
+            return skill;
+        }
+    }
+}


### PR DESCRIPTION
This PR covers issue #39 and adds the NPC buff system. (known as "buff pang system")
You can configure several npc buffs in the `npcBuff` section of the `world.json` configuration file. There is a `default` configuration that will be applied to every npc buffers otherwise you specify a custom one in the `additionnal` section.
Example:

```json
"npcBuff": {
  "default": {
    "min": 1,
    "max": 20,
    "buffs": [
      {
        "skillId": "SI_ASS_HEAL_PATIENCE",
        "level": 7,
        "time": 3600
      },
      {
        "skillId": "SI_ASS_CHEER_HEAPUP",
        "level": 7,
        "time": 3600
      }
    ]
  },
  "additionnal": [
    {
      "name": "MaFl_Helper_ver12",
      "min": 1,
      "max": 60,
      "buffs": [
        {
          "skillId": "SI_ASS_HEAL_PATIENCE",
          "level": 7,
          "time": 3600
        }
      ]
    }
  ]
}
```
The `default` configuration will apply the `SI_ASS_HEAL_PATIENCE` buff at level `7` for `3600` seconds (1h) and the `SI_ASS_CHEER_HEAPUP` Lv. `7` for 3600 seconds to, only to players that have a level between 1 and 20.

If the NPC that is giving buffs the player is named `MaFl_Helper_ver12` will only apply the `SI_ASS_HEAL_PATIENCE` at Lv. 7 for 3600 seconds for players that have a level between 1 and 60.

The configuration is preaty simple.

Note: The `min` and `max` entries will be renamed in `minPlayerLevel` and `maxPlayerLevel` for better clarity.

Closes #39 